### PR TITLE
fix: restore changesets/action publish flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: npm-publish
-    # Skip release commits to avoid infinite loops.
+    # Skip version commits to avoid infinite loops.
     # workflow_dispatch always runs so you can manually trigger publish.
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -48,6 +48,7 @@ jobs:
         run: |
           npm install -g npm@latest
           npm config set registry https://registry.npmjs.org/
+          npm config set provenance true
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -147,27 +148,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for pending changesets
-        id: check
-        run: |
-          if ls .changeset/*.md 2>/dev/null | grep -v README.md | head -1 > /dev/null 2>&1; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-          fi
-
+      # Run unconditionally - changesets/action handles both cases:
+      # 1. Pending changesets -> creates Version Packages PR
+      # 2. No pending changesets but bumped versions -> publishes to npm
       - name: Create Release PR or Publish
-        if: steps.check.outputs.has_changesets == 'true'
         id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm changeset publish
-          commit: "chore(release): version packages [skip ci]"
+          commit: "chore(release): version packages"
           title: "chore(release): version packages"
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ""
 
       - name: Create git tag for release
         if: steps.changesets.outputs.published == 'true'
@@ -184,13 +177,10 @@ jobs:
           fi
 
       - name: Auto-merge Version Packages PR
-        if: steps.check.outputs.has_changesets == 'true' && steps.changesets.outputs.published != 'true'
+        if: steps.changesets.outputs.pullRequestNumber != ''
         run: |
-          # Find the open Version Packages PR and enable auto-merge
-          PR_NUMBER=$(gh pr list --state open --head changeset-release/main --json number --jq '.[0].number')
-          if [ -n "$PR_NUMBER" ]; then
-            echo "Enabling auto-merge on Version Packages PR #$PR_NUMBER"
-            gh pr merge "$PR_NUMBER" --squash --auto
-          fi
+          PR_NUMBER='${{ steps.changesets.outputs.pullRequestNumber }}'
+          echo "Enabling auto-merge on Version Packages PR #$PR_NUMBER"
+          gh pr merge "$PR_NUMBER" --squash --auto
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Restore the original `changesets/action` publish flow that was working for v1.0.2
- Reverts the broken direct `npm publish` approach from PR #27
- Keeps the two fixes: `public/icons/` detection + `workflow_dispatch` trigger

## Context
PR #27 replaced `changesets/action` with direct `npm publish --provenance` calls, which failed with 404 errors for all packages. This restores the exact approach that successfully published v1.0.2.

## Test plan
- [ ] Merge and trigger workflow_dispatch
- [ ] Verify version PR is created and auto-merged
- [ ] Confirm packages publish to npm