### PR TITLE
fix(ci): publish via npm directly so readme renders on npmjs.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,17 @@ jobs:
           cd packages/svelte && npm run build && cd ../..
 
       - name: Publish to npm
-        # Use `npm publish` per-package instead of `pnpm changeset publish`.
-        # pnpm publish includes README.md in the tarball but does not populate
-        # the `readme` field on the per-version registry manifest, which is
-        # what npmjs.com renders. Publishing with npm directly fixes that.
+        # pnpm changeset publish ships README.md inside the tarball but does
+        # not populate the per-version `readme` field on the npm registry
+        # manifest, which is what npmjs.com renders. To get both correct
+        # readme rendering AND pnpm's workspace-protocol rewriting, we
+        # `pnpm pack` each package (which rewrites `workspace:*` -> real
+        # versions) and then `npm publish <tarball>` (which populates the
+        # readme field on the registry manifest).
         run: |
-          for PKG_DIR in packages/icons packages/thesvg packages/cli packages/mcp packages/react packages/vue packages/svelte; do
-            if [ ! -d "$PKG_DIR" ]; then continue; fi
+          for PKG_DIR in packages/*/; do
+            PKG_DIR="${PKG_DIR%/}"
+            [ -f "$PKG_DIR/package.json" ] || continue
             PKG_NAME=$(node -p "require('./$PKG_DIR/package.json').name")
             PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
             PKG_PRIVATE=$(node -p "require('./$PKG_DIR/package.json').private || false")
@@ -71,16 +75,20 @@ jobs:
               echo "Skipping $PKG_NAME (private)"
               continue
             fi
-            # Skip if this exact version is already on the registry
             if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
               echo "Skipping $PKG_NAME@$PKG_VERSION (already published)"
               continue
             fi
-            echo "Publishing $PKG_NAME@$PKG_VERSION"
-            (cd "$PKG_DIR" && npm publish --access public --provenance)
+            echo "Packing and publishing $PKG_NAME@$PKG_VERSION"
+            (
+              cd "$PKG_DIR"
+              # pnpm pack rewrites workspace:* deps to concrete versions
+              TARBALL=$(pnpm pack 2>/dev/null | tail -1)
+              # npm publish populates the readme field on the registry manifest
+              npm publish "$TARBALL" --access public --provenance
+              rm -f "$TARBALL"
+            )
           done
-        env:
-          NPM_CONFIG_PROVENANCE: "true"
 
       - name: Create git tags
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,28 @@ jobs:
           cd packages/svelte && npm run build && cd ../..
 
       - name: Publish to npm
-        run: pnpm changeset publish
+        # Use `npm publish` per-package instead of `pnpm changeset publish`.
+        # pnpm publish includes README.md in the tarball but does not populate
+        # the `readme` field on the per-version registry manifest, which is
+        # what npmjs.com renders. Publishing with npm directly fixes that.
+        run: |
+          for PKG_DIR in packages/icons packages/thesvg packages/cli packages/mcp packages/react packages/vue packages/svelte; do
+            if [ ! -d "$PKG_DIR" ]; then continue; fi
+            PKG_NAME=$(node -p "require('./$PKG_DIR/package.json').name")
+            PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
+            PKG_PRIVATE=$(node -p "require('./$PKG_DIR/package.json').private || false")
+            if [ "$PKG_PRIVATE" = "true" ]; then
+              echo "Skipping $PKG_NAME (private)"
+              continue
+            fi
+            # Skip if this exact version is already on the registry
+            if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+              echo "Skipping $PKG_NAME@$PKG_VERSION (already published)"
+              continue
+            fi
+            echo "Publishing $PKG_NAME@$PKG_VERSION"
+            (cd "$PKG_DIR" && npm publish --access public --provenance)
+          done
         env:
           NPM_CONFIG_PROVENANCE: "true"
 


### PR DESCRIPTION
## Problem
`@thesvg/icons`, `@thesvg/react`, `@thesvg/svelte`, `@thesvg/vue`, and `thesvg` all show "This package does not have a README" on npmjs.com despite each package having a `README.md` in its `files` array.

Verification:
- `npm pack @thesvg/icons@3.0.9 --dry-run` shows README.md (4098 bytes) IS in the tarball.
- `curl https://registry.npmjs.org/@thesvg/icons | jq '.versions["3.0.9"] | has("readme")'` returns `false`.
- All five most recent versions (3.0.5-3.0.9) have `readme_len=0` on their per-version manifest.

This is a long-standing `pnpm changeset publish` quirk: it bundles README.md into the tarball but doesn't populate the `readme` field on the per-version registry manifest that npmjs.com renders.

## Fix
Switch the publish step to a per-package `npm publish --access public --provenance` loop:
- Skips private packages and already-published versions (idempotent, safe to retry)
- Provenance + OIDC auth path unchanged (uses the same `id-token: write` permission and registry-url setup that pnpm was using)
- Order matches the build loop above

## Test plan
- [ ] On next release, verify `curl https://registry.npmjs.org/@thesvg/icons | jq '.versions | to_entries | last | .value | has("readme")'` returns `true`
- [ ] Confirm npmjs.com page shows the README content
- [ ] Provenance badges still appear on the published version pages