### PR TITLE
fix: mark Roborock and FPT Play licenses as Proprietary

### DIFF
--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -51710,7 +51710,7 @@
       "default": "/icons/fpt-play/default.svg",
       "mono": "/icons/fpt-play/mono.svg"
     },
-    "license": "TODO",
+    "license": "Proprietary",
     "url": "https://fptplay.vn/",
     "dateAdded": "2026-04-20",
     "collection": "brands"
@@ -89774,7 +89774,7 @@
       "default": "/icons/roborock/default.svg",
       "mono": "/icons/roborock/mono.svg"
     },
-    "license": "TODO",
+    "license": "Proprietary",
     "url": "https://us.roborock.com/",
     "dateAdded": "2026-04-20",
     "collection": "brands"


### PR DESCRIPTION
## Summary
Both icons landed in v2.2.0 with `"license": "TODO"` (the value the submission template uses). A quick search of each brand's terms shows neither has granted a permissive licence:

- Roborock's user agreement explicitly forbids trademark use without written consent.
- FPT Play has no public brand-asset guidelines.

`Proprietary` is already used in the registry for 13 similar entries, so switching to it is more honest than leaving `TODO` in shipped data.

MindStudio also has `TODO` but predates this PR — leaving it for a separate pass.

## Test plan
- [ ] `node -e "..."` confirms both slugs now read `Proprietary`
- [ ] Diff is exactly two line changes