### PR TITLE
feat: add Homebrew tap (extensions/homebrew)

### DIFF
--- a/.github/workflows/homebrew-tap-update.yml
+++ b/.github/workflows/homebrew-tap-update.yml
@@ -1,0 +1,39 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-formula:
+    name: Bump thesvg formula
+    runs-on: ubuntu-latest
+    if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read CLI version from package.json
+        id: pkg
+        run: |
+          VERSION=$(jq -r '.version' packages/cli/package.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          TARBALL_URL="https://registry.npmjs.org/@thesvg/cli/-/cli-${VERSION}.tgz"
+          echo "tarball_url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          SHA=$(curl -fsSL "${{ steps.pkg.outputs.tarball_url }}" | sha256sum | awk '{print $1}')
+          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Update formula in tap repo
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          tap: glincker/thesvg
+          formula: thesvg
+          tag: v${{ steps.pkg.outputs.version }}
+          revision: ${{ github.sha }}
+          force: false

--- a/.github/workflows/homebrew-tap-update.yml
+++ b/.github/workflows/homebrew-tap-update.yml
@@ -19,14 +19,6 @@ jobs:
         run: |
           VERSION=$(jq -r '.version' packages/cli/package.json)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          TARBALL_URL="https://registry.npmjs.org/@thesvg/cli/-/cli-${VERSION}.tgz"
-          echo "tarball_url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
-
-      - name: Compute SHA256
-        id: sha
-        run: |
-          SHA=$(curl -fsSL "${{ steps.pkg.outputs.tarball_url }}" | sha256sum | awk '{print $1}')
-          echo "sha256=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Update formula in tap repo
         uses: dawidd6/action-homebrew-bump-formula@v3
@@ -35,5 +27,4 @@ jobs:
           tap: glincker/thesvg
           formula: thesvg
           tag: v${{ steps.pkg.outputs.version }}
-          revision: ${{ github.sha }}
           force: false

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/visual-studio-marketplace/v/glincker.thesvg?style=flat-square&color=007ACC&label=VS%20Code&logo=visualstudiocode" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
   <a href="https://skills.sh/glincker/thesvg"><img src="https://skills.sh/b/glincker/thesvg" alt="skills.sh" /></a>
+  <a href="https://github.com/glincker/homebrew-thesvg"><img src="https://img.shields.io/badge/Homebrew-thesvg-FBB040?style=flat-square&logo=homebrew&logoColor=white" alt="Homebrew" /></a>
 </p>
 
 <p align="center">
@@ -77,8 +78,17 @@ Browse all AWS service and resource icons at [thesvg.org/collection/aws](https:/
 
 ## Install
 
+**npm**
+
 ```bash
 npm install thesvg
+```
+
+**Homebrew**
+
+```bash
+brew tap glincker/thesvg
+brew install thesvg
 ```
 
 ```ts
@@ -120,6 +130,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [Agent Skill](https://skills.sh/glincker/thesvg) | Published | Drop-in skill for AI agents. Install via `npx skills add glincker/thesvg`. Teaches the icon CDN and registry. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |
+| [Homebrew](https://github.com/glincker/homebrew-thesvg) | Published | `brew tap glincker/thesvg && brew install thesvg` |
 | [CDN via jsDelivr](https://www.jsdelivr.com/package/gh/glincker/thesvg) | Published | Serve any icon via global CDN. Drop into HTML, CSS, Markdown, Notion, Webflow, Framer. |
 | [JetBrains](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | IntelliJ, WebStorm, PyCharm, Rider tool window. Help wanted. |
 | [Neovim](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | Telescope picker with floating preview. Help wanted. |

--- a/extensions/homebrew/.gitignore
+++ b/extensions/homebrew/.gitignore
@@ -1,0 +1,2 @@
+*.bottle.tar.gz
+*.bottle.json

--- a/extensions/homebrew/Formula/thesvg.rb
+++ b/extensions/homebrew/Formula/thesvg.rb
@@ -1,0 +1,18 @@
+class Thesvg < Formula
+  desc "Browse and install brand SVG icons from theSVG (thesvg.org)"
+  homepage "https://thesvg.org"
+  url "https://registry.npmjs.org/@thesvg/cli/-/cli-0.5.4.tgz"
+  sha256 "fa4f3d190348cce2010fbb70f996b46559889c6d98059f16c953b83526440a24"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "thesvg", shell_output("#{bin}/thesvg --help 2>&1", 0)
+  end
+end

--- a/extensions/homebrew/README.md
+++ b/extensions/homebrew/README.md
@@ -1,0 +1,27 @@
+# thesvg Homebrew Tap
+
+Install the thesvg CLI via [Homebrew](https://brew.sh).
+
+```sh
+brew tap glincker/thesvg
+brew install thesvg
+```
+
+Then use it:
+
+```sh
+thesvg add github
+thesvg add --format react stripe
+```
+
+## Maintenance
+
+The formula is kept in sync by the `homebrew-tap-update` workflow in this repo.
+It fires on each published release and pushes an updated formula to
+[glincker/homebrew-thesvg](https://github.com/glincker/homebrew-thesvg).
+
+Before the workflow can run, a repository maintainer must:
+
+1. Create the tap repo at `github.com/glincker/homebrew-thesvg`.
+2. Add a fine-grained PAT with `contents: write` on that repo as the
+   `HOMEBREW_TAP_TOKEN` secret in the main repo settings.

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -209,6 +209,14 @@ const CATEGORIES: Category[] = [
         iconSlug: "jsdelivr",
       },
       {
+        name: "Homebrew",
+        description: "Install the thesvg CLI via Homebrew. brew tap glincker/thesvg && brew install thesvg.",
+        status: "available",
+        cta: "brew tap",
+        href: "https://github.com/glincker/homebrew-thesvg",
+        iconSlug: "homebrew",
+      },
+      {
         name: "REST API",
         description: "Paid API coming soon at api.thesvg.org. Search, fetch metadata, retrieve SVGs programmatically.",
         status: "coming-soon",


### PR DESCRIPTION
## Summary

- Adds \`extensions/homebrew/Formula/thesvg.rb\` wrapping \`@thesvg/cli\` as a Node-based Homebrew formula
- Adds \`.github/workflows/homebrew-tap-update.yml\` to auto-sync the formula on every published release
- Adds a Homebrew badge, install subsection, and Extensions table row to the main \`README.md\`
- Adds a Homebrew card to the Developer Tools section of \`/extensions\`

## Files

- \`extensions/homebrew/Formula/thesvg.rb\`
- \`extensions/homebrew/README.md\`
- \`extensions/homebrew/.gitignore\`
- \`.github/workflows/homebrew-tap-update.yml\`
- \`README.md\`
- \`src/app/extensions/page.tsx\`

## Before the auto-update workflow can run (maintainer actions)

1. Create the tap repo at \`github.com/glincker/homebrew-thesvg\` and seed it with \`Formula/thesvg.rb\`.
2. Add a fine-grained PAT (contents: write on that repo) as the \`HOMEBREW_TAP_TOKEN\` secret in this repo's settings. Until then the workflow is soft-gated and will no-op.

End-user install command after the tap is live:
\`\`\`
brew tap glincker/thesvg
brew install thesvg
\`\`\`

## Test plan

- [x] Formula syntax valid (Ruby class, std_npm_args, depends_on node, test block)
- [x] SHA256 verified against the live npm tarball for the pinned version
- [x] Workflow uses soft gate \`if: \${{ secrets.HOMEBREW_TAP_TOKEN != '' }}\`
- [x] No em dashes anywhere
- [ ] Tap repo \`glincker/homebrew-thesvg\` created by maintainer
- [ ] \`HOMEBREW_TAP_TOKEN\` secret set in repo settings
- [ ] End-to-end brew install smoke-test on macOS