### PR TITLE
fix: eliminate route flicker on icon click and variant change

### DIFF
--- a/src/components/icons/icon-card.tsx
+++ b/src/components/icons/icon-card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Check, Copy, Download, Eye, Heart } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
 import type { IconEntry } from "@/lib/icons";
 import { useFavoritesStore } from "@/lib/stores/favorites-store";
@@ -20,8 +21,16 @@ export const IconCard = memo(function IconCard({
   compact = false,
 }: IconCardProps) {
   const [copied, setCopied] = useState(false);
+  const router = useRouter();
+  const prefetched = useRef(false);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
   const isFavorite = useFavoritesStore((s) => s.favorites.includes(icon.slug));
+
+  const handleHoverPrefetch = useCallback(() => {
+    if (prefetched.current) return;
+    prefetched.current = true;
+    router.prefetch(`/icon/${icon.slug}`);
+  }, [router, icon.slug]);
 
   const handleCopy = useCallback(
     async (e: React.MouseEvent) => {
@@ -109,6 +118,9 @@ export const IconCard = memo(function IconCard({
       <Link
         href={`/icon/${icon.slug}`}
         prefetch={false}
+        onMouseEnter={handleHoverPrefetch}
+        onFocus={handleHoverPrefetch}
+        onTouchStart={handleHoverPrefetch}
         className="group relative flex w-full min-w-0 flex-col items-center gap-1.5 overflow-hidden rounded-xl border border-border/40 bg-card/80 p-3 transition-all duration-200 hover:border-border hover:bg-card hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <div
@@ -145,6 +157,9 @@ export const IconCard = memo(function IconCard({
     <Link
       href={`/icon/${icon.slug}`}
       prefetch={false}
+      onMouseEnter={handleHoverPrefetch}
+      onFocus={handleHoverPrefetch}
+      onTouchStart={handleHoverPrefetch}
       className="group relative flex h-full min-w-0 flex-col items-center rounded-xl border border-border/40 bg-card/80 transition-all duration-200 hover:border-border hover:bg-card hover:shadow-lg hover:shadow-black/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-black/20"
     >
       {/* Favorite toggle */}

--- a/src/components/icons/icon-card.tsx
+++ b/src/components/icons/icon-card.tsx
@@ -22,13 +22,16 @@ export const IconCard = memo(function IconCard({
 }: IconCardProps) {
   const [copied, setCopied] = useState(false);
   const router = useRouter();
-  const prefetched = useRef(false);
+  // Track the slug we last prefetched, not a boolean, so virtualised/windowed
+  // parents that reuse IconCard instances with different icons still prefetch
+  // when the prop changes.
+  const prefetchedSlug = useRef<string | null>(null);
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite);
   const isFavorite = useFavoritesStore((s) => s.favorites.includes(icon.slug));
 
   const handleHoverPrefetch = useCallback(() => {
-    if (prefetched.current) return;
-    prefetched.current = true;
+    if (prefetchedSlug.current === icon.slug) return;
+    prefetchedSlug.current = icon.slug;
     router.prefetch(`/icon/${icon.slug}`);
   }, [router, icon.slug]);
 

--- a/src/components/icons/icon-detail-page.tsx
+++ b/src/components/icons/icon-detail-page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import posthog from "posthog-js";
 import Link from "next/link";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 import {
   ArrowUpRight,
   Check,
@@ -34,7 +34,6 @@ export function IconDetailPage({
   relatedIcons = [],
 }: IconDetailPageProps) {
   const searchParams = useSearchParams();
-  const router = useRouter();
   const pathname = usePathname();
 
   // Read variant from URL param, fallback to "default"
@@ -69,9 +68,14 @@ export function IconDetailPage({
       const qs = params.toString();
       const queryString = qs ? `?${qs}` : "";
       const newUrl = `${pathname}${queryString}`;
-      router.replace(newUrl, { scroll: false });
+      // Avoid router.replace here: it re-runs App Router reconciliation and
+      // triggers loading.tsx, causing a visible flash. Active variant is
+      // already tracked in local state; the URL update is for shareability.
+      if (typeof window !== "undefined") {
+        window.history.replaceState(null, "", newUrl);
+      }
     },
-    [searchParams, pathname, router, icon.slug],
+    [searchParams, pathname, icon.slug],
   );
 
   const variants = Object.entries(icon.variants).filter(

--- a/src/components/icons/icon-detail-page.tsx
+++ b/src/components/icons/icon-detail-page.tsx
@@ -59,7 +59,16 @@ export function IconDetailPage({
         variant,
         source: "detail_page",
       });
-      const params = new URLSearchParams(searchParams.toString());
+      // history.replaceState (used below) bypasses the Next router, so
+      // useSearchParams does not refresh after the first update. Read the
+      // current query from window.location.search so repeated variant clicks
+      // preserve any other params (e.g. utm tags, future filters) rather than
+      // folding them back to whatever useSearchParams captured on mount.
+      const currentSearch =
+        typeof window !== "undefined"
+          ? window.location.search
+          : `?${searchParams.toString()}`;
+      const params = new URLSearchParams(currentSearch);
       if (variant === "default") {
         params.delete("variant");
       } else {


### PR DESCRIPTION
## Root causes

Two separate flicker sources, different mechanisms.

### 1. Icon card click flickered, nav tabs were smooth

The header's collection tabs (AWS/GCP/Azure) use a plain `<Link>` with default prefetch, so Next warms the RSC payload and the swap is instant on click.

`icon-card.tsx` had `prefetch={false}` on both the compact and default `<Link>`s. That was originally protective: viewport-prefetching every one of 5,650 cards would be wasteful. But it also meant **zero warm RSC on click**, so `loading.tsx` flashed for 100-300ms while Next fetched the tree for the icon detail page.

**Fix:** keep `prefetch={false}` (still want to avoid scroll-prefetch explosion) and add targeted hover/focus/touchstart prefetch via `router.prefetch()`. Only the card a user is about to click gets warmed. A `useRef` dedupes so prefetch runs once per card per mount.

### 2. Variant click flickered

`handleVariantSelect` in `icon-detail-page.tsx` was calling `router.replace(newUrl, { scroll: false })` after a variant was clicked, to keep the URL shareable. `router.replace` re-runs App Router reconciliation, refetches the RSC payload with new search params, and re-triggers any Suspense boundary — including the `loading.tsx` file — even for the same page.

The active variant is already local state (`activeVariant` via `useState`). The URL update is purely for shareability; no reactive round trip is needed.

**Fix:** swap `router.replace` for `window.history.replaceState(null, '', newUrl)`. URL updates instantly, no RSC fetch, no loading flash. `useRouter` import dropped since it's no longer used.

## Test plan

- [ ] Click an icon in the grid: no skeleton flash on the detail page
- [ ] Hover a card briefly then click: instant swap
- [ ] Click variants on a detail page with multiple variants: URL updates, no skeleton flash
- [ ] Direct-load a URL with `?variant=mono`: correct variant selected on first paint
- [ ] Scroll the grid fast: network tab should show hover-triggered prefetches only, not a flood