### PR TITLE
fix: add major changeset for v2.0.0 release

### DIFF
--- a/.changeset/bump-v2-major.md
+++ b/.changeset/bump-v2-major.md
@@ -1,0 +1,17 @@
+---
+"@thesvg/icons": major
+"thesvg": major
+"@thesvg/react": major
+"@thesvg/vue": major
+"@thesvg/svelte": major
+---
+
+v2.0.0 - AWS Architecture Icons, Amazon family brands, SEO improvements
+
+- Added 739 AWS architecture icons (services, resources, categories, groups)
+- Added Amazon family brand icons (Amazon, Prime, Kindle, Fire TV, Music, Whole Foods Market)
+- Total icon count now 4,758 with 10,000+ SVG variants
+- Enhanced sitemap with image URLs for Google Image indexing
+- Added JSON-LD structured data (WebPage, BreadcrumbList) for icon pages
+- Professional footer redesign with glassmorphism, animated counters, partner logos
+- New "collections" system (brands, aws) for icon organization


### PR DESCRIPTION
## Summary
- Adds a fresh major changeset to bump all linked packages (@thesvg/icons, thesvg, @thesvg/react, @thesvg/vue, @thesvg/svelte) from 1.0.x to 2.0.0
- The original major changeset was consumed during earlier merges but the version PR never picked up the major bump
- Once merged, the Changesets action will update PR #51 to show 2.0.0 instead of patch bumps

## Test plan
- [ ] Merge this PR
- [ ] Verify PR #51 updates to show 2.0.0 versions
- [ ] Merge PR #51 to publish 2.0.0