### PR TITLE
fix(ci): create needs-review label idempotently in dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -47,6 +47,12 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-major' ||
           (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:production')
         run: |
+          # Idempotently ensure the needs-review label exists before applying.
+          gh label create "needs-review" \
+            --color "fbca04" \
+            --description "Dependabot major bump or production minor; needs human review" \
+            --repo "$GITHUB_REPOSITORY" \
+            2>/dev/null || true
           gh pr edit "$PR_URL" --add-label "needs-review"
           gh pr comment "$PR_URL" --body "This update crosses a boundary that needs human review (major bump, or minor bump on a production dependency). Not auto-merging."
         env:


### PR DESCRIPTION
## Summary
The dependabot-auto-merge workflow was failing for major-bump and production-minor PRs because the \`needs-review\` label didn't exist in the repo yet:

\`\`\`
Run gh pr edit \"\$PR_URL\" --add-label \"needs-review\"
'needs-review' not found
Error: Process completed with exit code 1.
\`\`\`

## Fix
Pre-create the label inline before applying it. \`gh label create\` returns non-zero if the label already exists, so the \`|| true\` swallows that on subsequent runs. Workflow is now self-bootstrapping and doesn't need manual repo setup.

The label was also created directly on the repo (\`gh label create needs-review --color fbca04\`) so the five Dependabot PRs currently open (#144, #145, #146, #147, #149) get re-evaluated cleanly on their next event.

## Closes
This PR fixes the root cause; there's no separate issue to close.