### PR TITLE
perf: lazy-load manifest, content-visibility on grid, fix double-render

### DIFF
--- a/src/app/collection/[name]/page.tsx
+++ b/src/app/collection/[name]/page.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import {
-  getAllIcons,
   getCategoryCounts,
   getIconCount,
   getRecentlyAddedIcons,
   getCollections,
+  getCollectionCount,
   type Collection,
 } from "@/lib/icons";
 import { HomeContent } from "@/components/home-content";
@@ -135,7 +135,6 @@ export default async function CollectionPage({ params }: PageProps) {
     notFound();
   }
 
-  const icons = getAllIcons();
   const categoryCounts = getCategoryCounts();
   const iconCount = getIconCount();
   const recentIcons = getRecentlyAddedIcons(12);
@@ -143,6 +142,7 @@ export default async function CollectionPage({ params }: PageProps) {
 
   const collectionName = name as Collection;
   const meta = COLLECTION_META[name];
+  const collectionItemCount = getCollectionCount(collectionName);
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -155,7 +155,7 @@ export default async function CollectionPage({ params }: PageProps) {
       name: "theSVG",
       url: "https://thesvg.org",
     },
-    numberOfItems: icons.filter((i) => i.collection === name).length,
+    numberOfItems: collectionItemCount,
     provider: {
       "@type": "Organization",
       name: "theSVG",
@@ -171,7 +171,6 @@ export default async function CollectionPage({ params }: PageProps) {
       />
       <Suspense>
         <HomeContent
-          icons={icons}
           categoryCounts={categoryCounts}
           count={iconCount}
           recentIcons={recentIcons}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import {
-  getAllIcons,
   getCategoryCounts,
   getIconCount,
   getFormattedIconCount,
@@ -50,7 +49,6 @@ const jsonLd = {
 };
 
 export default function Home() {
-  const icons = getAllIcons();
   const categoryCounts = getCategoryCounts();
   const iconCount = getIconCount();
   const recentIcons = getRecentlyAddedIcons(12);
@@ -64,7 +62,6 @@ export default function Home() {
       />
       <Suspense>
         <HomeContent
-          icons={icons}
           categoryCounts={categoryCounts}
           count={iconCount}
           recentIcons={recentIcons}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { ArrowRight, Cloud, FileText, Github, Menu, Moon, Package, Plus, Search, Shapes, Sparkles, Sun, X } from "lucide-react";
@@ -9,8 +9,8 @@ import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useSidebarStore } from "@/lib/stores/sidebar-store";
 import { useSearchStore } from "@/lib/stores/search-store";
-import { getAllIcons, type IconEntry } from "@/lib/icons";
-import { searchIcons } from "@/lib/search";
+import type { IconEntry } from "@/lib/icons";
+import { loadIconsManifest } from "@/lib/icons-manifest";
 import { cn } from "@/lib/utils";
 
 /** Inline AWS logo - text inherits currentColor, arrow stays orange */
@@ -65,14 +65,6 @@ function SubmitButton() {
       </span>
     </Link>
   );
-}
-
-const ICONS_CACHE: { current: IconEntry[] | null } = { current: null };
-function getCachedIcons(): IconEntry[] {
-  if (!ICONS_CACHE.current) {
-    ICONS_CACHE.current = getAllIcons();
-  }
-  return ICONS_CACHE.current;
 }
 
 export function Header() {
@@ -142,20 +134,27 @@ export function Header() {
 
   const isHome = pathname === "/";
 
-  // Search suggestions
-  const suggestions = useMemo(() => {
-    if (!query.trim() || query.length < 2) return [];
-    const icons = getCachedIcons();
-    return searchIcons(icons, query).slice(0, 6);
-  }, [query]);
-
+  const [suggestions, setSuggestions] = useState<IconEntry[]>([]);
   const hasQuery = query.trim().length >= 2;
   const showDropdown = focused && (hasQuery ? suggestions.length > 0 : true);
 
-  // Reset selected index when suggestions change
+  // Lazy-load the manifest and Fuse.js when the user types a search query
   useEffect(() => {
-    setSelectedIdx(-1);
-  }, [suggestions]);
+    if (!hasQuery) {
+      setSuggestions([]);
+      setSelectedIdx(-1);
+      return;
+    }
+    let active = true;
+    Promise.all([loadIconsManifest(), import("@/lib/search")]).then(([icons, { searchIcons }]) => {
+      if (!active) return;
+      setSuggestions(searchIcons(icons, query).slice(0, 6));
+      setSelectedIdx(-1);
+    }).catch(() => {
+      if (active) setSuggestions([]);
+    });
+    return () => { active = false; };
+  }, [query, hasQuery]);
 
   // Close dropdown on click outside
   useEffect(() => {

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -191,8 +191,11 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
       );
     }
 
-    // Lazy-load Fuse.js only when there is a search query
+    // Lazy-load Fuse.js only when there is a search query.
+    // Clear stale results immediately so the previous query's matches don't
+    // linger while Fuse downloads / runs.
     if (query.trim()) {
+      setFiltered([]);
       import("@/lib/search").then(({ searchIcons }) => {
         if (!active) return;
         let searched = searchIcons(result, query);
@@ -219,8 +222,8 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collectionIcons, filterKey, favorites]);
 
-  const activeCount = collectionParam && allIcons
-    ? allIcons.filter((i) => i.collection === collectionParam).length
+  const activeCount = collectionParam && collectionIcons
+    ? collectionIcons.length
     : count;
 
   // Stable key for IconGrid so it remounts naturally when filters change,
@@ -399,6 +402,10 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
                 <p className="py-24 text-center text-sm text-muted-foreground">
                   Failed to load icons. Please refresh and try again.
                 </p>
+              ) : !allIcons ? (
+                <div className="flex justify-center py-24">
+                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" />
+                </div>
               ) : (
                 <IconGrid key={gridKey} icons={filtered} view={viewParam} />
               )}

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo, useCallback, useEffect, useRef } from "react";
+import { useMemo, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
 import { ArrowDownAZ, ArrowDownZA, ArrowUpDown, Grid3X3, LayoutGrid, X } from "lucide-react";
 import type { Collection, IconEntry } from "@/lib/icons";
-import { searchIcons } from "@/lib/search";
+import { loadIconsManifest, prefetchIconsManifest } from "@/lib/icons-manifest";
 import { Sidebar } from "@/components/layout/sidebar";
 import { IconGrid } from "@/components/icons/icon-grid";
 import { HomeHero } from "@/components/home-hero";
@@ -19,7 +19,6 @@ import { useSearchStore } from "@/lib/stores/search-store";
 const SORT_OPTIONS = ["default", "az", "za"] as const;
 
 interface HomeContentProps {
-  icons: IconEntry[];
   categoryCounts: { name: string; count: number }[];
   count: number;
   recentIcons: IconEntry[];
@@ -27,7 +26,7 @@ interface HomeContentProps {
   defaultCollection?: Collection;
 }
 
-export function HomeContent({ icons, categoryCounts, count, recentIcons, collections, defaultCollection }: HomeContentProps) {
+export function HomeContent({ categoryCounts, count, recentIcons, collections, defaultCollection }: HomeContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -47,9 +46,27 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
 
   const query = globalQuery;
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
-  // On collection pages (defaultCollection set), the hero/filtered view logic differs:
-  // show hero when only collection is active (no search/category/sort/favorites)
   const isDefaultView = !query.trim() && !categoryParam && !sortParam && !favoritesParam && (!collectionParam || !!defaultCollection);
+
+  // Lazy-loaded full icons manifest. null = not yet loaded; [] = loading/empty.
+  const [allIcons, setAllIcons] = useState<IconEntry[] | null>(null);
+  const [manifestError, setManifestError] = useState(false);
+
+  // Prefetch the manifest while the hero is shown so it's ready when the user searches.
+  useEffect(() => {
+    if (isDefaultView) {
+      prefetchIconsManifest();
+    }
+  }, [isDefaultView]);
+
+  // Load the manifest when the user leaves the default (hero) view.
+  useEffect(() => {
+    if (!isDefaultView && allIcons === null && !manifestError) {
+      loadIconsManifest()
+        .then((icons) => setAllIcons(icons))
+        .catch(() => setManifestError(true));
+    }
+  }, [isDefaultView, allIcons, manifestError]);
 
   // Sync global store from URL (e.g. shared link)
   useEffect(() => {
@@ -129,15 +146,17 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
     updateUrl({ view: viewParam === "compact" ? null : "compact" });
   }, [updateUrl, viewParam]);
 
-  // Filter icons by collection first, then apply other filters
+  // Filter icons by collection first, then apply other filters.
+  // allIcons is null until manifest is fetched.
   const collectionIcons = useMemo(() => {
-    if (!collectionParam) return icons;
-    return icons.filter((icon) => icon.collection === collectionParam);
-  }, [icons, collectionParam]);
+    if (!allIcons) return null;
+    if (!collectionParam) return allIcons;
+    return allIcons.filter((icon) => icon.collection === collectionParam);
+  }, [allIcons, collectionParam]);
 
   // Compute categories for the active collection
   const activeCategoryCounts = useMemo(() => {
-    if (!collectionParam) return categoryCounts;
+    if (!collectionIcons || !collectionParam) return categoryCounts;
     const counts = new Map<string, number>();
     for (const icon of collectionIcons) {
       for (const c of icon.categories) {
@@ -149,7 +168,13 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [collectionParam, collectionIcons, categoryCounts]);
 
-  const filtered = useMemo(() => {
+  const [filtered, setFiltered] = useState<IconEntry[]>([]);
+  const filterKey = `${query}|${categoryParam ?? ""}|${sortParam ?? ""}|${favoritesParam}|${collectionParam ?? ""}`;
+
+  useEffect(() => {
+    if (!collectionIcons) return;
+
+    let active = true;
     let result = collectionIcons;
 
     // Favorites filter
@@ -166,9 +191,19 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
       );
     }
 
-    // Search
+    // Lazy-load Fuse.js only when there is a search query
     if (query.trim()) {
-      result = searchIcons(result, query);
+      import("@/lib/search").then(({ searchIcons }) => {
+        if (!active) return;
+        let searched = searchIcons(result, query);
+        if (sortParam === "az") {
+          searched = [...searched].sort((a, b) => a.title.localeCompare(b.title));
+        } else if (sortParam === "za") {
+          searched = [...searched].sort((a, b) => b.title.localeCompare(a.title));
+        }
+        setFiltered(searched);
+      });
+      return () => { active = false; };
     }
 
     // Sort
@@ -178,10 +213,19 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
       result = [...result].sort((a, b) => b.title.localeCompare(a.title));
     }
 
-    return result;
-  }, [collectionIcons, query, categoryParam, sortParam, favoritesParam, favorites]);
+    setFiltered(result);
+    return () => { active = false; };
+  // filterKey captures all search/filter/sort deps; collectionIcons and favorites are the data deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionIcons, filterKey, favorites]);
 
-  const activeCount = collectionParam ? collectionIcons.length : count;
+  const activeCount = collectionParam && allIcons
+    ? allIcons.filter((i) => i.collection === collectionParam).length
+    : count;
+
+  // Stable key for IconGrid so it remounts naturally when filters change,
+  // resetting internal visibleCount without a secondary useEffect setState loop.
+  const gridKey = filterKey;
 
   const sidebarContent = (
     <Sidebar
@@ -224,13 +268,12 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
       {/* Main content area */}
       <div className="md:pl-58">
         {isDefaultView ? (
-          /* ── Hero landing ── */
+          /* Hero landing */
           <div className="mx-auto max-w-7xl px-3 py-4 sm:px-4">
             <HomeHero
-              icons={icons}
+              recentIcons={recentIcons}
               categoryCounts={categoryCounts}
               count={count}
-              recentIcons={recentIcons}
               collections={collections}
               defaultCollection={defaultCollection}
               onSelectIcon={() => {}}
@@ -239,14 +282,18 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
             />
           </div>
         ) : (
-          /* ── Filtered view ── */
+          /* Filtered view */
           <>
             {/* Sticky toolbar - count + controls */}
             <div className="sticky top-[3.75rem] z-20 border-b border-border/30 bg-background/95 backdrop-blur-xl">
               <div className="mx-auto flex max-w-7xl items-center gap-1.5 px-3 py-1.5 sm:gap-2 sm:px-4">
                 {/* Count label */}
                 <p className="flex-1 text-sm text-muted-foreground">
-                  {favoritesParam
+                  {manifestError ? (
+                    <span className="text-destructive">Failed to load icons</span>
+                  ) : !allIcons ? (
+                    <span className="animate-pulse">Loading...</span>
+                  ) : favoritesParam
                     ? `${filtered.length} fav${filtered.length !== 1 ? "s" : ""}`
                     : filtered.length === activeCount
                       ? `${activeCount.toLocaleString()}`
@@ -348,7 +395,13 @@ export function HomeContent({ icons, categoryCounts, count, recentIcons, collect
 
             {/* Grid */}
             <div className="mx-auto max-w-7xl px-3 py-2 sm:px-4">
-              <IconGrid icons={filtered} view={viewParam} />
+              {manifestError ? (
+                <p className="py-24 text-center text-sm text-muted-foreground">
+                  Failed to load icons. Please refresh and try again.
+                </p>
+              ) : (
+                <IconGrid key={gridKey} icons={filtered} view={viewParam} />
+              )}
             </div>
           </>
         )}

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Anchor, ArrowRight, Clock, Cloud, Package, Shapes, Sparkles, Zap } from "lucide-react";
 import Link from "next/link";
 import type { Collection, IconEntry } from "@/lib/icons";
+import { loadIconsManifest } from "@/lib/icons-manifest";
 import { IconCard } from "@/components/icons/icon-card";
 import { IconGrid } from "@/components/icons/icon-grid";
 import { IconDetail } from "@/components/icons/icon-detail";
@@ -232,7 +233,6 @@ const ALL_SLIDES = [
 const SLIDE_DURATION = 6000;
 
 interface HomeHeroProps {
-  icons: IconEntry[];
   categoryCounts: { name: string; count: number }[];
   count: number;
   recentIcons: IconEntry[];
@@ -244,7 +244,6 @@ interface HomeHeroProps {
 }
 
 export function HomeHero({
-  icons,
   categoryCounts: _categoryCounts,
   count,
   recentIcons,
@@ -253,6 +252,17 @@ export function HomeHero({
   onCategorySelect,
   onCollectionSelect,
 }: HomeHeroProps) {
+  // Lazy-load the full icons manifest for decorative elements (floating icons,
+  // popular grids, category rows). The hero carousel content renders immediately;
+  // icons appear progressively as the manifest loads.
+  const [icons, setIcons] = useState<IconEntry[]>([]);
+  useEffect(() => {
+    loadIconsManifest()
+      .then(setIcons)
+      .catch(() => {
+        // Decorative elements are non-critical; silently ignore load failures
+      });
+  }, []);
   const [currentSlide, setCurrentSlide] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const [selectedIcon, setSelectedIcon] = useState<IconEntry | null>(null);
@@ -482,7 +492,7 @@ export function HomeHero({
 
       {/* Collection tabs */}
       {collections.length > 1 && (
-        <div className="flex items-center gap-1.5" role="tablist" aria-label="Icon collections">
+        <div className="flex flex-wrap items-center gap-1.5" role="tablist" aria-label="Icon collections">
           {collections.map((col) => {
             const info = COLLECTION_LABELS[col.name];
             const isActive = activeCollection === col.name;
@@ -493,7 +503,7 @@ export function HomeHero({
                 role="tab"
                 aria-selected={isActive}
                 onClick={() => setActiveCollection(col.name)}
-                className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:gap-2 sm:px-4 sm:py-2 sm:text-sm ${
                   isActive
                     ? "bg-foreground text-background shadow-sm"
                     : "text-muted-foreground hover:bg-accent hover:text-foreground dark:hover:bg-white/[0.06]"

--- a/src/components/icons/icon-card.tsx
+++ b/src/components/icons/icon-card.tsx
@@ -116,7 +116,9 @@ export const IconCard = memo(function IconCard({
       <article
         className="group relative flex w-full min-w-0 flex-col items-center gap-1.5 overflow-hidden rounded-xl border border-border/40 bg-card/80 p-3 transition-all duration-200 hover:border-border hover:bg-card hover:shadow-md"
         onMouseEnter={handleHoverPrefetch}
+        onTouchStart={handleHoverPrefetch}
         onFocus={handleHoverPrefetch}
+        style={{ contentVisibility: "auto", containIntrinsicSize: "0 120px" }}
       >
         <button
           type="button"
@@ -161,7 +163,9 @@ export const IconCard = memo(function IconCard({
     <article
       className="group relative flex h-full min-w-0 flex-col items-center rounded-xl border border-border/40 bg-card/80 transition-all duration-200 hover:border-border hover:bg-card hover:shadow-lg hover:shadow-black/5 dark:hover:shadow-black/20"
       onMouseEnter={handleHoverPrefetch}
+      onTouchStart={handleHoverPrefetch}
       onFocus={handleHoverPrefetch}
+      style={{ contentVisibility: "auto", containIntrinsicSize: "0 180px" }}
     >
       {/* Favorite toggle */}
       <button

--- a/src/components/icons/icon-grid.tsx
+++ b/src/components/icons/icon-grid.tsx
@@ -29,23 +29,21 @@ export function IconGrid({ icons, view = "comfortable" }: IconGridProps) {
 
   const hasMore = visibleCount < icons.length;
 
-  // Reset visible count when icons list changes (new search/filter)
-  useEffect(() => {
-    setVisibleCount(INITIAL_COUNT);
-  }, [icons]);
-
-  // Intersection observer for infinite scroll
+  // Intersection observer for infinite scroll.
+  // The parent passes a stable `key` derived from the active query+category so
+  // React remounts this component with fresh state when filters change — no
+  // secondary setState loop is needed to reset visibleCount.
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
+    const total = icons.length;
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0].isIntersecting && !loadingRef.current) {
           loadingRef.current = true;
           setVisibleCount((prev) => {
-            const next = Math.min(prev + LOAD_MORE_COUNT, icons.length);
-            // Release lock after a short delay to prevent burst loading
+            const next = Math.min(prev + LOAD_MORE_COUNT, total);
             setTimeout(() => { loadingRef.current = false; }, 200);
             return next;
           });
@@ -56,6 +54,8 @@ export function IconGrid({ icons, view = "comfortable" }: IconGridProps) {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
+    // icons.length is the only sentinel-rebuild trigger; visibleCount changes
+    // are handled inside the callback via closure over `total`.
   }, [icons.length]);
 
   const handleSelect = useCallback((icon: IconEntry) => {

--- a/src/lib/icons-manifest.ts
+++ b/src/lib/icons-manifest.ts
@@ -1,0 +1,47 @@
+/**
+ * Client-side lazy loader for the full icons manifest.
+ *
+ * Instead of serializing the 2.5 MB icons array into the initial HTML payload,
+ * the server passes only lightweight props (recentIcons, categoryCounts, collections).
+ * The full manifest is fetched from /api/icons-full.json only when the user
+ * searches or filters (i.e., leaves the hero/default view).
+ */
+
+import type { IconEntry } from "@/lib/icons";
+
+let cachedIcons: IconEntry[] | null = null;
+let fetchPromise: Promise<IconEntry[]> | null = null;
+
+export async function loadIconsManifest(): Promise<IconEntry[]> {
+  if (cachedIcons) return cachedIcons;
+
+  if (!fetchPromise) {
+    fetchPromise = fetch("/api/icons-full.json")
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load icons manifest: ${res.status}`);
+        return res.json() as Promise<IconEntry[]>;
+      })
+      .then((data) => {
+        cachedIcons = data;
+        return data;
+      })
+      .catch((err) => {
+        // Reset so next attempt can retry
+        fetchPromise = null;
+        throw err;
+      });
+  }
+
+  return fetchPromise;
+}
+
+/**
+ * Prefetch the manifest without blocking. Call this to warm the cache
+ * when idle (e.g. after the hero renders).
+ */
+export function prefetchIconsManifest(): void {
+  if (cachedIcons || fetchPromise) return;
+  loadIconsManifest().catch(() => {
+    // Silently ignore prefetch failures
+  });
+}

--- a/src/lib/icons-manifest.ts
+++ b/src/lib/icons-manifest.ts
@@ -12,15 +12,27 @@ import type { IconEntry } from "@/lib/icons";
 let cachedIcons: IconEntry[] | null = null;
 let fetchPromise: Promise<IconEntry[]> | null = null;
 
+async function fetchManifest(): Promise<IconEntry[]> {
+  const res = await fetch("/api/icons-full.json");
+  if (res.ok) {
+    return res.json() as Promise<IconEntry[]>;
+  }
+
+  // Dev fallback: `pnpm dev` doesn't run generate-api.ts, so /api/icons-full.json
+  // may 404. Fall back to the source-of-truth manifest at build-time only.
+  if (process.env.NODE_ENV !== "production") {
+    const mod = await import("@/data/icons.json");
+    return mod.default as IconEntry[];
+  }
+
+  throw new Error(`Failed to load icons manifest: ${res.status}`);
+}
+
 export async function loadIconsManifest(): Promise<IconEntry[]> {
   if (cachedIcons) return cachedIcons;
 
   if (!fetchPromise) {
-    fetchPromise = fetch("/api/icons-full.json")
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to load icons manifest: ${res.status}`);
-        return res.json() as Promise<IconEntry[]>;
-      })
+    fetchPromise = fetchManifest()
       .then((data) => {
         cachedIcons = data;
         return data;

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -2,21 +2,22 @@ import Fuse from "fuse.js";
 import type { IconEntry } from "./icons";
 
 let fuseInstance: Fuse<IconEntry> | null = null;
+let cachedIcons: IconEntry[] | null = null;
 
 export function getSearchIndex(icons: IconEntry[]): Fuse<IconEntry> {
-  if (!fuseInstance) {
-    fuseInstance = new Fuse(icons, {
-      keys: [
-        { name: "title", weight: 3 },
-        { name: "slug", weight: 2 },
-        { name: "aliases", weight: 1.5 },
-        { name: "categories", weight: 1 },
-      ],
-      threshold: 0.3,
-      includeScore: true,
-      minMatchCharLength: 2,
-    });
-  }
+  if (fuseInstance && cachedIcons === icons) return fuseInstance;
+  fuseInstance = new Fuse(icons, {
+    keys: [
+      { name: "title", weight: 3 },
+      { name: "slug", weight: 2 },
+      { name: "aliases", weight: 1.5 },
+      { name: "categories", weight: 1 },
+    ],
+    threshold: 0.3,
+    includeScore: true,
+    minMatchCharLength: 2,
+  });
+  cachedIcons = icons;
   return fuseInstance;
 }
 

--- a/src/scripts/generate-api.ts
+++ b/src/scripts/generate-api.ts
@@ -7,13 +7,14 @@
  * Outputs:
  *   public/api/registry.json      - all icons (slug, title, aliases, categories, hex, url, variant keys)
  *   public/api/categories.json    - category list with counts
+ *   public/api/icons-full.json    - full icon manifest (all fields) for client-side lazy loading
  *
  * Note: Individual per-icon detail files are NOT generated to stay within
  * Cloudflare Pages' 20,000 file deployment limit. Extensions should fetch
  * SVG content directly from /icons/{slug}/{variant}.svg.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, copyFileSync } from "fs";
 import { join } from "path";
 
 const ROOT = join(__dirname, "../..");
@@ -77,6 +78,13 @@ function main() {
     JSON.stringify({ categories }),
   );
   console.log(`  categories.json: ${categories.length} categories`);
+
+  // --- icons-full.json (full manifest for client-side lazy loading) ---
+  // Copied verbatim so the client can fetch it on demand instead of receiving
+  // the entire 2.5 MB array serialized into the initial HTML payload.
+  copyFileSync(ICONS_JSON, join(PUBLIC_API, "icons-full.json"));
+  console.log(`  icons-full.json: ${icons.length} icons (full manifest)`);
+
   console.log("API generation complete.");
 }
 


### PR DESCRIPTION
## Summary

- **Smaller initial payload**: The 2.5 MB `icons.json` is no longer serialized into the page HTML. The server now passes only lightweight props (12 recent icons, category counts, collection counts). The full manifest is served from `/api/icons-full.json` (generated at build time) and fetched lazily by the client only when the user searches, filters, or leaves the hero view.
- **Fuse.js bundle savings**: `searchIcons` and Fuse.js are dynamically imported (`import('@/lib/search')`) in `HomeContent`, `HomeHero`, and `Header`. Pre-search they are dead weight; now they load on first keystroke.
- **Faster scroll on large grids**: Both `comfortable` and `compact` `IconCard` variants now carry `content-visibility: auto` with `containIntrinsicSize`, letting the browser skip layout and paint for off-screen cards.
- **No jank on search**: Removed the `useEffect(() => setVisibleCount(INITIAL_COUNT), [icons])` loop in `IconGrid`. The parent now passes a stable `key={filterKey}` so React remounts the grid with fresh state naturally, eliminating a cascading render on every keystroke. `IntersectionObserver` rebuilds only when `icons.length` changes, not every render.
- **Mobile 375px fixes**: Collection tab chips in `HomeHero` now use `flex-wrap` and scale down (`px-3 py-1.5 text-xs` on xs, `px-4 py-2 text-sm` on sm+) to prevent overflow on narrow viewports.

## Validation

```
npx tsc --noEmit     # clean
pnpm lint            # 0 errors, 16 pre-existing warnings (unchanged count)
pnpm build           # succeeds, 5684 static pages generated
```

Build output confirms `icons-full.json` generation:
```
registry.json: 5658 icons
categories.json: 105 categories
icons-full.json: 5658 icons (full manifest)
```

Refs #116