### PR TITLE
fix(seo): sitemap.xml, visible h1, trimmed meta, structured data, hero CLS

### DIFF
--- a/src/app/icon/[slug]/page.tsx
+++ b/src/app/icon/[slug]/page.tsx
@@ -18,6 +18,55 @@ export const dynamicParams = false;
 
 const CDN_BASE = "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 
+// Map our string licenses to canonical URLs so structured data passes
+// Google's "Invalid URL in field 'license'" check.
+const LICENSE_URLS: Record<string, string> = {
+  "CC0-1.0": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "MIT": "https://spdx.org/licenses/MIT.html",
+  "CC-BY-ND-2.0": "https://creativecommons.org/licenses/by-nd/2.0/",
+  "CC-BY-ND-4.0": "https://creativecommons.org/licenses/by-nd/4.0/",
+  "CC-BY-4.0": "https://creativecommons.org/licenses/by/4.0/",
+  "CC-BY-3.0": "https://creativecommons.org/licenses/by/3.0/",
+  "CC-BY-2.5": "https://creativecommons.org/licenses/by/2.5/",
+  "CC-BY-SA-4.0": "https://creativecommons.org/licenses/by-sa/4.0/",
+  "CC-BY-SA-3.0": "https://creativecommons.org/licenses/by-sa/3.0/",
+  "CC-BY-SA-2.5": "https://creativecommons.org/licenses/by-sa/2.5/",
+  "CC-BY-SA-2.0": "https://creativecommons.org/licenses/by-sa/2.0/",
+  "CC-BY-NC-4.0": "https://creativecommons.org/licenses/by-nc/4.0/",
+  "CC-BY-NC-SA-4.0": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+  "CC-BY-NC-SA-3.0": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+  "CC-BY-NC-ND-4.0": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+  "Apache-2.0": "https://spdx.org/licenses/Apache-2.0.html",
+  "GPL-2.0": "https://spdx.org/licenses/GPL-2.0-only.html",
+  "GPL-2.0-only": "https://spdx.org/licenses/GPL-2.0-only.html",
+  "GPL-2.0-or-later": "https://spdx.org/licenses/GPL-2.0-or-later.html",
+  "GPL-3.0": "https://spdx.org/licenses/GPL-3.0-only.html",
+  "GPL-3.0-only": "https://spdx.org/licenses/GPL-3.0-only.html",
+  "GPL-3.0-or-later": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+  "LGPL-2.1": "https://spdx.org/licenses/LGPL-2.1-only.html",
+  "LGPL-3.0": "https://spdx.org/licenses/LGPL-3.0-only.html",
+  "AGPL-3.0": "https://spdx.org/licenses/AGPL-3.0-only.html",
+  "AGPL-3.0-only": "https://spdx.org/licenses/AGPL-3.0-only.html",
+  "AGPL-3.0-or-later": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+  "MPL-2.0": "https://spdx.org/licenses/MPL-2.0.html",
+  "BSD-2-Clause": "https://spdx.org/licenses/BSD-2-Clause.html",
+  "BSD-3-Clause": "https://spdx.org/licenses/BSD-3-Clause.html",
+  "Unlicense": "https://spdx.org/licenses/Unlicense.html",
+  "PD": "https://creativecommons.org/publicdomain/mark/1.0/",
+  "brand-use": "https://thesvg.org/legal#trademark",
+  "Fair Use": "https://thesvg.org/legal#fair-use",
+  "Fair use": "https://thesvg.org/legal#fair-use",
+  "Custom": "https://thesvg.org/legal",
+  "Proprietary": "https://thesvg.org/legal#trademark",
+  "Unknown": "https://thesvg.org/legal",
+  "TODO": "https://thesvg.org/legal",
+};
+
+function licenseToUrl(license: string | undefined): string {
+  if (!license) return "https://thesvg.org/legal";
+  return LICENSE_URLS[license] || "https://thesvg.org/legal";
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const icon = getIconBySlug(slug);
@@ -120,6 +169,8 @@ export default async function IconPage({ params }: PageProps) {
     "free download",
     "open source",
   ];
+  const licenseUrl = licenseToUrl(icon.license);
+  const year = new Date().getFullYear();
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
@@ -132,7 +183,10 @@ export default async function IconPage({ params }: PageProps) {
         thumbnailUrl: `${CDN_BASE}/${slug}/default.svg`,
         url: `https://thesvg.org/icon/${slug}`,
         encodingFormat: "image/svg+xml",
-        license: icon.license,
+        license: licenseUrl,
+        acquireLicensePage: "https://thesvg.org/legal",
+        copyrightNotice: `${icon.title} logo © ${year} ${icon.title}. Distributed under ${icon.license}.`,
+        creditText: icon.title,
         width: "512",
         height: "512",
         ...(icon.url ? { sameAs: [icon.url] } : {}),
@@ -141,6 +195,11 @@ export default async function IconPage({ params }: PageProps) {
           "@type": "Organization",
           name: "theSVG",
           url: "https://thesvg.org",
+        },
+        copyrightHolder: {
+          "@type": "Organization",
+          name: icon.title,
+          ...(icon.url ? { url: icon.url } : {}),
         },
       },
       {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     default: `theSVG - ${count}+ Free Brand SVG Icons for Developers and Designers`,
     template: "%s | theSVG",
   },
-  description: `Search, copy, and ship ${count}+ brand SVG icons. Free, open-source library with npm packages, React components, CLI, CDN, and MCP server. Tree-shakeable, typed, zero config.`,
+  description: `Search, copy, and ship ${count}+ brand SVG icons. Open-source library with npm, React, Vue, Svelte, CLI, CDN, and MCP server support.`,
   keywords: [
     "svg",
     "brand icons",
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://thesvg.org"),
   openGraph: {
     title: `theSVG - ${count}+ Free Brand SVG Icons for Developers and Designers`,
-    description: `Search, copy, and ship ${count}+ brand SVG icons. Free, open-source library with npm packages, React components, CLI, CDN, and MCP server for AI assistants.`,
+    description: `Search, copy, and ship ${count}+ brand SVG icons. Open-source library with npm, React, Vue, Svelte, CLI, CDN, and MCP server support.`,
     url: "https://thesvg.org",
     siteName: "theSVG",
     type: "website",
@@ -64,7 +64,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: `theSVG - ${count}+ Free Brand SVG Icons for Developers and Designers`,
-    description: `Search, copy, and ship ${count}+ brand SVG icons. Free, open-source library with npm packages, React components, CLI, CDN, and MCP server for AI assistants.`,
+    description: `Search, copy, and ship ${count}+ brand SVG icons. Open-source library with npm, React, Vue, Svelte, CLI, CDN, and MCP server support.`,
     images: ["/og-image.png"],
   },
   manifest: "/manifest.json",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,74 +8,50 @@ const BASE_URL = "https://thesvg.org";
 const CDN_BASE =
   "https://cdn.jsdelivr.net/gh/glincker/thesvg@main/public/icons";
 
-// Next.js will generate /sitemap/0.xml, /sitemap/1.xml, etc.
-// Sitemaps: 0=static pages, 1=brands, 2=aws, 3=azure, 4=gcp
-export async function generateSitemaps() {
-  return [
-    { id: 0 }, // static pages
-    { id: 1 }, // brand icons
-    { id: 2 }, // aws icons
-    { id: 3 }, // azure icons
-    { id: 4 }, // gcp icons
-  ];
-}
-
-export default function sitemap({ id }: { id: number }): MetadataRoute.Sitemap {
+// Single sitemap output at /sitemap.xml. We previously used generateSitemaps
+// to shard by collection, but that path doesn't export cleanly with
+// output: "export" on GitHub Pages (the sharded files end up at
+// /sitemap/N.xml and the index is missing), so robots.txt-discovery breaks.
+// One sitemap fits comfortably under the 50,000-URL and 50MB Google limits
+// for our ~6,030 icons + the static pages.
+export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const icons = getAllIcons();
 
-  if (id === 0) {
-    // Static pages only - category ?category=foo querystrings are omitted
-    // as they are duplicate content of / from a search engine perspective.
-    const staticPages: MetadataRoute.Sitemap = [
-      { url: BASE_URL, lastModified: now, changeFrequency: "daily", priority: 1.0 },
-      { url: `${BASE_URL}/categories`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
-      { url: `${BASE_URL}/compare`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
-      { url: `${BASE_URL}/extensions`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
-      { url: `${BASE_URL}/submit`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
-      { url: `${BASE_URL}/blog`, lastModified: now, changeFrequency: "weekly" as const, priority: 0.8 },
-      { url: `${BASE_URL}/legal`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
-      { url: `${BASE_URL}/contact`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
-    ];
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: BASE_URL, lastModified: now, changeFrequency: "daily", priority: 1.0 },
+    { url: `${BASE_URL}/categories`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/compare`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE_URL}/extensions`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE_URL}/submit`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${BASE_URL}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE_URL}/legal`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+    { url: `${BASE_URL}/contact`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+  ];
 
-    const blogPages: MetadataRoute.Sitemap = (
-      postsData as { slug: string; date: string }[]
-    ).map((post) => ({
-      url: `${BASE_URL}/blog/${post.slug}`,
-      lastModified: new Date(post.date),
-      changeFrequency: "monthly" as const,
-      priority: 0.7,
-    }));
+  const collectionPages: MetadataRoute.Sitemap = [
+    { url: `${BASE_URL}/collection/brands`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/collection/aws`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE_URL}/collection/azure`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE_URL}/collection/gcp`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+  ];
 
-    // Collection landing pages (proper URL paths for indexing)
-    const collectionPages: MetadataRoute.Sitemap = [
-      { url: `${BASE_URL}/collection/brands`, lastModified: now, changeFrequency: "weekly" as const, priority: 0.9 },
-      { url: `${BASE_URL}/collection/aws`, lastModified: now, changeFrequency: "monthly" as const, priority: 0.9 },
-      { url: `${BASE_URL}/collection/azure`, lastModified: now, changeFrequency: "monthly" as const, priority: 0.9 },
-      { url: `${BASE_URL}/collection/gcp`, lastModified: now, changeFrequency: "monthly" as const, priority: 0.9 },
-    ];
+  const blogPages: MetadataRoute.Sitemap = (
+    postsData as { slug: string; date: string }[]
+  ).map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.date),
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
 
-    return [...staticPages, ...collectionPages, ...blogPages];
-  }
+  const iconPages: MetadataRoute.Sitemap = icons.map((icon) => ({
+    url: `${BASE_URL}/icon/${icon.slug}`,
+    lastModified: icon.dateAdded ? new Date(icon.dateAdded) : now,
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+    images: [`${CDN_BASE}/${icon.slug}/default.svg`],
+  }));
 
-  // Map id to collection
-  const collectionMap: Record<number, string> = {
-    1: "brands",
-    2: "aws",
-    3: "azure",
-    4: "gcp",
-  };
-
-  const collection = collectionMap[id];
-  if (!collection) return [];
-
-  return icons
-    .filter((icon) => icon.collection === collection)
-    .map((icon) => ({
-      url: `${BASE_URL}/icon/${icon.slug}`,
-      lastModified: icon.dateAdded ? new Date(icon.dateAdded) : now,
-      changeFrequency: "monthly" as const,
-      priority: 0.8,
-      images: [`${CDN_BASE}/${icon.slug}/default.svg`],
-    }));
+  return [...staticPages, ...collectionPages, ...blogPages, ...iconPages];
 }

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -365,9 +365,6 @@ export function HomeHero({
 
   return (
     <div className="space-y-8 pb-6">
-      {/* Visually hidden h1 for screen readers and SEO */}
-      <h1 className="sr-only">thesvg - The Open SVG Brand Library</h1>
-
       {/* Hero carousel - lifted card with depth */}
       <div className="relative">
         {/* Bottom shadow layer for lifted effect */}
@@ -382,7 +379,10 @@ export function HomeHero({
           {/* Top highlight edge */}
           <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/10" />
 
-          <div className="relative z-10 max-w-2xl">
+          {/* Min-height reserves space so rotating slide titles/descriptions
+              of different lengths don't trigger Cumulative Layout Shift.
+              Sized to the longest expected slide content. */}
+          <div className="relative z-10 max-w-2xl min-h-[220px] sm:min-h-[240px]">
             {/* Slide content with fade */}
             <div key={currentSlide} className="animate-fade-in">
               <div className={`mb-3 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium shadow-sm ${slide.accent}`}>
@@ -391,9 +391,9 @@ export function HomeHero({
                   ? `${count.toLocaleString()}+ icons`
                   : slide.badge}
               </div>
-              <h2 className="mb-2 text-2xl font-bold tracking-tight sm:text-3xl">
+              <h1 className="mb-2 text-2xl font-bold tracking-tight sm:text-3xl">
                 {slide.title}
-              </h2>
+              </h1>
               <p className="mb-6 max-w-lg text-sm leading-relaxed text-muted-foreground sm:text-base">
                 {slide.description}
               </p>


### PR DESCRIPTION
Five fixes batched, each surfaced by a different audit you ran today.

### 1. `sitemap.xml` resolves again

The previous setup used `generateSitemaps()` to shard by collection, but `output: 'export'` on GitHub Pages doesn't emit the index file at `/sitemap.xml` — shards landed at `/sitemap/N.xml` and the index was a 404 (which is what `robots.txt` points at). All five shards were also empty (only the XML wrapper, no `<url>` entries).

Collapsed to a single `sitemap()` default export. Our ~6,030 icons + static pages fits comfortably under Google's 50,000-URL / 50 MB caps.

### 2. Visible `<h1>` on the home page

Removed the `sr-only` h1 and promoted the hero carousel's slide title from `<h2>` to `<h1>`. Only one h1 per page; the rest stay h2.

### 3. Meta description trimmed from 188 → 130 chars

Now fits Google's snippet cap. Same shortened copy used on the OG and Twitter card descriptions.

### 4. `ImageObject` structured data on icon pages

Addresses the GSC enhancements report (126x missing fields, 24x invalid URL):

- `license` is now a real URL (mapped via `LICENSE_URLS` table) instead of the raw SPDX string
- `acquireLicensePage` → `/legal`
- `copyrightNotice` with the brand owner and license
- `creditText` with the brand name
- `copyrightHolder` organization with the brand URL

### 5. Hero CLS

Hero carousel got a `min-h-[220px] sm:min-h-[240px]` so rotating slide titles and descriptions of different lengths don't shove the rest of the page. PageSpeed had this at **CLS 0.312** on desktop; this should drop it toward the under-0.1 target.

## Test plan after merge

- [ ] Once Pages deploys, `curl -I https://thesvg.org/sitemap.xml` returns 200 with content-type `application/xml`
- [ ] View source of homepage, confirm exactly one `<h1>` element
- [ ] View source of any icon page, search JSON-LD for `acquireLicensePage`, `copyrightNotice`, `creditText`
- [ ] Re-run PageSpeed; CLS on desktop home page drops below 0.1
- [ ] In ~3-7 days, the GSC enhancements report should clear the "missing field" warnings