### PR TITLE
ci: path-filter the build, add labeler + dependabot + auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "@typescript-eslint/*"
+      changesets:
+        patterns:
+          - "@changesets/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tw-animate-css"
+      development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-patch:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci/cd"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,55 @@
+# Auto-label PRs by which paths changed.
+# Consumed by .github/workflows/labeler.yml using actions/labeler@v5.
+
+icons:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "public/icons/**"
+          - "src/data/icons.json"
+
+ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/components/**"
+          - "src/app/**"
+          - "src/styles/**"
+          - "src/lib/**"
+          - "src/hooks/**"
+          - "*.css"
+
+ci/cd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/scripts/**"
+          - ".github/labeler.yml"
+          - ".github/dependabot.yml"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs-local/**"
+
+packages:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "packages/**"
+          - "extensions/vscode/**"
+          - "extensions/raycast/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "pnpm-lock.yaml"
+          - "packages/**/package.json"
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "next.config.*"
+          - "tsconfig.json"
+          - "tailwind.config.*"
+          - "postcss.config.*"
+          - "eslint.config.*"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,15 @@ name: Check
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs-local/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/labeler.yml"
+      - ".github/dependabot.yml"
+      - "LICENSE"
+      - "TRADEMARK.md"
+      - "LEGAL.md"
 
 concurrency:
   group: check-${{ github.head_ref }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,53 @@
+name: Dependabot auto-merge
+
+# Auto-enables GitHub's native auto-merge on safe Dependabot PRs so they
+# merge themselves once CI passes. The human only sees major bumps and
+# production minor bumps.
+#
+# Safe means:
+#   - Any patch update (both runtime and dev dependencies)
+#   - Any minor update on a dev-only dependency
+#   - GitHub Actions bumps of any size (low blast radius, mostly version
+#     pinning)
+#
+# Anything else stays open for manual review with a "needs-review" label.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && !github.event.pull_request.draft
+    steps:
+      - name: Fetch dependency metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge on safe updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:development') ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label majors and production minors for manual review
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-major' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:production')
+        run: |
+          gh pr edit "$PR_URL" --add-label "needs-review"
+          gh pr comment "$PR_URL" --body "This update crosses a boundary that needs human review (major bump, or minor bump on a production dependency). Not auto-merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -35,7 +35,8 @@ jobs:
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:development') ||
-          steps.meta.outputs.package-ecosystem == 'github_actions'
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          steps.meta.outputs.package-ecosystem == 'github-actions'
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,23 @@
+name: Auto-label PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply path-based labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,18 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs-local/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/labeler.yml"
+      - ".github/dependabot.yml"
+      - ".github/workflows/triage-icon-issue.yml"
+      - ".github/workflows/labeler.yml"
+      - ".github/workflows/dependabot-auto-merge.yml"
+      - "LICENSE"
+      - "TRADEMARK.md"
+      - "LEGAL.md"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <strong>5,600+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
+  <strong>5,880+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-5%2C600%2B-F97316?style=flat-square" alt="5,600+ icons" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-5%2C880%2B-F97316?style=flat-square" alt="5,880+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/visual-studio-marketplace/v/glincker.thesvg?style=flat-square&color=007ACC&label=VS%20Code&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
@@ -37,7 +37,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,600+ SVG icons for developers" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ SVG icons for developers" width="720" />
   </a>
 </p>
 
@@ -47,7 +47,7 @@
 
 Most icon libraries focus on UI icons. Brand logos are scattered across press kits, Figma files, and random GitHub repos. **theSVG** is the single source for SVG icons - brand logos, cloud architecture diagrams, and more. Searchable, versioned, and available as npm packages, CDN, CLI, API, and MCP server.
 
-- **5,600+ icons** across multiple collections
+- **5,880+ icons** across multiple collections
 - **4,019 brand icons** across 55+ categories
 - **739 AWS Architecture icons** (2026-Q1)
 - **626 Azure Service icons** (2026-Q1)
@@ -112,7 +112,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 
 | Extension | Status | Description |
 |-----------|--------|-------------|
-| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 5,600+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
+| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 5,880+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -1,6 +1,6 @@
 # theSVG for Raycast
 
-Search, preview, and copy 5,600+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
+Search, preview, and copy 5,880+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
 
 ## Commands
 
@@ -34,7 +34,7 @@ Example: `Copy Brand Icon` > `github` copies the GitHub SVG to your clipboard.
 
 ## Features
 
-- Search 5,600+ brand icons with alias matching
+- Search 5,880+ brand icons with alias matching
 - Filter by 100+ categories (AI, Design, DevTool, Cloud, etc.)
 - Preview icon thumbnails in the list
 - View all available variants (up to 7 per icon)

--- a/extensions/raycast/package.json
+++ b/extensions/raycast/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "thesvg",
   "title": "TheSVG",
-  "description": "Search, preview, and copy 5,600+ brand SVG icons from thesvg.org",
+  "description": "Search, preview, and copy 5,880+ brand SVG icons from thesvg.org",
   "icon": "extension-icon.png",
   "author": "thegdsks",
   "categories": ["Design Tools", "Developer Tools"],
@@ -12,7 +12,7 @@
       "name": "search-icons",
       "title": "Search Brand Icons",
       "subtitle": "theSVG",
-      "description": "Search 5,600+ brand SVG icons. Copy SVG, download, or open in browser.",
+      "description": "Search 5,880+ brand SVG icons. Copy SVG, download, or open in browser.",
       "mode": "view"
     },
     {

--- a/extensions/raycast/src/search-icons.tsx
+++ b/extensions/raycast/src/search-icons.tsx
@@ -46,7 +46,7 @@ export default function SearchIcons() {
       isLoading={isLoading}
       searchText={searchText}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search 5,600+ brand icons..."
+      searchBarPlaceholder="Search 5,880+ brand icons..."
       filtering={false}
       searchBarAccessory={
         <List.Dropdown

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,10 +1,10 @@
 # theSVG for VS Code
 
-Search and copy 5,650+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
+Search and copy 5,880+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
 
 ## Features
 
-- **Search** across 5,650+ icons from the command palette
+- **Search** across 5,880+ icons from the command palette
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
-  "description": "Search and copy 5,650+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
+  "description": "Search and copy 5,880+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
   "version": "0.1.3",
   "publisher": "glincker",
   "license": "MIT",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,600+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,600+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,600+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,600+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -12,7 +12,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Browse All Categories",
   description:
-    "Explore all icon categories on theSVG. Browse 5,600+ brand, AWS, Azure, and GCP SVG icons organized by category.",
+    "Explore all icon categories on theSVG. Browse 5,880+ brand, AWS, Azure, and GCP SVG icons organized by category.",
   keywords: [
     "SVG icon categories",
     "brand icon categories",

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -81,7 +81,7 @@ const LIBRARIES: LibInfo[] = [
   {
     name: "theSVG",
     url: "https://thesvg.org",
-    icons: "5,600+",
+    icons: "5,880+",
     focus: "Brand logos + Cloud icons",
     desc: "Largest brand SVG library with multi-variant support (light/dark/wordmark/mono). Includes AWS, Azure, and GCP cloud icons. Full toolchain: npm, React/Vue/Svelte, CLI, API, MCP server.",
     highlight: true,

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -20,7 +20,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Extensions & Integrations - VS Code, Figma, React, CLI",
   description:
-    "Use 5,600+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
+    "Use 5,880+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
   keywords: [
     "SVG icon VS Code extension",
     "SVG icon Figma plugin",

--- a/src/app/icon/[slug]/opengraph-image.tsx
+++ b/src/app/icon/[slug]/opengraph-image.tsx
@@ -88,7 +88,16 @@ function ensureViewBox(svgContent: string): string | null {
  */
 async function loadSvg(slug: string): Promise<string | null> {
   try {
-    const svgPath = join(process.cwd(), "public", "icons", slug, "default.svg");
+    // Build the path at runtime via array reduction so Turbopack's static
+    // analyzer doesn't treat `public/icons/{slug}/default.svg` as a glob
+    // pattern matching every icon SVG (~12k files) at build time. The
+    // concatenation result is identical, but the bundler can't trace it.
+    const segments: string[] = [];
+    segments.push("public");
+    segments.push("icons");
+    segments.push(slug);
+    segments.push("default.svg");
+    const svgPath = segments.reduce((acc, part) => join(acc, part), process.cwd());
     const raw = await readFile(svgPath, "utf-8");
     return ensureViewBox(raw);
   } catch {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
         This icon might have been moved, renamed, or doesn&apos;t exist yet.
       </p>
       <p className="mb-8 max-w-md text-xs text-muted-foreground/60">
-        We have 5,600+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
+        We have 5,880+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
       </p>
 
       {/* Actions */}

--- a/src/components/help-fab.tsx
+++ b/src/components/help-fab.tsx
@@ -28,7 +28,7 @@ const TIPS = [
   {
     icon: Search,
     title: "Search everything",
-    description: "Press Cmd+K to search across 5,600+ icons",
+    description: "Press Cmd+K to search across 5,880+ icons",
     gradient: "from-orange-500 to-amber-500",
     glow: "shadow-orange-500/25",
   },

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -88,7 +88,7 @@ const ALL_SLIDES = [
   {
     badge: "Open Source",
     badgeIcon: Sparkles,
-    title: "5,600+ SVG Icons. Search. Copy. Ship.",
+    title: "5,880+ SVG Icons. Search. Copy. Ship.",
     description: "Search, copy, and ship brand icons in seconds. Free, open-source, and community-driven.",
     cta: { label: "Get Started", href: "/extensions" },
     ctaSecondary: { label: "Submit an Icon", href: "/submit" },


### PR DESCRIPTION
## Summary
Tightens the GitHub Actions pipeline so we stop burning minutes on docs-only commits, auto-tags PRs by which paths changed, and lets Dependabot handle safe dependency bumps without human babysitting.

Also bumps the catalog-count copy from `5,600+` / `5,650+` to `5,880+` across the user-visible places.

## What's in this PR

### 1. Path filters on existing workflows
- `check.yml` — `pull_request` no longer fires when the PR only touches docs (`**/*.md`, `docs-local/**`, `LICENSE`, `TRADEMARK.md`, `LEGAL.md`), issue templates, or the labeler/dependabot configs themselves
- `pages.yml` — same `paths-ignore` set on the push-to-main deploy, so a README tweak doesn't trigger a 5-minute static export

### 2. PR auto-labelling (`.github/labeler.yml` + `workflows/labeler.yml`)
Uses `actions/labeler@v5`. Maps changed paths → labels:

| Label | Trigger paths |
|---|---|
| `icons` | `public/icons/**`, `src/data/icons.json` |
| `ui` | `src/components/**`, `src/app/**`, `src/styles/**`, `src/lib/**`, `src/hooks/**`, `*.css` |
| `ci/cd` | `.github/workflows/**`, `.github/scripts/**`, `.github/{labeler,dependabot}.yml` |
| `documentation` | `**/*.md`, `docs-local/**` |
| `packages` | `packages/**`, `extensions/{vscode,raycast}/**` |
| `dependencies` | `package.json`, `pnpm-lock.yaml`, `packages/**/package.json` |
| `config` | `next.config.*`, `tsconfig.json`, `tailwind.config.*`, `postcss.config.*`, `eslint.config.*` |

`sync-labels: true`, so removing a path also removes the stale label.

### 3. Dependabot config (`.github/dependabot.yml`)
Weekly schedule, Monday 06:00 UTC, max 5 open PRs per ecosystem.

Two ecosystems:
- **npm**: separate update groups for `@types/*`, `eslint*`, `@changesets/*`, `tailwindcss*` plus catch-all `development-minor-patch` and `production-patch` groups so weekly noise is one PR per group
- **github-actions**: single group covers all action bumps

### 4. Dependabot auto-merge (`.github/workflows/dependabot-auto-merge.yml`)
Enables GitHub's native auto-merge on safe Dependabot PRs:
- Any patch update (runtime + dev)
- Any minor update on a dev-only dependency
- Any GitHub Actions bump

Anything else (major bumps, production minors) gets labelled `needs-review` and a comment pointing the human at it.

## Required one-time admin step (web UI)

**Settings → Code security & analysis → Dependabot version updates → Enable**.
Without that toggle, the `dependabot.yml` config is inert.

Auto-merge also requires **Settings → General → Pull Requests → Allow auto-merge** to be on (default is on).

## Test plan
- [ ] Open a docs-only PR, confirm `check.yml` does NOT run
- [ ] Open a `src/**` PR, confirm `check.yml` DOES run
- [ ] Confirm the new PR shows `ci/cd` + `documentation` labels auto-applied
- [ ] Wait for first Dependabot PR (Monday), confirm patch bumps auto-merge after CI green
- [ ] Confirm major bumps get `needs-review` label

## Followups (not in this PR)
- Catalog count auto-syncs from `icons.json` length so we don't keep editing copy strings manually