### PR TITLE
feat: per-icon OG images, fix sitemap, refresh default OG card

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,6 +6,29 @@ export const metadata: Metadata = {
   title: "Contact",
   description:
     "Get in touch with the thesvg team. Report issues, request icon removal, or ask questions.",
+  openGraph: {
+    title: "Contact | theSVG",
+    description:
+      "Get in touch with the thesvg team. Report issues, request icon removal, or ask questions.",
+    url: "https://thesvg.org/contact",
+    siteName: "theSVG",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "theSVG - The Open SVG Brand Library",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Contact | theSVG",
+    description:
+      "Get in touch with the thesvg team. Report issues, request icon removal, or ask questions.",
+    images: ["/og-image.png"],
+  },
+  alternates: { canonical: "https://thesvg.org/contact" },
 };
 
 const CONTACT_CHANNELS = [

--- a/src/app/icon/[slug]/opengraph-image.tsx
+++ b/src/app/icon/[slug]/opengraph-image.tsx
@@ -3,6 +3,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getAllIcons, getIconBySlug } from "@/lib/icons";
 
+// Pin to Node.js runtime so node:fs/promises and node:path are available.
+// Edge runtime would crash for any slug not in generateStaticParams (e.g., a
+// social crawler hitting a path that wasn't pre-rendered).
+export const runtime = "nodejs";
+
 export const alt = "Brand SVG icon on thesvg.org";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
@@ -17,14 +22,36 @@ export async function generateStaticParams() {
 }
 
 /**
+ * Normalize an icons.json `hex` value to a 6-digit form suitable for parsing.
+ * Accepts 3 or 6 digit hex (with or without leading #), strips alpha if present.
+ * Returns null when the input is unparseable.
+ */
+function normalizeHex(raw: string): string | null {
+  const stripped = raw.replace(/^#/, "");
+  if (/^[0-9a-fA-F]{3}$/.test(stripped)) {
+    // Expand 3-digit to 6-digit (#abc -> #aabbcc)
+    return stripped.split("").map((c) => c + c).join("");
+  }
+  if (/^[0-9a-fA-F]{6}$/.test(stripped)) {
+    return stripped;
+  }
+  if (/^[0-9a-fA-F]{8}$/.test(stripped)) {
+    // Drop alpha channel
+    return stripped.substring(0, 6);
+  }
+  return null;
+}
+
+/**
  * Returns true when the hex color is light enough that white text / white icon
  * would be hard to read. We switch to a dark-on-light layout in that case.
+ * Uses raw sRGB values weighted by BT.709 coefficients - close enough for an
+ * OG image; full gamma correction is unnecessary at this fidelity.
  */
 function isLightHex(hex: string): boolean {
   const r = parseInt(hex.substring(0, 2), 16);
   const g = parseInt(hex.substring(2, 4), 16);
   const b = parseInt(hex.substring(4, 6), 16);
-  // Perceived luminance (ITU-R BT.709)
   const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
   return luminance > 180;
 }
@@ -74,7 +101,9 @@ export default async function Image({ params }: ImageProps) {
   const icon = getIconBySlug(slug);
 
   const title = icon?.title ?? slug;
-  const rawHex = (icon?.hex ?? "1a1a2e").replace("#", "");
+  // Normalize to 6-digit hex; fall back to a neutral dark slate when the
+  // entry has an empty, missing, or malformed hex (e.g., 3-digit, alpha).
+  const rawHex = normalizeHex(icon?.hex ?? "") ?? "1a1a2e";
   const brandColor = `#${rawHex}`;
 
   const light = isLightHex(rawHex);

--- a/src/app/icon/[slug]/opengraph-image.tsx
+++ b/src/app/icon/[slug]/opengraph-image.tsx
@@ -1,0 +1,211 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getAllIcons, getIconBySlug } from "@/lib/icons";
+
+export const alt = "Brand SVG icon on thesvg.org";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+interface ImageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  const icons = getAllIcons();
+  return icons.map((icon) => ({ slug: icon.slug }));
+}
+
+/**
+ * Returns true when the hex color is light enough that white text / white icon
+ * would be hard to read. We switch to a dark-on-light layout in that case.
+ */
+function isLightHex(hex: string): boolean {
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  // Perceived luminance (ITU-R BT.709)
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance > 180;
+}
+
+/**
+ * Ensures an SVG string has a viewBox attribute so ImageResponse can render it.
+ * If viewBox is missing but width/height are present, derives viewBox from them.
+ * Returns null if the SVG cannot be made renderable.
+ */
+function ensureViewBox(svgContent: string): string | null {
+  // Already has viewBox - good to go
+  if (/viewBox\s*=/i.test(svgContent)) {
+    return svgContent;
+  }
+
+  // Try to derive viewBox from width and height attributes
+  const widthMatch = svgContent.match(/\bwidth\s*=\s*["']?([\d.]+)/i);
+  const heightMatch = svgContent.match(/\bheight\s*=\s*["']?([\d.]+)/i);
+
+  if (widthMatch && heightMatch) {
+    const w = widthMatch[1];
+    const h = heightMatch[1];
+    // Insert viewBox after the opening <svg tag
+    return svgContent.replace(/<svg\b/, `<svg viewBox="0 0 ${w} ${h}"`);
+  }
+
+  // Cannot make renderable
+  return null;
+}
+
+/**
+ * Tries to load the default SVG for a given slug from the filesystem.
+ * Returns the raw SVG string or null if not found / not renderable.
+ */
+async function loadSvg(slug: string): Promise<string | null> {
+  try {
+    const svgPath = join(process.cwd(), "public", "icons", slug, "default.svg");
+    const raw = await readFile(svgPath, "utf-8");
+    return ensureViewBox(raw);
+  } catch {
+    return null;
+  }
+}
+
+export default async function Image({ params }: ImageProps) {
+  const { slug } = await params;
+  const icon = getIconBySlug(slug);
+
+  const title = icon?.title ?? slug;
+  const rawHex = (icon?.hex ?? "1a1a2e").replace("#", "");
+  const brandColor = `#${rawHex}`;
+
+  const light = isLightHex(rawHex);
+
+  // Background: use brand color if dark enough, otherwise a neutral dark slate
+  const bgColor = light ? "#0f0f1a" : brandColor;
+  const textColor = "#ffffff";
+  const subtleColor = "rgba(255,255,255,0.45)";
+
+  // Derive a muted version of the brand color for the card glow
+  const glowColor = light ? brandColor : `${brandColor}33`;
+
+  const svgContent = await loadSvg(slug);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          background: bgColor,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* Radial glow behind icon */}
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "400px",
+            height: "400px",
+            borderRadius: "50%",
+            background: `radial-gradient(circle, ${glowColor} 0%, transparent 70%)`,
+            display: "flex",
+          }}
+        />
+
+        {/* Icon area */}
+        <div
+          style={{
+            width: "180px",
+            height: "180px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            marginBottom: "32px",
+            position: "relative",
+          }}
+        >
+          {svgContent ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={`data:image/svg+xml;base64,${Buffer.from(svgContent).toString("base64")}`}
+              width={160}
+              height={160}
+              alt={title}
+              style={{ objectFit: "contain" }}
+            />
+          ) : (
+            <div
+              style={{
+                width: "160px",
+                height: "160px",
+                borderRadius: "24px",
+                background: "rgba(255,255,255,0.1)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: "64px",
+                color: textColor,
+              }}
+            >
+              {title.charAt(0)}
+            </div>
+          )}
+        </div>
+
+        {/* Brand title */}
+        <div
+          style={{
+            fontSize: "52px",
+            fontWeight: 700,
+            color: textColor,
+            letterSpacing: "-1px",
+            textAlign: "center",
+            maxWidth: "800px",
+            lineHeight: 1.1,
+            marginBottom: "12px",
+            display: "flex",
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: "24px",
+            color: subtleColor,
+            display: "flex",
+          }}
+        >
+          Free SVG icon on thesvg.org
+        </div>
+
+        {/* thesvg.org wordmark - bottom right */}
+        <div
+          style={{
+            position: "absolute",
+            bottom: "32px",
+            right: "44px",
+            fontSize: "20px",
+            fontWeight: 600,
+            color: "rgba(255,255,255,0.35)",
+            letterSpacing: "0.5px",
+            display: "flex",
+          }}
+        >
+          thesvg.org
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/icon/[slug]/page.tsx
+++ b/src/app/icon/[slug]/page.tsx
@@ -78,20 +78,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       url: `https://thesvg.org/icon/${slug}`,
       type: "website",
       siteName: "theSVG",
-      images: [
-        {
-          url: "/og-image.png",
-          width: 1200,
-          height: 630,
-          alt: `${icon.title} SVG Icon - theSVG`,
-        },
-      ],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: ["/og-image.png"],
     },
     alternates: {
       canonical: `https://thesvg.org/icon/${slug}`,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,6 +9,17 @@ export default function robots(): MetadataRoute.Robots {
         userAgent: "*",
         allow: "/",
       },
+      // Explicit allow for AI crawlers to find the machine-readable index at /llms.txt
+      {
+        userAgent: [
+          "GPTBot",
+          "Claude-Web",
+          "Amazonbot",
+          "PerplexityBot",
+          "anthropic-ai",
+        ],
+        allow: ["/", "/llms.txt"],
+      },
     ],
     sitemap: "https://thesvg.org/sitemap.xml",
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { getAllIcons, getAllCategories } from "@/lib/icons";
+import { getAllIcons } from "@/lib/icons";
 import postsData from "@/data/posts.json";
 
 export const dynamic = "force-static";
@@ -9,10 +9,10 @@ const CDN_BASE =
   "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 
 // Next.js will generate /sitemap/0.xml, /sitemap/1.xml, etc.
-// Sitemaps: 0=static+categories, 1=brands, 2=aws, 3=azure, 4=gcp
+// Sitemaps: 0=static pages, 1=brands, 2=aws, 3=azure, 4=gcp
 export async function generateSitemaps() {
   return [
-    { id: 0 }, // static pages + categories
+    { id: 0 }, // static pages
     { id: 1 }, // brand icons
     { id: 2 }, // aws icons
     { id: 3 }, // azure icons
@@ -23,10 +23,10 @@ export async function generateSitemaps() {
 export default function sitemap({ id }: { id: number }): MetadataRoute.Sitemap {
   const now = new Date();
   const icons = getAllIcons();
-  const categories = getAllCategories();
 
   if (id === 0) {
-    // Static pages + category pages
+    // Static pages only - category ?category=foo querystrings are omitted
+    // as they are duplicate content of / from a search engine perspective.
     const staticPages: MetadataRoute.Sitemap = [
       { url: BASE_URL, lastModified: now, changeFrequency: "daily", priority: 1.0 },
       { url: `${BASE_URL}/categories`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
@@ -47,13 +47,6 @@ export default function sitemap({ id }: { id: number }): MetadataRoute.Sitemap {
       priority: 0.7,
     }));
 
-    const categoryPages: MetadataRoute.Sitemap = categories.map((cat) => ({
-      url: `${BASE_URL}/?category=${encodeURIComponent(cat)}`,
-      lastModified: now,
-      changeFrequency: "weekly" as const,
-      priority: 0.7,
-    }));
-
     // Collection landing pages (proper URL paths for indexing)
     const collectionPages: MetadataRoute.Sitemap = [
       { url: `${BASE_URL}/collection/brands`, lastModified: now, changeFrequency: "weekly" as const, priority: 0.9 },
@@ -62,7 +55,7 @@ export default function sitemap({ id }: { id: number }): MetadataRoute.Sitemap {
       { url: `${BASE_URL}/collection/gcp`, lastModified: now, changeFrequency: "monthly" as const, priority: 0.9 },
     ];
 
-    return [...staticPages, ...collectionPages, ...categoryPages, ...blogPages];
+    return [...staticPages, ...collectionPages, ...blogPages];
   }
 
   // Map id to collection


### PR DESCRIPTION
## Summary

- **Per-icon OG images**: Added `src/app/icon/[slug]/opengraph-image.tsx` using Next.js 15's `ImageResponse` API. Generates a 1200x630 PNG per icon at build time (SSG). The card renders the brand SVG centered on a brand-color background with the icon title and "thesvg.org" wordmark. When the brand color is too light, the background falls back to a dark neutral slate to keep text legible. SVGs without `viewBox` are patched from `width`/`height` attributes where possible; otherwise a letter tile is used as fallback.
- **OG image refresh**: Replaced `public/og-image.png` with the updated 1.87 MB card. Updated stale alt text (`3,847 Brand SVG Icons`) in packages/thesvg, react, cli, and mcp READMEs to `5,600+ brand SVG icons`.
- **Sitemap fix**: Removed `?category=foo` querystring URLs from sitemap (they are duplicate content of `/`). Cleaned up the unused `getAllCategories` import.
- **Contact page OG**: Added canonical URL, openGraph, and Twitter card metadata to `/contact` to match the pattern used by all other static pages.
- **robots.txt / llms.txt**: Added explicit `Allow: ["/", "/llms.txt"]` rules for known AI crawlers (GPTBot, Claude-Web, Amazonbot, PerplexityBot, anthropic-ai) so they can discover the machine-readable library index.

## Generated OG image examples

After merging, the following routes will serve brand-specific OG PNGs:

- `/icon/openai/opengraph-image`
- `/icon/github/opengraph-image`
- `/icon/stripe/opengraph-image`

All 5,658 icons have a generated route (visible in build output: `● /icon/[slug]/opengraph-image` with 5,658 paths).

## Validation

- `npx tsc --noEmit` passes with 0 errors.
- `pnpm lint` passes with 0 errors (pre-existing warnings only).
- `pnpm build` succeeds and SSG-renders all 5,658 per-icon OG images.

Refs #116