### PR TITLE
fix: correct API docs link from /api to /api-docs

### DIFF
--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -38,7 +38,7 @@ const SLIDES = [
     title: "One Package, Every Brand",
     description: "Tree-shakeable, typed, dual ESM/CJS. Import any icon with zero config.",
     cta: { label: "View on npm", href: "https://www.npmjs.com/package/thesvg" },
-    ctaSecondary: { label: "API Docs", href: "/api" },
+    ctaSecondary: { label: "API Docs", href: "/api-docs" },
     gradient: "from-blue-50/50 via-background to-blue-50/30 dark:from-blue-950/20 dark:via-background dark:to-blue-950/10",
     accent: "border-blue-200/50 bg-blue-50/80 text-blue-600 dark:border-blue-500/20 dark:bg-blue-500/10 dark:text-blue-400",
     blob: "bg-blue-400/10 dark:bg-blue-500/5",


### PR DESCRIPTION
## Summary
- Fixed broken API docs link in hero section that pointed to `/api` (404) instead of `/api-docs`

## Test plan
- [ ] Visit thesvg.org and click "API Docs" button in hero
- [ ] Verify it navigates to /api-docs instead of /api