### PR TITLE
chore: auto-close icon issues blocked on the submitter

### DIFF
--- a/.github/workflows/stale-icon-issues.yml
+++ b/.github/workflows/stale-icon-issues.yml
@@ -1,0 +1,63 @@
+name: Stale icon issues
+
+# Closes icon-request / icon-update issues that are blocked on the
+# submitter for too long. Pairs with .github/workflows/triage-icon-issue.yml
+# which is the workflow that *applies* the triage:needs-* labels; this one
+# only watches them.
+#
+# Policy:
+#   - Touched only if an issue carries a triage:needs-* label (we asked
+#     the submitter for something and they haven't replied).
+#   - 14 days of inactivity -> mark stale, post a clear "here is what we
+#     need from you to keep this open" comment.
+#   - +7 more days (21 total) -> close as not-planned with a "happy to
+#     reopen later" note. Closing is housekeeping, not rejection.
+#   - Any new comment from the submitter clears the stale label and
+#     resets the clock (remove-stale-when-updated).
+#   - Pull requests are out of scope for this workflow.
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: stale-icon-issues
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    name: Mark and close blocked icon issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          any-of-issue-labels: "triage:needs-svg,triage:needs-license,triage:invalid-svg,triage:svg-oversize"
+          exempt-issue-labels: "pinned,security,help-wanted,blocked-on-maintainer"
+          stale-issue-label: stale
+          close-issue-label: auto-closed
+          close-issue-reason: not_planned
+          remove-stale-when-updated: true
+          operations-per-run: 60
+          ascending: true
+          stale-issue-message: |
+            This icon issue has been waiting on the submitter for 14 days, so it's being marked **stale**. If we don't hear back in another **7 days** it will close automatically.
+
+            Here's what we need from you to keep it open, based on the label:
+
+            - **`triage:needs-svg`** - paste the SVG source in a comment (under 50KB, valid `viewBox`, no scripts, no embedded raster images)
+            - **`triage:needs-license`** - link the brand assets / press page that confirms the mark is licensed for redistribution, or note the source we should record in the `guidelines` field
+            - **`triage:invalid-svg`** - the SVG we received didn't parse cleanly; please re-paste it or attach the file
+            - **`triage:svg-oversize`** - the SVG was over the 50KB limit; please re-export it with paths simplified or gradients flattened
+
+            Closing isn't a rejection. You're welcome to reopen anytime once you have the missing details.
+          close-issue-message: |
+            Closing as `not-planned` since we haven't heard back for 21 days. Happy to revisit if you reopen this with the missing details. Thanks for your interest in thesvg.


### PR DESCRIPTION
## Summary

Adds a scheduled stale-issues workflow that pairs with the existing `triage-icon-issue.yml`. The triage workflow applies labels like `triage:needs-svg`, `triage:needs-license`, `triage:invalid-svg`, `triage:svg-oversize` whenever a submission is missing something. This new workflow watches those labels and closes the threads where the submitter never came back.

Today this is done manually (see e.g. the housekeeping notes in #175 for #161, #162, etc.). This automates the "nudge then close" loop without ever auto-closing maintainer-driven work.

## Behaviour

| Step | Trigger | Action |
|---|---|---|
| Day 14 | issue inactive, has any `triage:needs-*` label | Mark `stale`, post a clear "here is what we need from you" comment keyed to the specific label |
| Day 21 | still inactive | Close as `not-planned`, post a "reopen anytime" note |
| Any reply | submitter comments | Stale label removed, clock resets (`remove-stale-when-updated`) |

## Scope guards

- **PRs are excluded** (`days-before-pr-stale: -1`, `days-before-pr-close: -1`) — this only touches icon-request / icon-update issues
- **Only fires on `triage:needs-*` labels** — `triage:ready` threads (ready for maintainer action) are never touched
- **Exempt labels**: `pinned`, `security`, `help-wanted`, `blocked-on-maintainer` — so a maintainer-led thread never gets auto-closed
- **Runs at 01:30 UTC daily** with `workflow_dispatch` for manual runs
- **`operations-per-run: 60`** caps GitHub API churn

## Why these defaults

- **14/7 not 60/7**: icon submissions are small asks. If a submitter doesn't respond in two weeks the issue is most likely dead. Faster timeout keeps the issue list signal-heavy.
- **Close as `not-planned`** (not `completed`) so it shows the grey closed icon, not the purple one. We're not shipping the icon, we're tidying up.
- **No `actions/stale@main`**: pinned to `v9` to avoid surprise breaking changes.

## What it would do today

Looking at currently labeled issues with `triage:needs-license`:
- The four open ones (#159, #183, #184, #185) are being resolved in this batch (closed / PR'd / merged) so they wouldn't be picked up.
- Going forward, any newly opened submission that hits `triage:needs-license` and goes quiet will follow the 14 / 21 day cadence.

## Test plan

- [ ] Merge to main, then trigger `workflow_dispatch` once to confirm the job runs clean against the current issue list
- [ ] Confirm zero issues are touched on the first dry-run (since the surviving labeled ones are recent / being handled)
- [ ] Wait for next regular cron firing, confirm the schedule is honored
- [ ] When a future submission goes stale, confirm the comment text formats correctly and the stale-then-close flow works end to end
