### PR TITLE
docs: add skills.sh badge and install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://www.figma.com/community/plugin/1612997159050367763"><img src="https://img.shields.io/badge/Figma-Plugin-F24E1E?style=flat-square&logo=figma&logoColor=white" alt="Figma" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/visual-studio-marketplace/v/glincker.thesvg?style=flat-square&color=007ACC&label=VS%20Code&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
+  <a href="https://skills.sh/glincker/thesvg"><img src="https://skills.sh/b/glincker/thesvg" alt="skills.sh" /></a>
 </p>
 
 <p align="center">
@@ -117,7 +118,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 | [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,030+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
-| [Agent Skill](./skills/thesvg/SKILL.md) | Published | Drop-in skill file for Claude Code, Cursor, and other AI agents. Teaches the icon CDN and registry. |
+| [Agent Skill](https://skills.sh/glincker/thesvg) | Published | Drop-in skill for AI agents. Install via `npx skills add glincker/thesvg`. Teaches the icon CDN and registry. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |
 | [CDN via jsDelivr](https://www.jsdelivr.com/package/gh/glincker/thesvg) | Published | Serve any icon via global CDN. Drop into HTML, CSS, Markdown, Notion, Webflow, Framer. |
 | [JetBrains](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | IntelliJ, WebStorm, PyCharm, Rider tool window. Help wanted. |

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -234,10 +234,10 @@ const CATEGORIES: Category[] = [
       },
       {
         name: "Agent Skill",
-        description: "Drop-in skill for Claude Code, Cursor, and other AI agents. Teaches your agent the icon CDN and registry in one file.",
+        description: "Drop-in skill for Claude Code, Cursor, and other AI agents. Install via skills.sh: npx skills add glincker/thesvg",
         status: "available",
-        cta: "View skill",
-        href: "https://github.com/GLINCKER/thesvg/blob/main/skills/thesvg/SKILL.md",
+        cta: "View on skills.sh",
+        href: "https://skills.sh/glincker/thesvg",
         iconFallback: <Sparkles className="h-6 w-6 text-muted-foreground" />,
       },
       {


### PR DESCRIPTION
## Summary

- Adds the official skills.sh install-count badge to the README badge row.
- README extensions table and \`/extensions\` Agent Skill card now point to the skills.sh listing and surface the install command \`npx skills add glincker/thesvg\`.

## Indexing note

The badge currently renders as **resource not found** because skills.sh has not indexed the repo yet. The vercel-labs auto-discovery scans GitHub for repos tagged with the \`skills\` topic. I added two topics on the repo settings (\`skills\` and \`agent-skills\`) to make us discoverable, dropping the singular dups \`brand\` and \`logo\` to stay under the 20-topic cap. Once skills.sh re-crawls the topic, the badge will start showing an install count.

## Files

- \`README.md\` (badge row + extensions table row)
- \`src/app/extensions/page.tsx\` (Agent Skill card CTA and copy)

## Test plan

- [x] README renders on GitHub
- [ ] Verify the badge URL responds (currently 404 as expected, will activate after indexing)
- [ ] Confirm \`/extensions\` Agent Skill card shows the new copy and CTA in the deploy preview