### PR TITLE
feat: surface VS Code extension on the site

### DIFF
--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -231,7 +231,7 @@ const CATEGORIES: Category[] = [
       },
       {
         name: "Raycast Extension",
-        description: "Search 5,650+ icons, copy SVG or CDN URL in one keystroke. Filter by category, preview variants.",
+        description: `Search ${iconCount} icons, copy SVG or CDN URL in one keystroke. Filter by category, preview variants.`,
         status: "available",
         cta: "Install",
         href: "https://www.raycast.com/thegdsks/thesvg",

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -127,10 +127,10 @@ const CATEGORIES: Category[] = [
     items: [
       {
         name: "VS Code",
-        description: "Fuzzy search, inline preview, one-click paste. Cmd+Shift+P to insert.",
-        status: "coming-soon",
-        cta: "GitHub",
-        href: "https://github.com/GLINCKER/thesvg/issues",
+        description: "Search 5,650+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor.",
+        status: "available",
+        cta: "Install",
+        href: "https://marketplace.visualstudio.com/items?itemName=glincker.thesvg",
         iconSlug: "visual-studio-code",
       },
       {
@@ -231,10 +231,10 @@ const CATEGORIES: Category[] = [
       },
       {
         name: "Raycast Extension",
-        description: "Search 5,600+ icons, copy SVG or CDN URL in one keystroke. Filter by category, preview variants.",
+        description: "Search 5,650+ icons, copy SVG or CDN URL in one keystroke. Filter by category, preview variants.",
         status: "available",
-        cta: "GitHub",
-        href: "https://github.com/GLINCKER/thesvg/tree/main/extensions/raycast",
+        cta: "Install",
+        href: "https://www.raycast.com/thegdsks/thesvg",
         iconSlug: "raycast",
       },
       {

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -127,7 +127,7 @@ const CATEGORIES: Category[] = [
     items: [
       {
         name: "VS Code",
-        description: "Search 5,650+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor.",
+        description: `Search ${iconCount} icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor.`,
         status: "available",
         cta: "Install",
         href: "https://marketplace.visualstudio.com/items?itemName=glincker.thesvg",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -497,6 +497,22 @@ export function Header() {
                 <span className="hidden lg:inline">Raycast</span>
               </a>
               <a
+                href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Install the VS Code extension"
+                className="hidden items-center gap-1.5 rounded-lg border border-border/50 px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-all hover:border-[#007ACC]/30 hover:bg-[#007ACC]/5 hover:text-[#007ACC] sm:inline-flex dark:border-white/[0.06] dark:hover:border-[#007ACC]/30"
+              >
+                <img
+                  src="/icons/visual-studio-code/default.svg"
+                  alt="VS Code"
+                  width={16}
+                  height={16}
+                  className="h-4 w-4"
+                />
+                <span className="hidden lg:inline">VS Code</span>
+              </a>
+              <a
                 href="https://github.com/GLINCKER/thesvg"
                 target="_blank"
                 rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
The VS Code extension (`glincker.thesvg`) is live on the Marketplace. This PR surfaces it across the site.

## Changes
- **`src/app/extensions/page.tsx`** — VS Code card switches from \"coming-soon → GitHub\" to \"Published → Install\" with the Marketplace URL. Description updated to describe actual shipped capabilities (command palette, copy SVG/JSX/CDN/insert at cursor). Raycast card also repointed at the canonical `raycast.com/thegdsks/thesvg` URL.
- **`src/components/header.tsx`** — New VS Code pill between Raycast and GitHub. Same visual pattern as the existing buttons: 16×16 icon, label shown at `lg+`, brand-blue hover. Keeps the right side clean on smaller screens.

## Why a nav button, not the footer
You already have npm, Raycast, GitHub as small icon-pills on the right side of the navbar. VS Code slots in naturally. The text labels collapse below `lg` so the 4-icon cluster stays the same width as before on mobile.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Visual check at 375 / 768 / 1024 / 1440 viewports
- [ ] VS Code pill routes to the Marketplace listing
- [ ] Extensions page VS Code card CTA says \"Install\" and links to the Marketplace