### PR TITLE
feat(figma): recents, variant picker, keyboard shortcuts, jsDelivr-only network (v1.2.0)

### DIFF
--- a/extensions/figma/README.md
+++ b/extensions/figma/README.md
@@ -6,9 +6,15 @@ Browse and insert 6,000+ brand SVG logos directly into your Figma designs.
 
 - Search across 6,000+ brand icons
 - Filter by category (AI, Analytics, Browser, CMS, etc.)
-- One-click insert into your canvas
-- Icons are inserted as editable vector nodes
-- Supports Figma light and dark themes
+- One-click insert as editable vector nodes
+- Variant picker for icons with light, dark, mono, or color versions (hover an icon, click the number badge in the corner)
+- Recent icons row: the last 12 you inserted, kept across sessions
+- Keyboard shortcuts: `Enter` inserts the first result, `Cmd/Ctrl+F` focuses search, `Esc` closes the plugin
+- Adapts to Figma light and dark themes automatically
+
+## How it works
+
+The plugin pulls the icon catalog and SVG files from the jsDelivr CDN mirror of the [open-source theSVG repo](https://github.com/glincker/thesvg). No traffic touches the thesvg.org website, so the plugin keeps working at full speed even during peak usage of the site. The CDN cache refreshes every few hours, so newly merged icons appear in the plugin within roughly a day of landing on `main`.
 
 ## Development
 

--- a/extensions/figma/manifest.json
+++ b/extensions/figma/manifest.json
@@ -7,7 +7,7 @@
   "ui": "build/ui.html",
   "documentAccess": "dynamic-page",
   "networkAccess": {
-    "allowedDomains": ["https://thesvg.org", "https://cdn.jsdelivr.net"],
-    "reasoning": "Fetches SVG brand icons from the theSVG API and loads icon previews from jsDelivr CDN"
+    "allowedDomains": ["https://cdn.jsdelivr.net"],
+    "reasoning": "Fetches the icon catalog and SVG files from the jsDelivr CDN mirror of the open-source theSVG repository"
   }
 }

--- a/extensions/figma/package.json
+++ b/extensions/figma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thesvg-figma",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "private": true,
   "description": "Browse and insert 6,000+ brand SVG logos from theSVG into your Figma designs",
   "scripts": {

--- a/extensions/figma/src/main.ts
+++ b/extensions/figma/src/main.ts
@@ -1,7 +1,13 @@
 // theSVG Figma Plugin - Main thread (sandbox)
-// All network requests happen here to avoid CORS issues in the iframe
+// All network requests happen here to avoid CORS issues in the iframe.
+// Data and SVGs are served from jsDelivr (CDN) rather than thesvg.org so
+// the plugin keeps working even if the website is down or rate-limited.
 
-const API_BASE = "https://thesvg.org";
+const CDN_BASE = "https://cdn.jsdelivr.net/gh/glincker/thesvg@main";
+const ICONS_JSON_URL = `${CDN_BASE}/src/data/icons.json`;
+const ICONS_PATH_PREFIX = `${CDN_BASE}/public`;
+const RECENTS_KEY = "thesvg.recents";
+const RECENTS_LIMIT = 12;
 
 interface SearchMessage {
   type: "search";
@@ -13,22 +19,53 @@ interface InsertMessage {
   type: "insert";
   slug: string;
   name: string;
+  variant?: string;
 }
 
 interface LoadCategoriesMessage {
   type: "load-categories";
 }
 
-type PluginMessage = SearchMessage | InsertMessage | LoadCategoriesMessage;
+interface LoadRecentsMessage {
+  type: "load-recents";
+}
+
+interface ClearRecentsMessage {
+  type: "clear-recents";
+}
+
+interface CloseMessage {
+  type: "close";
+}
+
+type PluginMessage =
+  | SearchMessage
+  | InsertMessage
+  | LoadCategoriesMessage
+  | LoadRecentsMessage
+  | ClearRecentsMessage
+  | CloseMessage;
 
 figma.showUI(__html__, {
   width: 380,
-  height: 520,
+  height: 560,
   themeColors: true,
   title: "theSVG",
 });
 
-interface RegistryIcon {
+interface RawIcon {
+  slug: string;
+  title: string;
+  aliases?: string[];
+  hex: string;
+  categories: string[];
+  variants: Record<string, string>;
+  license: string;
+  url?: string | null;
+  collection?: string;
+}
+
+interface PluginIcon {
   slug: string;
   title: string;
   aliases: string[];
@@ -37,26 +74,56 @@ interface RegistryIcon {
   url: string | null;
   license: string;
   variants: string[];
+  variantPaths: Record<string, string>;
 }
 
-interface RegistryDocument {
-  total: number;
-  icons: RegistryIcon[];
+interface RecentEntry {
+  slug: string;
+  title: string;
+  variant: string;
+  at: number;
 }
 
-let cachedRegistry: RegistryDocument | null = null;
+let cachedCatalog: PluginIcon[] | null = null;
+let cachedCategories: Array<{ name: string; count: number }> | null = null;
 
-async function loadRegistry(): Promise<RegistryDocument> {
-  if (cachedRegistry) return cachedRegistry;
-  const res = await fetch(API_BASE + "/api/registry.json");
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
-  cachedRegistry = (await res.json()) as RegistryDocument;
-  return cachedRegistry;
+async function loadCatalog(): Promise<PluginIcon[]> {
+  if (cachedCatalog) return cachedCatalog;
+  const res = await fetch(ICONS_JSON_URL);
+  if (!res.ok) throw new Error(`CDN error: ${res.status}`);
+  const raw = (await res.json()) as RawIcon[];
+  cachedCatalog = raw.map((i) => ({
+    slug: i.slug,
+    title: i.title,
+    aliases: i.aliases || [],
+    categories: i.categories || [],
+    hex: i.hex,
+    url: i.url || null,
+    license: i.license,
+    variants: Object.keys(i.variants || { default: "" }),
+    variantPaths: i.variants || {},
+  }));
+  return cachedCatalog;
+}
+
+async function loadCategories() {
+  if (cachedCategories) return cachedCategories;
+  const catalog = await loadCatalog();
+  const counts = new Map<string, number>();
+  for (const icon of catalog) {
+    for (const c of icon.categories) {
+      counts.set(c, (counts.get(c) || 0) + 1);
+    }
+  }
+  cachedCategories = [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return cachedCategories;
 }
 
 async function searchIcons(query?: string, category?: string) {
-  const registry = await loadRegistry();
-  let icons = registry.icons;
+  const catalog = await loadCatalog();
+  let icons = catalog;
 
   if (category && category !== "all") {
     const wanted = category.toLowerCase();
@@ -77,33 +144,72 @@ async function searchIcons(query?: string, category?: string) {
 
   return {
     total: icons.length,
+    registryTotal: catalog.length,
     count: Math.min(icons.length, 100),
     limit: 100,
-    icons: icons.slice(0, 100),
+    icons: icons.slice(0, 100).map((i) => ({
+      slug: i.slug,
+      title: i.title,
+      categories: i.categories,
+      variants: i.variants,
+      variantPaths: i.variantPaths,
+    })),
   };
 }
 
-async function getIconSvg(slug: string): Promise<string> {
-  const url = `${API_BASE}/icons/${encodeURIComponent(slug)}/default.svg`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Failed to fetch SVG: ${res.status}`);
+async function fetchWithRetry(url: string, retries = 1): Promise<Response> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return res;
+      if (attempt === retries) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+    } catch (err) {
+      if (attempt === retries) throw err;
+    }
+  }
+  throw new Error("unreachable");
+}
+
+async function getIconSvg(slug: string, variant: string): Promise<string> {
+  const catalog = await loadCatalog();
+  const icon = catalog.find((i) => i.slug === slug);
+  if (!icon) throw new Error(`Unknown icon: ${slug}`);
+  const relPath = icon.variantPaths[variant] || icon.variantPaths.default;
+  if (!relPath) throw new Error(`No variant ${variant} for ${slug}`);
+  const url = `${ICONS_PATH_PREFIX}${relPath}`;
+  const res = await fetchWithRetry(url, 1);
   return res.text();
 }
 
-async function loadCategories() {
-  const res = await fetch(`${API_BASE}/api/categories.json`);
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
-  const data = await res.json();
-  return data.categories;
+async function loadRecents(): Promise<RecentEntry[]> {
+  const raw = (await figma.clientStorage.getAsync(RECENTS_KEY)) as
+    | RecentEntry[]
+    | undefined;
+  return Array.isArray(raw) ? raw : [];
+}
+
+async function pushRecent(entry: RecentEntry) {
+  const current = await loadRecents();
+  const dedup = current.filter(
+    (e) => !(e.slug === entry.slug && e.variant === entry.variant)
+  );
+  dedup.unshift(entry);
+  const trimmed = dedup.slice(0, RECENTS_LIMIT);
+  await figma.clientStorage.setAsync(RECENTS_KEY, trimmed);
+  return trimmed;
+}
+
+async function clearRecents() {
+  await figma.clientStorage.setAsync(RECENTS_KEY, []);
+  return [];
 }
 
 figma.ui.onmessage = async (msg: PluginMessage) => {
   if (msg.type === "search") {
     try {
-      const result = await searchIcons(
-        msg.query || undefined,
-        msg.category
-      );
+      const result = await searchIcons(msg.query || undefined, msg.category);
       figma.ui.postMessage({ type: "search-results", data: result });
     } catch (error) {
       const message =
@@ -113,6 +219,7 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
   }
 
   if (msg.type === "insert") {
+    const variant = msg.variant || "default";
     try {
       figma.ui.postMessage({
         type: "insert-status",
@@ -120,17 +227,22 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
         status: "loading",
       });
 
-      const svg = await getIconSvg(msg.slug);
+      const svg = await getIconSvg(msg.slug, variant);
       const node = figma.createNodeFromSvg(svg);
-      node.name = msg.name;
+      node.name = variant === "default" ? msg.name : `${msg.name} (${variant})`;
 
-      // Center in viewport
       node.x = figma.viewport.center.x - node.width / 2;
       node.y = figma.viewport.center.y - node.height / 2;
 
-      // Select and scroll to the new node
       figma.currentPage.selection = [node];
       figma.viewport.scrollAndZoomIntoView([node]);
+
+      const recents = await pushRecent({
+        slug: msg.slug,
+        title: msg.name,
+        variant,
+        at: Date.now(),
+      });
 
       figma.notify(`Inserted "${msg.name}"`);
       figma.ui.postMessage({
@@ -138,6 +250,7 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
         slug: msg.slug,
         status: "done",
       });
+      figma.ui.postMessage({ type: "recents", data: recents });
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unknown error";
@@ -157,5 +270,19 @@ figma.ui.onmessage = async (msg: PluginMessage) => {
     } catch {
       // Categories are optional, fail silently
     }
+  }
+
+  if (msg.type === "load-recents") {
+    const recents = await loadRecents();
+    figma.ui.postMessage({ type: "recents", data: recents });
+  }
+
+  if (msg.type === "clear-recents") {
+    const empty = await clearRecents();
+    figma.ui.postMessage({ type: "recents", data: empty });
+  }
+
+  if (msg.type === "close") {
+    figma.closePlugin();
   }
 };

--- a/extensions/figma/src/ui.html
+++ b/extensions/figma/src/ui.html
@@ -86,6 +86,87 @@
         text-decoration: underline;
       }
 
+      /* ---- Recents ---- */
+      .recents-section {
+        display: none;
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--figma-color-border, #e5e5e5);
+        flex-shrink: 0;
+        background: var(--figma-color-bg-secondary, #f7f7f7);
+      }
+
+      .recents-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--figma-color-text-tertiary, #999);
+      }
+
+      .recents-clear {
+        background: none;
+        border: none;
+        color: var(--figma-color-text-tertiary, #999);
+        cursor: pointer;
+        font-size: 10px;
+        font-family: inherit;
+        padding: 2px 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .recents-clear:hover {
+        color: var(--figma-color-text-secondary, #666);
+      }
+
+      .recents-row {
+        display: flex;
+        gap: 4px;
+        overflow-x: auto;
+        padding-bottom: 2px;
+      }
+
+      .recents-row::-webkit-scrollbar {
+        height: 4px;
+      }
+
+      .recents-row::-webkit-scrollbar-thumb {
+        background: var(--figma-color-border, #ddd);
+        border-radius: 2px;
+      }
+
+      .recent-card {
+        flex: 0 0 32px;
+        height: 32px;
+        border: 1px solid var(--figma-color-border, #e5e5e5);
+        border-radius: 4px;
+        background: var(--figma-color-bg, #fff);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        padding: 4px;
+        transition: border-color 0.15s, transform 0.1s;
+      }
+
+      .recent-card:hover {
+        border-color: var(--figma-color-border-brand, #18a0fb);
+      }
+
+      .recent-card:active {
+        transform: scale(0.92);
+      }
+
+      .recent-card img {
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+      }
+
       /* ---- Loading ---- */
       .loading {
         display: none;
@@ -124,19 +205,14 @@
       }
 
       .icon-card {
+        position: relative;
         display: flex;
         flex-direction: column;
-        align-items: center;
-        gap: 4px;
-        padding: 10px 4px 6px;
+        align-items: stretch;
         border: 1px solid transparent;
         border-radius: 6px;
         background: var(--figma-color-bg-secondary, #f5f5f5);
-        cursor: pointer;
         transition: all 0.15s;
-        font-family: inherit;
-        font-size: inherit;
-        color: inherit;
       }
 
       .icon-card:hover {
@@ -144,13 +220,29 @@
         background: var(--figma-color-bg-hover, #eef);
       }
 
-      .icon-card:active {
-        transform: scale(0.95);
-      }
-
       .icon-card.inserting {
         opacity: 0.5;
         pointer-events: none;
+      }
+
+      .icon-card-main {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        padding: 10px 4px 6px;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: inherit;
+        color: inherit;
+        width: 100%;
+        transition: transform 0.1s;
+      }
+
+      .icon-card-main:active {
+        transform: scale(0.95);
       }
 
       .icon-preview {
@@ -178,6 +270,86 @@
         color: var(--figma-color-text-secondary, #666);
       }
 
+      .variant-trigger {
+        position: absolute;
+        top: 4px;
+        right: 4px;
+        width: 16px;
+        height: 16px;
+        border: 1px solid var(--figma-color-border, #ddd);
+        border-radius: 4px;
+        background: var(--figma-color-bg, #fff);
+        color: var(--figma-color-text-secondary, #666);
+        font-size: 9px;
+        font-weight: 600;
+        font-family: inherit;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        opacity: 0;
+        transition: opacity 0.15s, border-color 0.15s;
+      }
+
+      .icon-card:hover .variant-trigger {
+        opacity: 1;
+      }
+
+      .variant-trigger:hover {
+        border-color: var(--figma-color-border-brand, #18a0fb);
+        color: var(--figma-color-text-brand, #18a0fb);
+      }
+
+      /* ---- Variant menu (floating) ---- */
+      .variant-menu {
+        position: fixed;
+        z-index: 100;
+        background: var(--figma-color-bg, #fff);
+        border: 1px solid var(--figma-color-border, #ddd);
+        border-radius: 6px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+        padding: 4px;
+        min-width: 140px;
+        max-width: 200px;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .variant-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 8px;
+        border: none;
+        background: transparent;
+        border-radius: 4px;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 11px;
+        color: var(--figma-color-text, #333);
+        text-align: left;
+        width: 100%;
+      }
+
+      .variant-item:hover {
+        background: var(--figma-color-bg-hover, #f0f6ff);
+      }
+
+      .variant-item img {
+        width: 20px;
+        height: 20px;
+        object-fit: contain;
+        flex-shrink: 0;
+      }
+
+      .variant-item span {
+        text-transform: capitalize;
+      }
+
+      /* ---- Empty / scrollbar ---- */
       .empty {
         grid-column: 1 / -1;
         text-align: center;
@@ -186,7 +358,6 @@
         font-size: 12px;
       }
 
-      /* ---- Scrollbar ---- */
       .grid-container::-webkit-scrollbar {
         width: 6px;
       }
@@ -212,7 +383,7 @@
           id="search"
           class="search-input"
           type="text"
-          placeholder="Search 4,000+ brand icons..."
+          placeholder="Search 6,000+ brand icons..."
           autofocus
         />
         <select id="category" class="category-select">
@@ -220,9 +391,17 @@
         </select>
       </div>
       <div class="status-bar">
-        <span id="status">Loading...</span>
+        <span id="status">Loading catalog...</span>
         <a href="https://thesvg.org" target="_blank">thesvg.org</a>
       </div>
+    </div>
+
+    <div id="recents-section" class="recents-section">
+      <div class="recents-header">
+        <span>Recent</span>
+        <button id="recents-clear" class="recents-clear" type="button">Clear</button>
+      </div>
+      <div id="recents-row" class="recents-row"></div>
     </div>
 
     <div id="loading" class="loading">

--- a/extensions/figma/src/ui.ts
+++ b/extensions/figma/src/ui.ts
@@ -1,21 +1,29 @@
 // theSVG Figma Plugin - UI thread (iframe)
-// No network requests here - all fetches happen in the sandbox (main.ts)
-// to avoid CORS issues with the null-origin iframe
+// No network requests here; all fetches happen in the sandbox (main.ts).
 
-const CDN_BASE =
-  "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
+const CDN_ROOT = "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public";
 
 interface IconEntry {
   slug: string;
   title: string;
   categories: string[];
   variants: string[];
+  variantPaths: Record<string, string>;
+}
+
+interface RecentEntry {
+  slug: string;
+  title: string;
+  variant: string;
+  at: number;
 }
 
 // ---- State ----
 let currentQuery = "";
 let currentCategory = "all";
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let lastResults: IconEntry[] = [];
+let cachedRecents: RecentEntry[] = [];
 
 // ---- DOM refs ----
 const searchInput = document.getElementById("search") as HTMLInputElement;
@@ -23,8 +31,11 @@ const categorySelect = document.getElementById("category") as HTMLSelectElement;
 const grid = document.getElementById("grid") as HTMLDivElement;
 const status = document.getElementById("status") as HTMLDivElement;
 const loading = document.getElementById("loading") as HTMLDivElement;
+const recentsSection = document.getElementById("recents-section") as HTMLDivElement;
+const recentsRow = document.getElementById("recents-row") as HTMLDivElement;
+const recentsClear = document.getElementById("recents-clear") as HTMLButtonElement;
 
-// ---- Rendering ----
+// ---- Helpers ----
 function setLoading(show: boolean) {
   loading.style.display = show ? "flex" : "none";
   if (show) {
@@ -44,6 +55,68 @@ function escapeHtml(str: string): string {
   return div.innerHTML;
 }
 
+function postToSandbox(message: unknown) {
+  parent.postMessage({ pluginMessage: message }, "*");
+}
+
+// Build a preview URL using the actual variant path from icons.json.
+// Falls back to a guessed path when we don't have variantPaths (recents).
+function previewUrl(
+  slug: string,
+  variant = "default",
+  paths?: Record<string, string>
+) {
+  if (paths) {
+    const rel = paths[variant] || paths.default;
+    if (rel) return `${CDN_ROOT}${rel}`;
+  }
+  return `${CDN_ROOT}/icons/${encodeURIComponent(slug)}/${encodeURIComponent(variant)}.svg`;
+}
+
+// ---- Insert flow ----
+function insertIcon(slug: string, title: string, variant = "default") {
+  postToSandbox({ type: "insert", slug, name: title, variant });
+}
+
+// ---- Variant menu ----
+let openVariantMenu: HTMLDivElement | null = null;
+
+function closeVariantMenu() {
+  if (openVariantMenu) {
+    openVariantMenu.remove();
+    openVariantMenu = null;
+  }
+}
+
+function showVariantMenu(
+  anchor: HTMLElement,
+  icon: IconEntry
+) {
+  closeVariantMenu();
+  const menu = document.createElement("div");
+  menu.className = "variant-menu";
+  for (const v of icon.variants) {
+    const item = document.createElement("button");
+    item.className = "variant-item";
+    item.innerHTML = `
+      <img src="${previewUrl(icon.slug, v, icon.variantPaths)}" alt="${escapeHtml(v)}" />
+      <span>${escapeHtml(v)}</span>
+    `;
+    item.addEventListener("click", (e) => {
+      e.stopPropagation();
+      insertIcon(icon.slug, icon.title, v);
+      closeVariantMenu();
+    });
+    menu.appendChild(item);
+  }
+  const rect = anchor.getBoundingClientRect();
+  menu.style.left = `${Math.min(rect.left, window.innerWidth - 200)}px`;
+  menu.style.top = `${rect.bottom + 4}px`;
+  document.body.appendChild(menu);
+  openVariantMenu = menu;
+}
+
+// ---- Rendering ----
 function renderGrid(icons: IconEntry[]) {
   grid.innerHTML = "";
 
@@ -53,55 +126,74 @@ function renderGrid(icons: IconEntry[]) {
   }
 
   for (const icon of icons) {
-    const card = document.createElement("button");
+    const card = document.createElement("div");
     card.className = "icon-card";
-    card.title = `Insert ${icon.title}`;
     card.setAttribute("data-slug", icon.slug);
 
-    // Use jsDelivr CDN for preview (no CORS/redirect issues)
-    const previewUrl = `${CDN_BASE}/${encodeURIComponent(icon.slug)}/default.svg`;
+    const hasVariants = icon.variants.length > 1;
 
     card.innerHTML = `
-      <div class="icon-preview">
-        <img src="${previewUrl}" alt="${escapeHtml(icon.title)}" loading="lazy" />
-      </div>
-      <span class="icon-name">${escapeHtml(icon.title)}</span>
+      <button class="icon-card-main" title="Insert ${escapeHtml(icon.title)}">
+        <div class="icon-preview">
+          <img src="${previewUrl(icon.slug, "default", icon.variantPaths)}" alt="${escapeHtml(icon.title)}" loading="lazy" />
+        </div>
+        <span class="icon-name">${escapeHtml(icon.title)}</span>
+      </button>
+      ${
+        hasVariants
+          ? `<button class="variant-trigger" title="${icon.variants.length} variants" aria-label="Choose variant">${icon.variants.length}</button>`
+          : ""
+      }
     `;
 
-    card.addEventListener("click", () => {
-      // Tell the sandbox to fetch + insert
-      parent.postMessage(
-        {
-          pluginMessage: {
-            type: "insert",
-            slug: icon.slug,
-            name: icon.title,
-          },
-        },
-        "*"
-      );
-    });
+    const mainBtn = card.querySelector(".icon-card-main") as HTMLButtonElement;
+    mainBtn.addEventListener("click", () =>
+      insertIcon(icon.slug, icon.title)
+    );
+
+    if (hasVariants) {
+      const trigger = card.querySelector(
+        ".variant-trigger"
+      ) as HTMLButtonElement;
+      trigger.addEventListener("click", (e) => {
+        e.stopPropagation();
+        showVariantMenu(trigger, icon);
+      });
+    }
 
     grid.appendChild(card);
+  }
+}
+
+function renderRecents(recents: RecentEntry[]) {
+  cachedRecents = recents;
+  if (recents.length === 0) {
+    recentsSection.style.display = "none";
+    return;
+  }
+  recentsSection.style.display = "flex";
+  recentsRow.innerHTML = "";
+  for (const r of recents) {
+    const card = document.createElement("button");
+    card.className = "recent-card";
+    card.title = `Reinsert ${r.title}${r.variant !== "default" ? " (" + r.variant + ")" : ""}`;
+    card.innerHTML = `<img src="${previewUrl(r.slug, r.variant)}" alt="${escapeHtml(r.title)}" />`;
+    card.addEventListener("click", () => insertIcon(r.slug, r.title, r.variant));
+    recentsRow.appendChild(card);
   }
 }
 
 // ---- Search ----
 function performSearch() {
   setLoading(true);
-  parent.postMessage(
-    {
-      pluginMessage: {
-        type: "search",
-        query: currentQuery,
-        category: currentCategory,
-      },
-    },
-    "*"
-  );
+  postToSandbox({
+    type: "search",
+    query: currentQuery,
+    category: currentCategory,
+  });
 }
 
-// ---- Message handler (responses from sandbox) ----
+// ---- Sandbox responses ----
 window.onmessage = (event: MessageEvent) => {
   const msg = event.data.pluginMessage;
   if (!msg) return;
@@ -109,16 +201,24 @@ window.onmessage = (event: MessageEvent) => {
   if (msg.type === "search-results") {
     setLoading(false);
     const data = msg.data;
+    lastResults = data.icons;
     renderGrid(data.icons);
-    setStatus(
-      `${data.total.toLocaleString()} icon${data.total !== 1 ? "s" : ""}${currentQuery ? ` matching "${currentQuery}"` : ""}`
-    );
+    const total = data.total.toLocaleString();
+    const noun = data.total === 1 ? "icon" : "icons";
+    if (currentQuery) {
+      setStatus(`${total} ${noun} matching "${currentQuery}"`);
+    } else if (currentCategory !== "all") {
+      setStatus(`${total} ${noun} in ${currentCategory}`);
+    } else {
+      setStatus(`${total} ${noun} in the catalog`);
+    }
   }
 
   if (msg.type === "search-error") {
     setLoading(false);
     setStatus(`Error: ${msg.error}`);
-    grid.innerHTML = '<div class="empty">Failed to load icons</div>';
+    grid.innerHTML =
+      '<div class="empty">Failed to load icons. Check your connection.</div>';
   }
 
   if (msg.type === "categories") {
@@ -134,14 +234,15 @@ window.onmessage = (event: MessageEvent) => {
   if (msg.type === "insert-status") {
     const card = grid.querySelector(
       `[data-slug="${msg.slug}"]`
-    ) as HTMLButtonElement | null;
+    ) as HTMLDivElement | null;
     if (card) {
-      if (msg.status === "loading") {
-        card.classList.add("inserting");
-      } else {
-        card.classList.remove("inserting");
-      }
+      if (msg.status === "loading") card.classList.add("inserting");
+      else card.classList.remove("inserting");
     }
+  }
+
+  if (msg.type === "recents") {
+    renderRecents(msg.data);
   }
 };
 
@@ -157,6 +258,47 @@ categorySelect.addEventListener("change", () => {
   performSearch();
 });
 
+recentsClear.addEventListener("click", () => {
+  postToSandbox({ type: "clear-recents" });
+});
+
+// Insert first result on Enter from the search box
+searchInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && lastResults.length > 0) {
+    e.preventDefault();
+    const first = lastResults[0];
+    insertIcon(first.slug, first.title);
+  }
+});
+
+// Global keyboard shortcuts
+window.addEventListener("keydown", (e) => {
+  // Esc: close variant menu, then close plugin
+  if (e.key === "Escape") {
+    if (openVariantMenu) {
+      closeVariantMenu();
+      e.preventDefault();
+      return;
+    }
+    postToSandbox({ type: "close" });
+    return;
+  }
+  // Cmd/Ctrl+F focuses search
+  if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+    e.preventDefault();
+    searchInput.focus();
+    searchInput.select();
+  }
+});
+
+// Click outside the variant menu closes it
+document.addEventListener("click", (e) => {
+  if (openVariantMenu && !openVariantMenu.contains(e.target as Node)) {
+    closeVariantMenu();
+  }
+});
+
 // ---- Init ----
-parent.postMessage({ pluginMessage: { type: "load-categories" } }, "*");
+postToSandbox({ type: "load-categories" });
+postToSandbox({ type: "load-recents" });
 performSearch();


### PR DESCRIPTION
Layered improvements on top of the v1.0.1 host fix, ready for resubmission.

## User-facing additions

- **Recents row** above the grid: the last 12 inserted icons, persisted across sessions via `figma.clientStorage`. A small `Clear` link wipes them.
- **Variant picker**: icons with multiple variants (color, mono, dark, light, wordmark) get a number badge in the corner on hover. Click to open a small menu with thumbnails, click one to insert that variant instead of `default`. The inserted node's name includes the variant.
- **Keyboard shortcuts**:
  - `Enter` from the search box inserts the first result
  - `Cmd/Ctrl+F` focuses search
  - `Esc` closes the variant menu, then closes the plugin on a second press
- **Initial loading status** reads `Loading catalog...` so reviewers see something immediately instead of a frozen `Loading...`
- **Retry on insert**: SVG fetches retry once on transient failure before surfacing an error toast

## Network changes (the big one)

Plugin now pulls **both the catalog and the SVG files from jsDelivr** instead of `thesvg.org`.

| | Before | After |
|---|---|---|
| Catalog source | `thesvg.org/api/registry.json` (GitHub Pages) | `cdn.jsdelivr.net/.../src/data/icons.json` |
| SVG source | `thesvg.org/icons/` (GitHub Pages) | `cdn.jsdelivr.net/.../public/icons/` |
| `allowedDomains` | `thesvg.org`, `cdn.jsdelivr.net` | `cdn.jsdelivr.net` only |

Why: jsDelivr is a Cloudflare/Fastly-backed CDN with effectively unlimited bandwidth for public OSS repos. GitHub Pages has a soft 100GB/month quota that the plugin would chew through as adoption grows. With this change:
- Plugin keeps working at full speed during peak site traffic
- thesvg.org stays available for human visitors
- Single domain in `allowedDomains` is cleaner for Figma review

Categories are now computed client-side from the catalog instead of a separate `/api/categories.json` endpoint — same UX, fewer requests.

**Trade-off**: jsDelivr caches `@main` refs for up to ~24h, so newly merged icons take up to a day to appear in the plugin. Acceptable for the use case.

## Versions

- `1.0.0` → original submission (broken by API host redirect)
- `1.0.1` → host fix (PR #343, already merged)
- `1.2.0` → this PR

## Resubmit

After merge:
```bash
git pull
cd extensions/figma && npm install && npm run build
```
Then Figma Desktop → Plugins → Manage plugins → Publish update.