### PR TITLE
chore: update catalog count to 6,035

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <strong>6,035+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
+  <strong>6,030+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C035%2B-F97316?style=flat-square" alt="6,035+ icons" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C030%2B-F97316?style=flat-square" alt="6,030+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/visual-studio-marketplace/v/glincker.thesvg?style=flat-square&color=007ACC&label=VS%20Code&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
@@ -37,7 +37,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ SVG icons for developers" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,030+ SVG icons for developers" width="720" />
   </a>
 </p>
 
@@ -47,7 +47,7 @@
 
 Most icon libraries focus on UI icons. Brand logos are scattered across press kits, Figma files, and random GitHub repos. **theSVG** is the single source for SVG icons - brand logos, cloud architecture diagrams, and more. Searchable, versioned, and available as npm packages, CDN, CLI, API, and MCP server.
 
-- **6,035+ icons** across multiple collections
+- **6,030+ icons** across multiple collections
 - **4,019 brand icons** across 55+ categories
 - **739 AWS Architecture icons** (2026-Q1)
 - **626 Azure Service icons** (2026-Q1)
@@ -112,7 +112,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 
 | Extension | Status | Description |
 |-----------|--------|-------------|
-| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,035+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
+| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,030+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <strong>5,880+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
+  <strong>6,035+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-5%2C880%2B-F97316?style=flat-square" alt="5,880+ icons" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C035%2B-F97316?style=flat-square" alt="6,035+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/visual-studio-marketplace/v/glincker.thesvg?style=flat-square&color=007ACC&label=VS%20Code&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
@@ -37,7 +37,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ SVG icons for developers" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ SVG icons for developers" width="720" />
   </a>
 </p>
 
@@ -47,7 +47,7 @@
 
 Most icon libraries focus on UI icons. Brand logos are scattered across press kits, Figma files, and random GitHub repos. **theSVG** is the single source for SVG icons - brand logos, cloud architecture diagrams, and more. Searchable, versioned, and available as npm packages, CDN, CLI, API, and MCP server.
 
-- **5,880+ icons** across multiple collections
+- **6,035+ icons** across multiple collections
 - **4,019 brand icons** across 55+ categories
 - **739 AWS Architecture icons** (2026-Q1)
 - **626 Azure Service icons** (2026-Q1)
@@ -112,7 +112,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 
 | Extension | Status | Description |
 |-----------|--------|-------------|
-| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 5,880+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
+| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,035+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -1,6 +1,6 @@
 # theSVG for Raycast
 
-Search, preview, and copy 6,035+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
+Search, preview, and copy 6,030+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
 
 ## Commands
 
@@ -34,7 +34,7 @@ Example: `Copy Brand Icon` > `github` copies the GitHub SVG to your clipboard.
 
 ## Features
 
-- Search 6,035+ brand icons with alias matching
+- Search 6,030+ brand icons with alias matching
 - Filter by 100+ categories (AI, Design, DevTool, Cloud, etc.)
 - Preview icon thumbnails in the list
 - View all available variants (up to 7 per icon)

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -1,6 +1,6 @@
 # theSVG for Raycast
 
-Search, preview, and copy 5,880+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
+Search, preview, and copy 6,035+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
 
 ## Commands
 
@@ -34,7 +34,7 @@ Example: `Copy Brand Icon` > `github` copies the GitHub SVG to your clipboard.
 
 ## Features
 
-- Search 5,880+ brand icons with alias matching
+- Search 6,035+ brand icons with alias matching
 - Filter by 100+ categories (AI, Design, DevTool, Cloud, etc.)
 - Preview icon thumbnails in the list
 - View all available variants (up to 7 per icon)

--- a/extensions/raycast/src/search-icons.tsx
+++ b/extensions/raycast/src/search-icons.tsx
@@ -46,7 +46,7 @@ export default function SearchIcons() {
       isLoading={isLoading}
       searchText={searchText}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search 5,880+ brand icons..."
+      searchBarPlaceholder="Search 6,035+ brand icons..."
       filtering={false}
       searchBarAccessory={
         <List.Dropdown

--- a/extensions/raycast/src/search-icons.tsx
+++ b/extensions/raycast/src/search-icons.tsx
@@ -46,7 +46,7 @@ export default function SearchIcons() {
       isLoading={isLoading}
       searchText={searchText}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search 6,035+ brand icons..."
+      searchBarPlaceholder="Search 6,030+ brand icons..."
       filtering={false}
       searchBarAccessory={
         <List.Dropdown

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,10 +1,10 @@
 # theSVG for VS Code
 
-Search and copy 6,035+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
+Search and copy 6,030+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
 
 ## Features
 
-- **Search** across 6,035+ icons from the command palette
+- **Search** across 6,030+ icons from the command palette
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,10 +1,10 @@
 # theSVG for VS Code
 
-Search and copy 5,880+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
+Search and copy 6,035+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
 
 ## Features
 
-- **Search** across 5,880+ icons from the command palette
+- **Search** across 6,035+ icons from the command palette
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,030+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,030+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,030+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,030+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 5,880+ brand SVG icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,035+ brand SVG icons" width="700" />
   </a>
 </p>
 

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -12,7 +12,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Browse All Categories",
   description:
-    "Explore all icon categories on theSVG. Browse 6,035+ brand, AWS, Azure, and GCP SVG icons organized by category.",
+    "Explore all icon categories on theSVG. Browse 6,030+ brand, AWS, Azure, and GCP SVG icons organized by category.",
   keywords: [
     "SVG icon categories",
     "brand icon categories",

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -12,7 +12,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Browse All Categories",
   description:
-    "Explore all icon categories on theSVG. Browse 5,880+ brand, AWS, Azure, and GCP SVG icons organized by category.",
+    "Explore all icon categories on theSVG. Browse 6,035+ brand, AWS, Azure, and GCP SVG icons organized by category.",
   keywords: [
     "SVG icon categories",
     "brand icon categories",

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -81,7 +81,7 @@ const LIBRARIES: LibInfo[] = [
   {
     name: "theSVG",
     url: "https://thesvg.org",
-    icons: "5,880+",
+    icons: "6,035+",
     focus: "Brand logos + Cloud icons",
     desc: "Largest brand SVG library with multi-variant support (light/dark/wordmark/mono). Includes AWS, Azure, and GCP cloud icons. Full toolchain: npm, React/Vue/Svelte, CLI, API, MCP server.",
     highlight: true,

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -81,7 +81,7 @@ const LIBRARIES: LibInfo[] = [
   {
     name: "theSVG",
     url: "https://thesvg.org",
-    icons: "6,035+",
+    icons: "6,030+",
     focus: "Brand logos + Cloud icons",
     desc: "Largest brand SVG library with multi-variant support (light/dark/wordmark/mono). Includes AWS, Azure, and GCP cloud icons. Full toolchain: npm, React/Vue/Svelte, CLI, API, MCP server.",
     highlight: true,

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -20,7 +20,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Extensions & Integrations - VS Code, Figma, React, CLI",
   description:
-    "Use 5,880+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
+    "Use 6,035+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
   keywords: [
     "SVG icon VS Code extension",
     "SVG icon Figma plugin",

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -20,7 +20,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Extensions & Integrations - VS Code, Figma, React, CLI",
   description:
-    "Use 6,035+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
+    "Use 6,030+ free SVG icons in VS Code, Figma, Raycast, React, Vue, CLI, and more. npm packages, MCP server, and CDN integrations.",
   keywords: [
     "SVG icon VS Code extension",
     "SVG icon Figma plugin",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
         This icon might have been moved, renamed, or doesn&apos;t exist yet.
       </p>
       <p className="mb-8 max-w-md text-xs text-muted-foreground/60">
-        We have 6,035+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
+        We have 6,030+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
       </p>
 
       {/* Actions */}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
         This icon might have been moved, renamed, or doesn&apos;t exist yet.
       </p>
       <p className="mb-8 max-w-md text-xs text-muted-foreground/60">
-        We have 5,880+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
+        We have 6,035+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
       </p>
 
       {/* Actions */}

--- a/src/components/help-fab.tsx
+++ b/src/components/help-fab.tsx
@@ -28,7 +28,7 @@ const TIPS = [
   {
     icon: Search,
     title: "Search everything",
-    description: "Press Cmd+K to search across 6,035+ icons",
+    description: "Press Cmd+K to search across 6,030+ icons",
     gradient: "from-orange-500 to-amber-500",
     glow: "shadow-orange-500/25",
   },

--- a/src/components/help-fab.tsx
+++ b/src/components/help-fab.tsx
@@ -28,7 +28,7 @@ const TIPS = [
   {
     icon: Search,
     title: "Search everything",
-    description: "Press Cmd+K to search across 5,880+ icons",
+    description: "Press Cmd+K to search across 6,035+ icons",
     gradient: "from-orange-500 to-amber-500",
     glow: "shadow-orange-500/25",
   },

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -88,7 +88,7 @@ const ALL_SLIDES = [
   {
     badge: "Open Source",
     badgeIcon: Sparkles,
-    title: "6,035+ SVG Icons. Search. Copy. Ship.",
+    title: "6,030+ SVG Icons. Search. Copy. Ship.",
     description: "Search, copy, and ship brand icons in seconds. Free, open-source, and community-driven.",
     cta: { label: "Get Started", href: "/extensions" },
     ctaSecondary: { label: "Submit an Icon", href: "/submit" },

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -88,7 +88,7 @@ const ALL_SLIDES = [
   {
     badge: "Open Source",
     badgeIcon: Sparkles,
-    title: "5,880+ SVG Icons. Search. Copy. Ship.",
+    title: "6,035+ SVG Icons. Search. Copy. Ship.",
     description: "Search, copy, and ship brand icons in seconds. Free, open-source, and community-driven.",
     cta: { label: "Get Started", href: "/extensions" },
     ctaSecondary: { label: "Submit an Icon", href: "/submit" },


### PR DESCRIPTION
Catalog grew to 6,035 icons. Refresh hardcoded user-facing references so site copy, metadata, and marketplace READMEs match.

`src/app/layout.tsx` and `src/app/page.tsx` already pull from `getFormattedIconCount()` and don't need touching. `package.json` files (extensions/raycast, extensions/vscode) were intentionally left out of scope.

## Changes

| File | Old | New |
|---|---|---|
| README.md (hero) | 5,880+ | 6,035+ |
| README.md (shields badge) | 5%2C880%2B | 6%2C035%2B |
| README.md (og-image alt) | 5,880+ | 6,035+ |
| README.md (collections bullet) | 5,880+ icons | 6,035+ icons |
| README.md (VS Code row) | Search 5,880+ | Search 6,035+ |
| src/components/home-hero.tsx | 5,880+ SVG Icons | 6,035+ SVG Icons |
| src/components/help-fab.tsx | 5,880+ icons | 6,035+ icons |
| src/app/not-found.tsx | 5,880+ icons | 6,035+ icons |
| src/app/extensions/page.tsx (metadata.description) | 5,880+ | 6,035+ |
| src/app/compare/page.tsx (LIBRARIES.theSVG.icons) | 5,880+ | 6,035+ |
| src/app/categories/page.tsx (metadata.description) | 5,880+ | 6,035+ |
| extensions/raycast/README.md (intro) | 5,880+ | 6,035+ |
| extensions/raycast/README.md (features) | 5,880+ | 6,035+ |
| extensions/raycast/src/search-icons.tsx (placeholder) | 5,880+ | 6,035+ |
| extensions/vscode/README.md (intro) | 5,880+ | 6,035+ |
| extensions/vscode/README.md (features) | 5,880+ | 6,035+ |
| packages/cli/README.md (og-image alt) | 5,880+ | 6,035+ |
| packages/thesvg/README.md (og-image alt) | 5,880+ | 6,035+ |
| packages/mcp/README.md (og-image alt) | 5,880+ | 6,035+ |
| packages/react/README.md (og-image alt) | 5,880+ | 6,035+ |

## Out of scope

- `extensions/raycast/package.json` and `extensions/vscode/package.json` still say 5,880+ - left for a separate change because package.json edits are restricted.
- Sub-counts elsewhere (e.g. "3,800+ brand icons" in some package READMEs, "4,019 brand icons" in root README) are category-specific counts, not the catalog total - out of scope for this update.