### PR TITLE
fix: scope icons.json validation to changed slugs, accept 3-char hex

### DIFF
--- a/.github/workflows/validate-svg.yml
+++ b/.github/workflows/validate-svg.yml
@@ -102,7 +102,25 @@ jobs:
             exit 1
           fi
 
+      - name: Compute added slugs (icons.json diff)
+        id: jsondiff
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          # Lines newly added in icons.json that look like "slug": "x" entries
+          added=$(git diff "$base"...HEAD -- src/data/icons.json | grep -E '^\+\s+"slug":' | sed -E 's/.*"slug":\s*"([^"]+)".*/\1/' || true)
+          echo "added<<EOF" >> $GITHUB_OUTPUT
+          echo "$added" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          if [ -z "$added" ]; then
+            echo "(no new slugs in icons.json)"
+          else
+            echo "Newly added slugs:"
+            echo "$added" | sed 's/^/  /'
+          fi
+
       - name: Validate icons.json structure
+        env:
+          NEW_SLUGS: ${{ steps.jsondiff.outputs.added }}
         run: |
           set -e
           node -e '
@@ -111,20 +129,28 @@ jobs:
             const raw = fs.readFileSync(path, "utf8");
             const data = JSON.parse(raw);
             if (!Array.isArray(data)) throw new Error("icons.json is not an array");
+            const newSlugs = new Set((process.env.NEW_SLUGS || "").split(/\s+/).filter(Boolean));
             const slugs = new Set();
             let prevSlug = "";
             const issues = [];
+            // 3- or 6-character hex, both valid CSS color shorthands
+            const hexRe = /^[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/;
             for (let i = 0; i < data.length; i++) {
               const e = data[i];
-              if (!e.slug) issues.push(`#${i}: missing slug`);
-              if (!e.title) issues.push(`#${i} (${e.slug}): missing title`);
-              if (!e.hex || !/^[0-9A-Fa-f]{6}$/.test(e.hex)) issues.push(`#${i} (${e.slug}): bad hex ${e.hex}`);
-              if (!Array.isArray(e.categories)) issues.push(`#${i} (${e.slug}): categories not array`);
-              if (!e.variants || !e.variants.default) issues.push(`#${i} (${e.slug}): missing default variant`);
+              const scoped = newSlugs.size === 0 || newSlugs.has(e.slug);
               if (slugs.has(e.slug)) issues.push(`#${i} (${e.slug}): duplicate slug`);
               slugs.add(e.slug);
+              if (scoped) {
+                if (!e.slug) issues.push(`#${i}: missing slug`);
+                if (!e.title) issues.push(`#${i} (${e.slug}): missing title`);
+                if (!e.hex || !hexRe.test(e.hex)) issues.push(`#${i} (${e.slug}): bad hex ${e.hex}`);
+                if (!Array.isArray(e.categories)) issues.push(`#${i} (${e.slug}): categories not array`);
+                if (!e.variants || !e.variants.default) issues.push(`#${i} (${e.slug}): missing default variant`);
+              }
               if (prevSlug && e.slug < prevSlug) {
-                issues.push(`#${i} (${e.slug}): out of alphabetical order (after ${prevSlug})`);
+                if (scoped || newSlugs.has(prevSlug)) {
+                  issues.push(`#${i} (${e.slug}): out of alphabetical order (after ${prevSlug})`);
+                }
               }
               prevSlug = e.slug;
             }


### PR DESCRIPTION
Two issues surfaced once `validate-svg.yml` started running against real PRs:

1. **Hex regex too strict.** The original `/^[0-9A-Fa-f]{6}$/` rejects the well-formed 3-character shorthand used by ~90 existing entries (`fff`, `000`, `03F`). Both lengths are valid CSS. Regex updated to `/^[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/`.

2. **Whole-file scope.** The structural check walked every entry in `icons.json` on every PR, so a PR that added one new entry failed because of pre-existing entries it didn't touch. Now the check derives the set of newly added slugs from the diff and only enforces field validation against those. Duplicate detection still walks the whole file; alphabetical-order checks fire only when one side of the offending pair was newly added.

Unblocks every open icon-add PR currently failing on this check.

## Test plan

- [ ] Re-trigger checks on one of the blocked icon PRs and confirm the workflow now passes
- [ ] Add a deliberately bad-hex entry to a test branch and confirm the workflow catches it