### PR TITLE
chore: changeset for 3.0 catalog milestone (6,000+ icons)

### DIFF
--- a/.changeset/v3-six-thousand-icons.md
+++ b/.changeset/v3-six-thousand-icons.md
@@ -1,0 +1,11 @@
+---
+"@thesvg/icons": major
+"thesvg": major
+"@thesvg/react": major
+"@thesvg/vue": major
+"@thesvg/svelte": major
+---
+
+3.0: catalog crosses six thousand icons.
+
+The 3.0 line marks the catalog passing 6,000 entries. No package-level API changes — every export, hook, and component continues to work without code edits. The major bump reflects the data-side milestone: a meaningful expansion of brand coverage across finance, gaming, consumer goods, entertainment, regional carriers, and dev tooling that contributors should know about before pinning.


### PR DESCRIPTION
Adds a major-bump changeset for all five linked packages. No package-level API changes — the major bump is a deliberate signal that the data side passed the **6,000-icon milestone**.

Once this merges, the changesets release workflow will auto-open a `chore(release): version packages` PR bumping every linked package from 2.1.x to 3.0.0. Merging that triggers the npm publish.

### Versioned together

- `@thesvg/icons`
- `thesvg`
- `@thesvg/react`
- `@thesvg/vue`
- `@thesvg/svelte`

### Why a major bump for a data milestone

Consumers pinning to a version generally don't expect the catalog to suddenly contain ~150 new brands at the same major. Some downstream tooling enumerates the full set at install time (CLI installers, build-time prebakes). Moving them to the next major lets them opt in deliberately rather than picking up the expansion silently on a minor.