### PR TITLE
fix: update org references from GLINCKER to glincker

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "GLINCKER/thesvg" }
+    { "repo": "glincker/thesvg" }
   ],
   "commit": false,
   "fixed": [],

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [GLINCKER]
+github: [glincker]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://thesvg.org
     about: Search all 3,800+ icons
   - name: Discussions
-    url: https://github.com/GLINCKER/thesvg/discussions
+    url: https://github.com/glincker/thesvg/discussions
     about: Ask questions and share ideas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# thesvg - AI Review Guidelines
+
+## SVG Icon Submission Rules
+
+### Required
+- Every icon directory must have `default.svg`
+- Every SVG must have a valid `viewBox` attribute
+- Every SVG must contain a `<title>` element with the brand name
+- Preferred viewBox: `0 0 24 24` (match library convention)
+- File size must be under 50KB
+- No `<script>` tags, event handlers, or `javascript:` URIs
+- No embedded raster images (`<image>` with base64 data)
+- No `<?xml>` declarations or `<!DOCTYPE>` preambles
+
+### Fill and Color Rules
+- `default.svg`: Must use the brand hex color as `fill` on `<svg>` root (not `currentColor`)
+- `mono.svg`: Must use `fill="currentColor"` on `<svg>` root
+- `light.svg`: Must use `fill="#ffffff"` or similar light color
+- `dark.svg`: Must use `fill="#1a1a2e"` or similar dark color
+- Detail elements (eyes, pupils, accents) that contrast with the body must have explicit `fill` overrides - they must not inherit the root fill if that makes them invisible
+- Stroke colors on antennae, lines, or accents must contrast with adjacent filled shapes - same-color strokes over same-color fills are invisible
+- Never include a viewport-covering rectangle like `<path d="M0 0h24v24H0z"/>` without `fill="none"` - this covers the entire icon
+
+### icons.json Registry
+- Located at `src/data/icons.json`
+- Entries must be alphabetically sorted by `slug`
+- Required fields: `slug`, `title`, `aliases`, `hex`, `categories`, `variants`, `license`, `url`
+- `hex` must not include `#` prefix (e.g. `"f43f5e"` not `"#f43f5e"`)
+- `variants` object keys must match filenames in `public/icons/{slug}/`
+- `categories` must use existing category names (check existing entries)
+
+### Variant File Naming
+```
+public/icons/{slug}/
+  default.svg          # Required - brand color
+  mono.svg             # Recommended - inherits text color
+  light.svg            # Optional - for dark backgrounds
+  dark.svg             # Optional - for light backgrounds
+  color.svg            # Optional - multi-color/gradient version
+  wordmark.svg         # Optional - text logo
+  wordmarkLight.svg    # Optional - light text logo
+  wordmarkDark.svg     # Optional - dark text logo
+```
+
+### Slug Naming Convention
+- Lowercase, hyphen-separated
+- No uppercase, no spaces, no underscores
+- Must match the directory name under `public/icons/`
+
+## Code Quality Rules
+
+### TypeScript
+- No `any` types
+- Strict mode enabled
+- Server Components by default, `"use client"` only when needed
+
+### Styling
+- Tailwind CSS only, no inline styles or CSS modules
+- shadcn/ui components, extend don't reinvent
+- Lucide icons for UI chrome (not for brand icons)
+
+### Git
+- Never commit directly to `main`
+- Conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `perf:`
+- No AI tool mentions in commit messages
+
+## Common Review Pitfalls
+
+1. **Invisible elements**: Fill color matches background or parent fill - always verify contrast
+2. **Bounding box paths**: `M0 0hWvH` rectangles that cover the entire icon
+3. **Wrong alphabetical position**: icons.json must stay sorted by slug
+4. **Missing fill overrides**: Child elements inheriting root fill when they need a different color
+5. **Inconsistent viewBox**: All icons in a PR should use the same coordinate space as the library standard
+6. **Google Fonts in SVG**: External `@import url()` for fonts will not render in most contexts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The easiest way to contribute is to submit a new brand icon:
 - **Broken icon** - SVG doesn't render correctly
 - **Package bug** - import errors, TypeScript issues, build problems
 
-Use the appropriate [issue template](https://github.com/GLINCKER/thesvg/issues/new/choose).
+Use the appropriate [issue template](https://github.com/glincker/thesvg/issues/new/choose).
 
 ### Improve the Code
 
@@ -47,7 +47,7 @@ Use the appropriate [issue template](https://github.com/GLINCKER/thesvg/issues/n
 
 ```bash
 # Clone the repo
-git clone https://github.com/GLINCKER/thesvg.git
+git clone https://github.com/glincker/thesvg.git
 cd thesvg
 
 # Install dependencies
@@ -127,6 +127,6 @@ For trademark concerns, see [TRADEMARK.md](./TRADEMARK.md) or contact
 
 ## Questions?
 
-- [Open a discussion](https://github.com/GLINCKER/thesvg/discussions)
-- [Browse existing issues](https://github.com/GLINCKER/thesvg/issues)
+- [Open a discussion](https://github.com/glincker/thesvg/discussions)
+- [Browse existing issues](https://github.com/glincker/thesvg/issues)
 - [Contact us](https://thesvg.org/contact)

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -21,12 +21,12 @@ where guidelines can typically be found.
 
 We make every effort to ensure icons are accurate and up-to-date. However, brands
 may update their logos at any time. If you notice an outdated or incorrect icon,
-please [open an issue](https://github.com/GLINCKER/thesvg/issues).
+please [open an issue](https://github.com/glincker/thesvg/issues).
 
 ## Removal Requests
 
 If you are a brand owner and would like your icon removed or updated, please
-[open an issue](https://github.com/GLINCKER/thesvg/issues) or email
+[open an issue](https://github.com/glincker/thesvg/issues) or email
 hello@thesvg.org. We will process removal requests promptly.
 
 ## License

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -39,7 +39,7 @@ Where available, we link to official brand guidelines on each icon's detail page
 
 We respect intellectual property rights. If you are a brand owner or authorized representative:
 
-- **Request removal**: [Open an issue](https://github.com/GLINCKER/thesvg/issues/new?template=icon_removal.yml) or email [support@glincker.com](mailto:support@glincker.com)
+- **Request removal**: [Open an issue](https://github.com/glincker/thesvg/issues/new?template=icon_removal.yml) or email [support@glincker.com](mailto:support@glincker.com)
 - **Update your icon**: Submit the correct version via issue or pull request
 - **Add usage guidelines**: Let us know your guidelines URL and we will link to it
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://thesvg.org">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/logo-wordmark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/logo-wordmark-dark.svg" />
-      <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/logo-wordmark-dark.svg" alt="theSVG" height="48" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" />
+      <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" alt="theSVG" height="48" />
     </picture>
   </a>
 </p>
@@ -15,9 +15,9 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
-  <a href="https://github.com/GLINCKER/thesvg/stargazers"><img src="https://img.shields.io/github/stars/GLINCKER/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/GLINCKER/thesvg"><img src="https://img.shields.io/badge/icons-4%2C007-F97316?style=flat-square" alt="4,007 icons" /></a>
-  <a href="https://github.com/GLINCKER/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/GLINCKER/thesvg?style=flat-square" alt="license" /></a>
+  <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-4%2C007-F97316?style=flat-square" alt="4,007 icons" /></a>
+  <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
 </p>
 
 <p align="center">
@@ -34,7 +34,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ brand SVG icons" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ brand SVG icons" width="720" />
   </a>
 </p>
 
@@ -93,7 +93,7 @@ Use any icon directly without installing:
 <img src="https://thesvg.org/icons/github/default.svg" width="32" height="32" alt="GitHub" />
 
 <!-- From jsDelivr -->
-<img src="https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons/github/default.svg" width="32" height="32" alt="GitHub" />
+<img src="https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons/github/default.svg" width="32" height="32" alt="GitHub" />
 ```
 
 **URL pattern:** `https://thesvg.org/icons/{slug}/{variant}.svg`
@@ -135,7 +135,7 @@ import { Github, Figma } from "@thesvg/vue";
 ### CDN
 
 ```html
-<img src="https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons/github/default.svg" width="32" height="32" alt="GitHub" />
+<img src="https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons/github/default.svg" width="32" height="32" alt="GitHub" />
 ```
 
 ### CLI
@@ -188,12 +188,12 @@ Icons are organized into 55+ categories:
 
 Every brand deserves a place. No gatekeeping.
 
-**Submit an icon:** [thesvg.org/submit](https://thesvg.org/submit) or open a [pull request](https://github.com/GLINCKER/thesvg/pulls).
+**Submit an icon:** [thesvg.org/submit](https://thesvg.org/submit) or open a [pull request](https://github.com/glincker/thesvg/pulls).
 
 **Development setup:**
 
 ```bash
-git clone https://github.com/GLINCKER/thesvg.git
+git clone https://github.com/glincker/thesvg.git
 cd thesvg
 pnpm install
 pnpm dev     # http://localhost:3333
@@ -205,7 +205,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
 
 All brand names, logos, and trademarks are the property of their respective owners. theSVG provides these icons for development and design purposes only under nominative fair use. Use of brand assets must comply with each brand's usage guidelines.
 
-If you are a brand owner and would like an icon updated or removed, please [open an issue](https://github.com/GLINCKER/thesvg/issues) or email **support@glincker.com**. See our [Legal Notice](https://thesvg.org/legal), [TRADEMARK.md](./TRADEMARK.md), and [LEGAL.md](./LEGAL.md) for full details.
+If you are a brand owner and would like an icon updated or removed, please [open an issue](https://github.com/glincker/thesvg/issues) or email **support@glincker.com**. See our [Legal Notice](https://thesvg.org/legal), [TRADEMARK.md](./TRADEMARK.md), and [LEGAL.md](./LEGAL.md) for full details.
 
 ## License
 
@@ -213,11 +213,11 @@ If you are a brand owner and would like an icon updated or removed, please [open
 
 ## Star History
 
-<a href="https://star-history.com/#GLINCKER/thesvg&Date">
+<a href="https://star-history.com/#glincker/thesvg&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GLINCKER/thesvg&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GLINCKER/thesvg&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GLINCKER/thesvg&type=Date" width="600" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date" width="600" />
  </picture>
 </a>
 
@@ -225,5 +225,5 @@ If you are a brand owner and would like an icon updated or removed, please [open
 
 <p align="center">
   <a href="https://thesvg.org">thesvg.org</a> &nbsp;&bull;&nbsp;
-  <a href="https://github.com/GLINCKER/thesvg/issues">Issues</a>
+  <a href="https://github.com/glincker/thesvg/issues">Issues</a>
 </p>

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -25,7 +25,7 @@ We respect your intellectual property. If you are a brand owner or authorized re
 Please contact us:
 
 - **Email**: [support@glincker.com](mailto:support@glincker.com)
-- **GitHub Issue**: [Open a trademark issue](https://github.com/GLINCKER/thesvg/issues/new?labels=trademark&title=Trademark+Request:+[Brand+Name])
+- **GitHub Issue**: [Open a trademark issue](https://github.com/glincker/thesvg/issues/new?labels=trademark&title=Trademark+Request:+[Brand+Name])
 
 We take all trademark requests seriously and will respond within 48 hours. Removal requests are honored promptly, typically within 24 hours.
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
 		"brand-icons"
 	],
 	"support": {
-		"issues": "https://github.com/GLINCKER/thesvg/issues",
-		"source": "https://github.com/GLINCKER/thesvg",
+		"issues": "https://github.com/glincker/thesvg/issues",
+		"source": "https://github.com/glincker/thesvg",
 		"docs": "https://thesvg.org/api-docs"
 	},
 	"license": "MIT"

--- a/extensions/figma/src/ui.ts
+++ b/extensions/figma/src/ui.ts
@@ -3,7 +3,7 @@
 // to avoid CORS issues with the null-origin iframe
 
 const CDN_BASE =
-  "https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons";
+  "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 
 interface IconEntry {
   slug: string;

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -44,4 +44,4 @@ Example: `Copy Brand Icon` > `github` copies the GitHub SVG to your clipboard.
 
 - [thesvg.org](https://thesvg.org) - Browse all icons
 - [API Docs](https://thesvg.org/api-docs) - REST API reference
-- [GitHub](https://github.com/GLINCKER/thesvg) - Source code
+- [GitHub](https://github.com/glincker/thesvg) - Source code

--- a/extensions/raycast/src/api.ts
+++ b/extensions/raycast/src/api.ts
@@ -88,5 +88,5 @@ export function getIconPageUrl(slug: string): string {
 }
 
 export function getCdnUrl(slug: string, variant = "default"): string {
-  return `https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons/${slug}/${variant}.svg`;
+  return `https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons/${slug}/${variant}.svg`;
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
   </a>
 </p>
 
@@ -15,8 +15,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@thesvg/icons"><img src="https://img.shields.io/npm/v/@thesvg/icons?color=F97316&label=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@thesvg/icons"><img src="https://img.shields.io/npm/dm/@thesvg/icons?color=F97316" alt="npm downloads" /></a>
-  <a href="https://github.com/GLINCKER/thesvg/blob/main/packages/icons/LICENSE"><img src="https://img.shields.io/npm/l/@thesvg/icons?color=F97316" alt="license" /></a>
-  <a href="https://github.com/GLINCKER/thesvg"><img src="https://img.shields.io/github/stars/GLINCKER/thesvg?style=social" alt="GitHub stars" /></a>
+  <a href="https://github.com/glincker/thesvg/blob/main/packages/icons/LICENSE"><img src="https://img.shields.io/npm/l/@thesvg/icons?color=F97316" alt="license" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=social" alt="GitHub stars" /></a>
 </p>
 
 ---
@@ -129,7 +129,7 @@ Use icons directly without a bundler:
 
 ## Contributing
 
-Found a missing icon or incorrect data? [Open an issue](https://github.com/GLINCKER/thesvg/issues) or [submit an icon](https://thesvg.org/submit) on the website.
+Found a missing icon or incorrect data? [Open an issue](https://github.com/glincker/thesvg/issues) or [submit an icon](https://thesvg.org/submit) on the website.
 
 ## License
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/icons"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,11 +8,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/mcp"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "mcp",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -4,7 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 const BASE_URL = "https://thesvg.org/api";
-const CDN_BASE = "https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public";
+const CDN_BASE = "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public";
 
 // --- Types ---
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/react"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/svelte"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 3,847 Brand SVG Icons" width="700" />
   </a>
 </p>
 
@@ -15,8 +15,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?color=F97316&label=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?color=F97316" alt="npm downloads" /></a>
-  <a href="https://github.com/GLINCKER/thesvg/blob/main/packages/thesvg/LICENSE"><img src="https://img.shields.io/npm/l/thesvg?color=F97316" alt="license" /></a>
-  <a href="https://github.com/GLINCKER/thesvg"><img src="https://img.shields.io/github/stars/GLINCKER/thesvg?style=social" alt="GitHub stars" /></a>
+  <a href="https://github.com/glincker/thesvg/blob/main/packages/thesvg/LICENSE"><img src="https://img.shields.io/npm/l/thesvg?color=F97316" alt="license" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=social" alt="GitHub stars" /></a>
 </p>
 
 ---

--- a/packages/thesvg/package.json
+++ b/packages/thesvg/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/thesvg"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <a href="https://github.com/GLINCKER/thesvg">
-    <img src="https://raw.githubusercontent.com/GLINCKER/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ Brand SVG Icons" width="700" />
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 4,000+ Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -9,11 +9,11 @@
   "homepage": "https://thesvg.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/GLINCKER/thesvg.git",
+    "url": "https://github.com/glincker/thesvg.git",
     "directory": "packages/vue"
   },
   "bugs": {
-    "url": "https://github.com/GLINCKER/thesvg/issues"
+    "url": "https://github.com/glincker/thesvg/issues"
   },
   "keywords": [
     "svg",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -117,7 +117,7 @@ Returns all categories with icon counts.
 
 ### jsDelivr CDN
 ```
-https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons/{slug}/{variant}.svg
+https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons/{slug}/{variant}.svg
 ```
 
 ## Framework Examples
@@ -197,7 +197,7 @@ MIT for the codebase and tooling. Brand icons are property of their respective t
 ## Links
 
 - Website: https://thesvg.org
-- GitHub: https://github.com/GLINCKER/thesvg
+- GitHub: https://github.com/glincker/thesvg
 - npm: https://www.npmjs.com/package/thesvg
 - API Docs: https://thesvg.org/api-docs
 - Compare Libraries: https://thesvg.org/compare

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,7 +11,7 @@ theSVG provides 4,000+ brand SVG icons with multi-variant support (color, mono, 
 - Website: https://thesvg.org
 - API Docs: https://thesvg.org/api-docs
 - Compare Libraries: https://thesvg.org/compare
-- GitHub: https://github.com/GLINCKER/thesvg
+- GitHub: https://github.com/glincker/thesvg
 - npm: https://www.npmjs.com/package/thesvg
 - Submit Icon: https://thesvg.org/submit
 - Extensions: https://thesvg.org/extensions
@@ -52,7 +52,7 @@ Each icon can have up to 7 variants:
 
 ```
 https://thesvg.org/icons/{slug}/{variant}.svg
-https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons/{slug}/{variant}.svg
+https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons/{slug}/{variant}.svg
 ```
 
 ## Categories

--- a/src/app/api/registry/[slug]/route.ts
+++ b/src/app/api/registry/[slug]/route.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 const BASE_URL = "https://thesvg.org";
 const CDN_BASE =
-  "https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons";
+  "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",

--- a/src/lib/code-snippets.ts
+++ b/src/lib/code-snippets.ts
@@ -1,7 +1,7 @@
 export type SnippetFormat = "react" | "vue" | "html" | "nextjs" | "css" | "cli" | "mcp";
 
 const CDN_BASE =
-  "https://cdn.jsdelivr.net/gh/GLINCKER/thesvg@main/public/icons";
+  "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 const SITE_BASE = "https://thesvg.org/icons";
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,3 @@
 /** External URLs used across multiple pages/components. */
 export const TRADEMARK_POLICY_URL =
-  "https://github.com/GLINCKER/thesvg/blob/main/TRADEMARK.md";
+  "https://github.com/glincker/thesvg/blob/main/TRADEMARK.md";


### PR DESCRIPTION
## Summary
- Update all org references from `GLINCKER` to `glincker` (lowercase) across 30 files
- Matches the renamed GitHub org and npm trusted publisher config
- Covers: package.json repos, CDN URLs, README badges, issue templates, changeset config, extensions

Skipped: CHANGELOGs (auto-generated history), icons.json GLINCKER brand entry (actual brand name)

## Test plan
- [ ] Merge this PR
- [ ] Verify version.yml creates a Version PR
- [ ] Merge Version PR
- [ ] Verify release.yml publishes to npm via OIDC