### PR TITLE
feat: autonomous-mode (loosen dependabot, auto-merge icon PRs, direct-PR contributor path)

### DIFF
--- a/.github/workflows/auto-merge-icon-pr.yml
+++ b/.github/workflows/auto-merge-icon-pr.yml
@@ -1,0 +1,47 @@
+name: Auto-merge icon PRs
+
+# Enables GitHub's native auto-merge on icon-add / icon-update PRs once
+# the triage workflow has labeled them triage:ready and the submitter
+# isn't a first-time contributor (so we still eyeball brand-new sources
+# before shipping). CI gates the actual merge — this just removes the
+# manual "click merge" step once everything's green.
+#
+# Required check chain (configured at branch protection level):
+#   - Validate SVG
+#   - Lint & Build
+#
+# Skipped (left for manual merge):
+#   - First-time contributors (author_association is FIRST_TIME_CONTRIBUTOR
+#     or NONE) — we want a human to read the diff for those
+#   - PRs marked needs-review, blocked-on-maintainer, or any triage:needs-*
+#   - Draft PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'triage:ready') &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'blocked-on-maintainer') &&
+      !contains(github.event.pull_request.labels.*.name, 'triage:needs-svg') &&
+      !contains(github.event.pull_request.labels.*.name, 'triage:needs-license') &&
+      !contains(github.event.pull_request.labels.*.name, 'triage:invalid-svg') &&
+      !contains(github.event.pull_request.labels.*.name, 'triage:svg-oversize') &&
+      github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' &&
+      github.event.pull_request.author_association != 'NONE'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,16 +1,24 @@
 name: Dependabot auto-merge
 
-# Auto-enables GitHub's native auto-merge on safe Dependabot PRs so they
-# merge themselves once CI passes. The human only sees major bumps and
-# production minor bumps.
+# Auto-enables GitHub's native auto-merge on Dependabot PRs that match
+# our safety bands, so they merge themselves once CI passes. CI is the
+# real safety net here: every auto-merge still has to pass Lint & Build
+# and Validate SVG. The classification below is just about which bumps
+# we never want a human to gate on.
 #
-# Safe means:
-#   - Any patch update (both runtime and dev dependencies)
-#   - Any minor update on a dev-only dependency
-#   - GitHub Actions bumps of any size (low blast radius, mostly version
-#     pinning)
+# Auto-merged:
+#   - Any patch update (runtime or dev)
+#   - Any minor update (runtime or dev) — CI catches the rest
+#   - Any update on a dev-only dependency, including majors (we'll catch
+#     real breakage in Lint & Build before it can hit anyone)
+#   - Any GitHub Actions bump
 #
-# Anything else stays open for manual review with a "needs-review" label.
+# Labeled needs-review (human merges):
+#   - Production major bumps only — the one class that warrants reading
+#     the release notes before shipping
+#
+# This tier matters for autonomous-mode: nobody should need to babysit
+# the repo for routine dependency updates.
 
 on:
   pull_request:
@@ -34,7 +42,8 @@ jobs:
       - name: Enable auto-merge on safe updates
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:development') ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.dependency-type == 'direct:development' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
           steps.meta.outputs.package-ecosystem == 'github-actions'
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
@@ -42,19 +51,18 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Label majors and production minors for manual review
+      - name: Label production majors for manual review
         if: |
-          steps.meta.outputs.update-type == 'version-update:semver-major' ||
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' && steps.meta.outputs.dependency-type == 'direct:production')
+          steps.meta.outputs.update-type == 'version-update:semver-major' &&
+          steps.meta.outputs.dependency-type == 'direct:production'
         run: |
-          # Idempotently ensure the needs-review label exists before applying.
           gh label create "needs-review" \
             --color "fbca04" \
-            --description "Dependabot major bump or production minor; needs human review" \
+            --description "Dependabot production major bump; needs human review" \
             --repo "$GITHUB_REPOSITORY" \
             2>/dev/null || true
           gh pr edit "$PR_URL" --add-label "needs-review"
-          gh pr comment "$PR_URL" --body "This update crosses a boundary that needs human review (major bump, or minor bump on a production dependency). Not auto-merging."
+          gh pr comment "$PR_URL" --body "This is a major bump on a production dependency. Not auto-merging — release notes worth a read first."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,36 @@ get started.
 
 ### Submit a New Icon
 
-The easiest way to contribute is to submit a new brand icon:
+You have two options:
+
+**A. Via the submit form** (easiest):
 
 1. Go to [thesvg.org/submit](https://thesvg.org/submit)
-2. Upload the SVG file
-3. Fill in the brand name, category, and website URL
-4. Submit for review
+2. Upload the SVG, fill in the brand name, category, and website URL
+3. Submit — this opens a triaged issue
 
-**Requirements for icon submissions:**
+**B. Via a direct PR** (faster if you're comfortable with git):
+
+1. Fork the repo and branch off `main`: `git checkout -b feat/icon-{slug}`
+2. Drop the SVG at `public/icons/{slug}/default.svg`
+3. Add an entry to `src/data/icons.json` at the correct alphabetical position, following the schema:
+   ```json
+   {
+     "slug": "your-brand",
+     "title": "Your Brand",
+     "aliases": [],
+     "hex": "F97316",
+     "categories": ["DevTool"],
+     "variants": { "default": "/icons/your-brand/default.svg" },
+     "license": "CC0-1.0",
+     "url": "https://yourbrand.com",
+     "collection": "brands",
+     "dateAdded": "2026-05-16"
+   }
+   ```
+4. Open a PR titled `feat: add {slug} icon`. The triage workflow will auto-label it; if everything passes (`Validate SVG`, `Lint & Build`), it'll auto-merge.
+
+**Requirements for icon submissions (both paths):**
 
 - SVG format only (no PNG, JPG, etc.)
 - Must be an official brand logo or icon
@@ -22,6 +44,8 @@ The easiest way to contribute is to submit a new brand icon:
 - File size under 50KB
 - No embedded `<script>` tags, event handlers, or `javascript:` URIs
 - No raster images embedded in the SVG
+- Brand domain at least 30 days old (we reject fresh-spun-up sites)
+- One valid category from the [issue template's dropdown](.github/ISSUE_TEMPLATE/icon_request.yml)
 - Preferably optimized with [SVGO](https://github.com/svg/svgo)
 
 ### Report an Issue

--- a/extensions/raycast/package.json
+++ b/extensions/raycast/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "thesvg",
   "title": "TheSVG",
-  "description": "Search, preview, and copy 5,880+ brand SVG icons from thesvg.org",
+  "description": "Search, preview, and copy 6,030+ brand SVG icons from thesvg.org",
   "icon": "extension-icon.png",
   "author": "thegdsks",
   "categories": ["Design Tools", "Developer Tools"],
@@ -12,7 +12,7 @@
       "name": "search-icons",
       "title": "Search Brand Icons",
       "subtitle": "theSVG",
-      "description": "Search 5,880+ brand SVG icons. Copy SVG, download, or open in browser.",
+      "description": "Search 6,030+ brand SVG icons. Copy SVG, download, or open in browser.",
       "mode": "view"
     },
     {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
-  "description": "Search and copy 5,880+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
+  "description": "Search and copy 6,030+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
   "version": "0.1.3",
   "publisher": "glincker",
   "license": "MIT",


### PR DESCRIPTION
Three changes to let the repo run unattended for longer stretches without breaking anything. CI (Validate SVG + Lint & Build) is the real safety net for everything below.

### 1. Dependabot auto-merge band widened

Previously only patches and dev-minors merged themselves; production minors and dev majors sat behind a needs-review label. The classification was just noise reduction since CI gates the merge anyway. Now we auto-merge:

- Any patch (runtime or dev)
- Any minor (runtime or dev)
- Any dev update including majors
- Any GitHub Actions bump

Only **production major bumps** stay behind `needs-review` — the one class that warrants reading release notes first.

### 2. New `auto-merge-icon-pr.yml`

Enables GitHub's native auto-merge on icon-add PRs once **all of these** hold:
- `triage:ready` label applied by the existing triage workflow
- Submitter is not a first-time contributor (`author_association` filter)
- No `needs-review`, `blocked-on-maintainer`, or `triage:needs-*` label
- Not a draft

Required checks (`Validate SVG`, `Lint & Build`) still gate the merge — this just removes the manual click.

### 3. CONTRIBUTING.md: direct-PR path

Added a step-by-step "submit via direct PR" track alongside the existing form path. Includes the full `icons.json` schema and the requirement list (size, viewBox, no scripts, no rasters, 30-day domain age, valid category). Comfortable-with-git contributors can now skip the issue and go straight to a PR.

### What this enables

The repo can sit unattended for ~a month:
- Routine dependency updates self-merge
- New icon PRs from trusted contributors self-merge after triage labels and CI green
- Stale icon issues auto-close via the existing stale-icon-issues workflow
- First-time contributors and production majors still get human eyes

## Test plan

- [ ] Confirm a synthetic dependabot patch PR still auto-merges (no regression)
- [ ] Open a test icon PR, manually apply `triage:ready`, confirm auto-merge fires once CI is green
- [ ] Open a test icon PR with `triage:needs-svg`, confirm auto-merge does NOT fire
- [ ] Confirm a first-time contributor PR is left for manual merge