### PR TITLE
ci: deploy thesvg.org to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,74 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "20"
+
+jobs:
+  build:
+    name: Build static export
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.[jt]s', '**/*.[jt]sx', '!**/node_modules/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Build (next export -> out/)
+        run: pnpm build
+
+      - name: Disable Jekyll on Pages
+        run: touch out/.nojekyll
+
+      - name: Report build size
+        run: |
+          echo "Total files: $(find out -type f | wc -l)"
+          echo "Total size:  $(du -sh out | cut -f1)"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+thesvg.org


### PR DESCRIPTION
## Summary
Move thesvg.org off Cloudflare Pages (file-count cap blocked yesterday's deploy) onto **GitHub Pages**. Free, no file-count anxiety at our current scale.

## What's in this PR
- `.github/workflows/pages.yml` — builds `out/` via `pnpm build` and publishes via `actions/deploy-pages@v4`. Caches `.next/cache` between runs for fast repeat builds. Touches `.nojekyll` so Pages keeps `_next/static/` paths intact.
- `public/CNAME` containing `thesvg.org` so the custom domain pins on first deploy.

## After merge — admin steps (web UI, can't be done in code)

1. **Settings → Pages → Source: GitHub Actions** (default is "Deploy from a branch", must change once)
2. Wait for first deploy to go green — site appears at `glincker.github.io/thesvg`
3. **Settings → Pages → Custom domain: `thesvg.org`** (CNAME file pre-creates this; just confirm)
4. **DNS flip** (when ready):
   - Replace existing apex A records on Cloudflare with GitHub's:
     ```
     A    @   185.199.108.153
     A    @   185.199.109.153
     A    @   185.199.110.153
     A    @   185.199.111.153
     ```
   - Keep Cloudflare proxy **off** (grey cloud) until cert provisions
   - **Settings → Pages → Enforce HTTPS** once cert is ready (10-60 min)
   - Flip Cloudflare proxy back on (orange cloud) for free CDN cache
5. Done

## Hard caps to watch

| Limit | Value | Status |
|---|---|---|
| Site size | 1 GB | report in build log; should be ~300-500 MB |
| Bandwidth | 100 GB / month soft | Cloudflare proxy in front absorbs most |
| File count | effectively unlimited on Pages | unlike Cloudflare Pages' 20k cap |
| Build time | 10 min per run | currently ~3-5 min |
| Deploy frequency | 10 / hour | squash-merge keeps this low |

## Test plan
- [ ] Workflow run completes; "Total files" + "Total size" reported in log
- [ ] First deploy lands at `https://glincker.github.io/thesvg/` (or pre-pinned `thesvg.org` once CNAME applies)
- [ ] `_next/static/*` assets load with 200 (Jekyll-not-stripping check)
- [ ] Icon pages render at `/icon/<slug>/`
- [ ] OG images and sitemap accessible
- [ ] Cloudflare proxy can be re-enabled in front after DNS flip without breaking SSL

Cut-over playbook lives in `docs-local/github-pages-cutover.md` (gitignored).