### PR TITLE
fix(figma): point plugin at thesvg.org bare host so network calls succeed

### DIFF
--- a/extensions/figma/README.md
+++ b/extensions/figma/README.md
@@ -1,10 +1,10 @@
 # theSVG for Figma
 
-Browse and insert 4,000+ brand SVG logos directly into your Figma designs.
+Browse and insert 6,000+ brand SVG logos directly into your Figma designs.
 
 ## Features
 
-- Search across 4,000+ brand icons
+- Search across 6,000+ brand icons
 - Filter by category (AI, Analytics, Browser, CMS, etc.)
 - One-click insert into your canvas
 - Icons are inserted as editable vector nodes

--- a/extensions/figma/manifest.json
+++ b/extensions/figma/manifest.json
@@ -7,7 +7,7 @@
   "ui": "build/ui.html",
   "documentAccess": "dynamic-page",
   "networkAccess": {
-    "allowedDomains": ["https://www.thesvg.org", "https://cdn.jsdelivr.net"],
+    "allowedDomains": ["https://thesvg.org", "https://cdn.jsdelivr.net"],
     "reasoning": "Fetches SVG brand icons from the theSVG API and loads icon previews from jsDelivr CDN"
   }
 }

--- a/extensions/figma/package.json
+++ b/extensions/figma/package.json
@@ -1,8 +1,8 @@
 {
   "name": "thesvg-figma",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
-  "description": "Browse and insert 4,000+ brand SVG logos from theSVG into your Figma designs",
+  "description": "Browse and insert 6,000+ brand SVG logos from theSVG into your Figma designs",
   "scripts": {
     "build": "node esbuild.config.mjs",
     "dev": "node esbuild.config.mjs --watch"

--- a/extensions/figma/src/main.ts
+++ b/extensions/figma/src/main.ts
@@ -1,7 +1,7 @@
 // theSVG Figma Plugin - Main thread (sandbox)
 // All network requests happen here to avoid CORS issues in the iframe
 
-const API_BASE = "https://www.thesvg.org";
+const API_BASE = "https://thesvg.org";
 
 interface SearchMessage {
   type: "search";

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
## What was broken

The plugin pointed `API_BASE` at `https://www.thesvg.org`. Two compounding issues:

1. The site now redirects `www` to the bare host with a 301.
2. Figma's `networkAccess` sandbox blocks redirects to domains that aren't explicitly whitelisted in the manifest, and the manifest only listed `https://www.thesvg.org`.

Net effect: every fetch from the plugin sandbox failed. Search, category load, and insert all errored. Plugin never cleared Figma's review queue.

## Fix

1. `src/main.ts` — `API_BASE` now points at `https://thesvg.org`
2. `manifest.json` — `networkAccess.allowedDomains` updated to the bare host
3. `package.json` + `README.md` — bumped 4,000+ to 6,000+ to match the current catalog (we're at 6,030)
4. `package.json` version 1.0.0 -> 1.0.1 to mark this as a fix for the reviewer

## Verified locally

- `npm run build` clean
- `build/main.js` contains `var API_BASE = "https://thesvg.org"`
- API endpoints respond 200 directly:
  - https://thesvg.org/api/registry.json -> 6,030 entries
  - https://thesvg.org/api/categories.json -> full category list
  - https://thesvg.org/icons/figma/default.svg -> 200

## Resubmission path

1. Merge this
2. Pull main, `cd extensions/figma && npm install && npm run build`
3. Figma Desktop -> Plugins -> Manage plugins -> Publish update
4. Note for the reviewer: 'fixed API host change that caused all network requests to fail in the previous submission'