### PR TITLE
chore: drop default VS Code keybinding

### DIFF
--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3
+
+- Remove the default keybinding. Invoke via the command palette (`theSVG: Search Icons`) or bind your own under `Preferences: Open Keyboard Shortcuts`. Avoids shadowing any built-in VS Code chord.
+
 ## 0.1.2
 
 - Default shortcut changed to `Cmd/Ctrl+Shift+Alt+I` to avoid the built-in Developer Tools chord on Windows and Linux

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -4,7 +4,7 @@ Search and copy 5,650+ SVG icons directly from VS Code. Brand logos, AWS, Azure,
 
 ## Features
 
-- **Search** across 5,650+ icons from the command palette (`Cmd+Shift+Alt+I`)
+- **Search** across 5,650+ icons from the command palette
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS
@@ -14,14 +14,12 @@ Search and copy 5,650+ SVG icons directly from VS Code. Brand logos, AWS, Azure,
 
 ## Usage
 
-1. Press `Cmd+Shift+Alt+I` (or `Ctrl+Shift+Alt+I` on Windows/Linux)
-2. Type an icon name (e.g. "lambda", "stripe", "compute")
-3. Select an icon
+1. Open the command palette: `Cmd+Shift+P` (macOS) or `Ctrl+Shift+P` (Windows/Linux)
+2. Run `theSVG: Search Icons`
+3. Type an icon name (e.g. "lambda", "stripe", "compute") and pick one
 4. Choose an action (copy SVG, copy JSX, copy CDN, insert, etc.)
 
-Or use the command palette (`Cmd+Shift+P`) and search for "theSVG".
-
-> The default shortcut avoids `Ctrl+Shift+I`, which VS Code uses to open the Developer Tools on Windows and Linux. Remap from `File > Preferences > Keyboard Shortcuts` if you prefer a shorter chord.
+> No default shortcut is bound so nothing gets shadowed. Bind any command to a key you like via `Preferences: Open Keyboard Shortcuts` and search for `thesvg`.
 
 ## Commands
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thesvg",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thesvg",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/vscode": "^1.85.0",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
   "description": "Search and copy 5,650+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "glincker",
   "license": "MIT",
   "icon": "assets/icon.png",
@@ -55,13 +55,6 @@
       {
         "command": "thesvg.insertSvg",
         "title": "theSVG: Insert SVG at Cursor"
-      }
-    ],
-    "keybindings": [
-      {
-        "command": "thesvg.search",
-        "key": "ctrl+shift+alt+i",
-        "mac": "cmd+shift+alt+i"
       }
     ]
   },


### PR DESCRIPTION
## Summary
Removes the default `Cmd/Ctrl+Shift+Alt+I` shortcut from the VS Code extension. The 4-finger chord was awkward and every 2-3 finger chord we considered shadows a legitimate VS Code or platform shortcut somewhere.

Users now invoke via the command palette (`theSVG: Search Icons`) and bind their own key if they want one. README updated.

Version: 0.1.2 → 0.1.3. Auto-publishes on merge via `Release - VS Code Extension`.

## Test plan
- [x] `npm install` updates lockfile to 0.1.3
- [x] `npm run build` clean
- [x] `keybindings` array no longer present in package.json