### PR TITLE
fix(cli): pin tsconfig types to node so release build sees @types/node

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
The release workflow uses `npm run build` inside `packages/cli`. In a pnpm-installed workspace, npm-driven typecheck doesn't see hoisted `@types/node` automatically, so every reference to `process`, `node:fs`, etc. errored out and the publish step never reached `changeset publish`.

Setting `types: ["node"]` explicitly makes resolution work under both installers and unblocks the autonomous-mode publish path. The package already declares `@types/node` as a devDependency, so no install change is needed.

This caught us on the 3.0.0 publish; this PR unblocks future ones.