### PR TITLE
fix: address VS Code extension review feedback

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2
+
+- Default shortcut changed to `Cmd/Ctrl+Shift+Alt+I` to avoid the built-in Developer Tools chord on Windows and Linux
+- Registry and SVG fetches now have a 15s timeout and are cancellable from the progress notification
+- `Copy as JSX` handles more SVG attributes: `xlink:*`, `for`, `tabindex`, and inline `style="..."` strings are converted to valid JSX
+
 ## 0.1.1
 
 - Switch icon registry to `thesvg.org/api/registry.json` (post Cloudflare migration)

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -4,7 +4,7 @@ Search and copy 5,650+ SVG icons directly from VS Code. Brand logos, AWS, Azure,
 
 ## Features
 
-- **Search** across 5,650+ icons from the command palette (`Cmd+Shift+I`)
+- **Search** across 5,650+ icons from the command palette (`Cmd+Shift+Alt+I`)
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS
@@ -14,12 +14,14 @@ Search and copy 5,650+ SVG icons directly from VS Code. Brand logos, AWS, Azure,
 
 ## Usage
 
-1. Press `Cmd+Shift+I` (or `Ctrl+Shift+I` on Windows/Linux)
+1. Press `Cmd+Shift+Alt+I` (or `Ctrl+Shift+Alt+I` on Windows/Linux)
 2. Type an icon name (e.g. "lambda", "stripe", "compute")
 3. Select an icon
 4. Choose an action (copy SVG, copy JSX, copy CDN, insert, etc.)
 
 Or use the command palette (`Cmd+Shift+P`) and search for "theSVG".
+
+> The default shortcut avoids `Ctrl+Shift+I`, which VS Code uses to open the Developer Tools on Windows and Linux. Remap from `File > Preferences > Keyboard Shortcuts` if you prefer a shorter chord.
 
 ## Commands
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thesvg",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thesvg",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.85.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
   "description": "Search and copy 5,650+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "glincker",
   "license": "MIT",
   "icon": "assets/icon.png",
@@ -60,8 +60,8 @@
     "keybindings": [
       {
         "command": "thesvg.search",
-        "key": "ctrl+shift+i",
-        "mac": "cmd+shift+i"
+        "key": "ctrl+shift+alt+i",
+        "mac": "cmd+shift+alt+i"
       }
     ]
   },

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -19,12 +19,38 @@ interface RegistryResponse {
   icons: IconEntry[];
 }
 
+const FETCH_TIMEOUT_MS = 15_000;
+
 let iconsCache: IconEntry[] | null = null;
 
-async function fetchIcons(): Promise<IconEntry[]> {
+async function fetchWithTimeout(
+  url: string,
+  token?: vscode.CancellationToken,
+  ms: number = FETCH_TIMEOUT_MS
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  const cancelSub = token?.onCancellationRequested(() => controller.abort());
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } catch (err) {
+    if (token?.isCancellationRequested) {
+      throw new Error("Cancelled");
+    }
+    if (controller.signal.aborted) {
+      throw new Error(`Request timed out after ${ms / 1000}s: ${url}`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+    cancelSub?.dispose();
+  }
+}
+
+async function fetchIcons(token?: vscode.CancellationToken): Promise<IconEntry[]> {
   if (iconsCache) return iconsCache;
 
-  const response = await fetch(REGISTRY_URL);
+  const response = await fetchWithTimeout(REGISTRY_URL, token);
   if (!response.ok) {
     throw new Error(`Failed to fetch icons: ${response.status}`);
   }
@@ -42,25 +68,48 @@ function getCdnUrl(slug: string, variant: string = "default"): string {
 }
 
 async function fetchSvgContent(slug: string, variant: string = "default"): Promise<string> {
-  const response = await fetch(getIconUrl(slug, variant));
+  const response = await fetchWithTimeout(getIconUrl(slug, variant));
   if (!response.ok) {
     throw new Error(`Failed to fetch SVG: ${response.status}`);
   }
   return response.text();
 }
 
+function kebabOrNsToCamel(name: string): string {
+  return name.replace(/[-:]([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function convertInlineStyle(styleBody: string): string {
+  const props = styleBody
+    .split(";")
+    .map((rule) => rule.trim())
+    .filter(Boolean)
+    .map((rule) => {
+      const idx = rule.indexOf(":");
+      if (idx === -1) return null;
+      const key = kebabOrNsToCamel(rule.slice(0, idx).trim());
+      const value = rule.slice(idx + 1).trim().replace(/"/g, '\\"');
+      return `${key}: "${value}"`;
+    })
+    .filter((p): p is string => p !== null)
+    .join(", ");
+  return ` style={{${props}}}`;
+}
+
 function svgToJsx(svg: string, title: string): string {
   const componentName = title.replace(/[^a-zA-Z0-9]/g, "") + "Icon";
+
   const jsxBody = svg
-    .replace(/class=/g, "className=")
-    .replace(/fill-rule=/g, "fillRule=")
-    .replace(/clip-rule=/g, "clipRule=")
-    .replace(/stroke-width=/g, "strokeWidth=")
-    .replace(/stroke-linecap=/g, "strokeLinecap=")
-    .replace(/stroke-linejoin=/g, "strokeLinejoin=")
-    .replace(/fill-opacity=/g, "fillOpacity=")
-    .replace(/stroke-opacity=/g, "strokeOpacity=")
-    .replace(/xmlns:xlink=/g, "xmlnsXlink=");
+    // Camel-case hyphenated or namespaced attribute names (stroke-width, xlink:href, etc.)
+    .replace(/(\s)([a-z]+(?:[-:][a-z]+)+)(\s*=)/g, (_m, ws: string, name: string, eq: string) =>
+      `${ws}${kebabOrNsToCamel(name)}${eq}`
+    )
+    // React-reserved single-word attributes
+    .replace(/(\s)class=/g, "$1className=")
+    .replace(/(\s)for=/g, "$1htmlFor=")
+    .replace(/(\s)tabindex=/g, "$1tabIndex=")
+    // Inline style="..." -> style={{...}}
+    .replace(/\sstyle="([^"]*)"/g, (_m, body: string) => convertInlineStyle(body));
 
   return `function ${componentName}(props) {\n  return (\n    ${jsxBody}\n  );\n}`;
 }
@@ -83,9 +132,9 @@ async function showIconPicker(): Promise<IconEntry | undefined> {
     {
       location: vscode.ProgressLocation.Notification,
       title: "theSVG: Loading icons...",
-      cancellable: false,
+      cancellable: true,
     },
-    () => fetchIcons()
+    (_progress, token) => fetchIcons(token)
   );
 
   const quickPick = vscode.window.createQuickPick<IconQuickPickItem>();


### PR DESCRIPTION
## Summary
Addresses the four greptile review comments on #101 and bumps to `0.1.2`, which will auto-publish to the Marketplace via the new workflow once merged.

## Fixes
- **Lockfile drift** — ran `npm install`, `package-lock.json` now records `0.1.2`
- **JSX conversion** — `svgToJsx` now camel-cases any hyphenated / namespaced attribute name (`xlink:href`, `xmlns:xlink`, etc.), maps `class`/`for`/`tabindex`, and converts inline `style="..."` strings to JSX object syntax. Verified with:
  ```
  <use xlink:href="#a"/>   -> <use xlinkHref="#a"/>
  <text for="x"/>          -> <text htmlFor="x"/>
  style="fill:red"         -> style={{fill: "red"}}
  ```
- **Fetch timeout** — new `fetchWithTimeout` uses `AbortController` (15s cap) and the progress notification is now `cancellable: true`, piping the cancellation token into the fetch
- **Keybinding conflict** — default shortcut moved from `Ctrl+Shift+I` (shadows VS Code DevTools on Windows/Linux) to `Cmd/Ctrl+Shift+Alt+I`. README updated with remap instructions

## Test plan
- [x] `npm install` updates lockfile version to 0.1.2
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Smoke-test of `svgToJsx` on namespaced/reserved/inline-style inputs
- [ ] Manual: install built VSIX, confirm new shortcut works and cancel button on the loading toast aborts the fetch

## Release
After merge, the `Release - VS Code Extension` workflow will detect `0.1.1 -> 0.1.2` and auto-publish to `glincker.thesvg`.