### PR TITLE
fix(ci): wire homebrew tap auto-bump + per-package GH releases with changelog notes

### DIFF
--- a/.github/workflows/homebrew-tap-update.yml
+++ b/.github/workflows/homebrew-tap-update.yml
@@ -54,6 +54,8 @@ jobs:
         uses: dawidd6/action-homebrew-bump-formula@v7
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # Homebrew tap naming: 'glincker/thesvg' resolves to the repo
+          # 'glincker/homebrew-thesvg' (the standard tap convention).
           tap: glincker/thesvg
           formula: thesvg
           tag: "@thesvg/cli@${{ steps.pkg.outputs.version }}"

--- a/.github/workflows/homebrew-tap-update.yml
+++ b/.github/workflows/homebrew-tap-update.yml
@@ -3,28 +3,58 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "CLI version to bump to (defaults to packages/cli/package.json)"
+        required: false
+        type: string
 
 jobs:
   bump-formula:
     name: Bump thesvg formula
     runs-on: ubuntu-latest
-    if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+    # Only fire for the @thesvg/cli release tag (skip per-package releases for
+    # other workspace packages). On manual dispatch the gate is bypassed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, '@thesvg/cli@')
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Read CLI version from package.json
+      - name: Resolve CLI version
         id: pkg
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          VERSION=$(jq -r '.version' packages/cli/package.json)
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION=$(jq -r '.version' packages/cli/package.json)
+          fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved CLI version: ${VERSION}"
+
+      - name: Check secret present
+        id: gate
+        env:
+          HAS_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        run: |
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "HOMEBREW_TAP_TOKEN is not configured; skipping formula bump."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Update formula in tap repo
+        if: steps.gate.outputs.skip == 'false'
         uses: dawidd6/action-homebrew-bump-formula@v7
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           tap: glincker/thesvg
           formula: thesvg
-          tag: v${{ steps.pkg.outputs.version }}
+          tag: "@thesvg/cli@${{ steps.pkg.outputs.version }}"
           force: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,21 +110,82 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create GitHub release for CLI
-        # The Homebrew tap auto-bump workflow listens for `release: published`,
-        # so we create a GH release specifically for the @thesvg/cli tag.
-        # Other packages get git tags only (above).
+      - name: Create GitHub releases per package
+        # Create one GitHub release per just-published package, with the
+        # release body sourced from that package's CHANGELOG.md section
+        # for the current version. This:
+        #   1. Fires `on: release: published` for downstream automations
+        #      (e.g. homebrew-tap-update, which gates on @thesvg/cli@*).
+        #   2. Gives each package a discoverable release page on GitHub
+        #      with the changeset entries that landed in that version.
         run: |
-          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
-          CLI_TAG="@thesvg/cli@${CLI_VERSION}"
-          if ! gh release view "$CLI_TAG" >/dev/null 2>&1; then
-            echo "Creating GitHub release for $CLI_TAG"
-            gh release create "$CLI_TAG" \
-              --title "@thesvg/cli ${CLI_VERSION}" \
-              --notes "Automated release for @thesvg/cli@${CLI_VERSION}. Triggers the homebrew-tap-update workflow." \
+          set -e
+          # Extract the section between `## <version>` and the next `## ` (or EOF)
+          # from a changesets-generated CHANGELOG.md. Echoes nothing if the
+          # section is absent.
+          extract_section() {
+            local file="$1" version="$2"
+            awk -v ver="## ${version}" '
+              $0 == ver { capture = 1; next }
+              capture && /^## / { exit }
+              capture { print }
+            ' "$file"
+          }
+
+          for PKG_DIR in packages/*/; do
+            PKG_DIR="${PKG_DIR%/}"
+            [ -f "$PKG_DIR/package.json" ] || continue
+            PKG_NAME=$(node -p "require('./$PKG_DIR/package.json').name")
+            PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
+            PKG_PRIVATE=$(node -p "require('./$PKG_DIR/package.json').private || false")
+            if [ "$PKG_PRIVATE" = "true" ]; then continue; fi
+
+            TAG="$PKG_NAME@$PKG_VERSION"
+
+            # Only create a release if the git tag exists (created above)
+            # and the release doesn't already exist.
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "Skipping $TAG (no git tag)"
+              continue
+            fi
+            if gh release view "$TAG" >/dev/null 2>&1; then
+              echo "Skipping $TAG (release exists)"
+              continue
+            fi
+
+            # Build release body from CHANGELOG.md section
+            CHANGELOG="$PKG_DIR/CHANGELOG.md"
+            BODY_FILE="$(mktemp)"
+            {
+              echo "## $PKG_NAME $PKG_VERSION"
+              echo
+              if [ -f "$CHANGELOG" ]; then
+                SECTION=$(extract_section "$CHANGELOG" "$PKG_VERSION")
+                if [ -n "$SECTION" ]; then
+                  echo "$SECTION"
+                else
+                  echo "_No changelog entry found for version $PKG_VERSION._"
+                fi
+              else
+                echo "_Package has no CHANGELOG.md._"
+              fi
+              echo
+              echo "---"
+              echo
+              if [ "$PKG_NAME" = "@thesvg/cli" ]; then
+                echo "Install: \`brew install glincker/thesvg/thesvg\` or \`npm i -g @thesvg/cli\`"
+              else
+                echo "Install: \`npm i $PKG_NAME@$PKG_VERSION\`"
+              fi
+              echo "Tarball: https://registry.npmjs.org/$PKG_NAME/-/$(basename $PKG_NAME)-$PKG_VERSION.tgz"
+            } > "$BODY_FILE"
+
+            echo "Creating GitHub release for $TAG"
+            gh release create "$TAG" \
+              --title "$PKG_NAME $PKG_VERSION" \
+              --notes-file "$BODY_FILE" \
               --verify-tag
-          else
-            echo "Release $CLI_TAG already exists; skipping."
-          fi
+            rm -f "$BODY_FILE"
+          done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Tag each package with its current version if not already tagged
-          for PKG_DIR in packages/icons packages/thesvg packages/cli packages/mcp packages/react packages/vue packages/svelte; do
-            if [ ! -d "$PKG_DIR" ]; then continue; fi
+          for PKG_DIR in packages/*/; do
+            PKG_DIR="${PKG_DIR%/}"
+            [ -f "$PKG_DIR/package.json" ] || continue
             PKG_NAME=$(node -p "require('./$PKG_DIR/package.json').name")
             PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
             TAG="$PKG_NAME@$PKG_VERSION"
@@ -106,5 +107,24 @@ jobs:
               git push origin "$TAG" || true
             fi
           done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release for CLI
+        # The Homebrew tap auto-bump workflow listens for `release: published`,
+        # so we create a GH release specifically for the @thesvg/cli tag.
+        # Other packages get git tags only (above).
+        run: |
+          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
+          CLI_TAG="@thesvg/cli@${CLI_VERSION}"
+          if ! gh release view "$CLI_TAG" >/dev/null 2>&1; then
+            echo "Creating GitHub release for $CLI_TAG"
+            gh release create "$CLI_TAG" \
+              --title "@thesvg/cli ${CLI_VERSION}" \
+              --notes "Automated release for @thesvg/cli@${CLI_VERSION}. Triggers the homebrew-tap-update workflow." \
+              --verify-tag
+          else
+            echo "Release $CLI_TAG already exists; skipping."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,10 @@ jobs:
             if ! git rev-parse "$TAG" >/dev/null 2>&1; then
               echo "Creating tag: $TAG"
               git tag "$TAG"
-              git push origin "$TAG" || true
+              # Tag push must succeed — the per-package GitHub release step
+              # below uses --verify-tag and will fail if the tag isn't on
+              # the remote.
+              git push origin "$TAG"
             fi
           done
         env:
@@ -119,7 +122,12 @@ jobs:
         #   2. Gives each package a discoverable release page on GitHub
         #      with the changeset entries that landed in that version.
         run: |
-          set -e
+          # Note: deliberately not using `set -e`. We want one failing
+          # release (e.g. flaky gh API) not to skip releases for every
+          # later package. We track failures and exit non-zero at the
+          # end so the workflow surfaces the problem.
+          failed=()
+
           # Extract the section between `## <version>` and the next `## ` (or EOF)
           # from a changesets-generated CHANGELOG.md. Echoes nothing if the
           # section is absent.
@@ -181,11 +189,21 @@ jobs:
             } > "$BODY_FILE"
 
             echo "Creating GitHub release for $TAG"
-            gh release create "$TAG" \
-              --title "$PKG_NAME $PKG_VERSION" \
-              --notes-file "$BODY_FILE" \
-              --verify-tag
+            if gh release create "$TAG" \
+                 --title "$PKG_NAME $PKG_VERSION" \
+                 --notes-file "$BODY_FILE" \
+                 --verify-tag; then
+              echo "Created release $TAG"
+            else
+              echo "::error::failed to create release for $TAG"
+              failed+=("$TAG")
+            fi
             rm -f "$BODY_FILE"
           done
+
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::${#failed[@]} release(s) failed: ${failed[*]}"
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Two related gaps in the release pipeline:

1. **`homebrew-tap-update.yml` silently failing on every push.** Root cause: `if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}` at the **job** level is an antipattern — when the secret is unset GitHub flags the workflow file as invalid and shows a failed run for every push. Even with the secret set, the trigger `on: release: published` would never fire because `release.yml` only created git tags, never GitHub releases.

2. **No GitHub releases at all.** Published packages on npm had no corresponding GitHub release pages — bad for discoverability and broke any downstream automation that listens for `release: published` (homebrew is one such consumer).

## Fix

### `homebrew-tap-update.yml`
- Move the secret check from job-level `if:` into a dedicated step with env-variable indirection. No more workflow-eval failures on push.
- Tighten the trigger gate: only fire when the released tag starts with `@thesvg/cli@` (don't bump brew when `@thesvg/icons` ships).
- Switch the bump action's `tag:` arg from `v$VERSION` to the actual `@thesvg/cli@$VERSION` tag that `release.yml` produces.
- Add `workflow_dispatch` so you can manually rerun the bump.

### `release.yml`
- Glob `packages/*/` in the tag loop instead of a hardcoded list (matches the publish loop, no drift risk).
- **New step**: after per-package git tags are pushed, create a GitHub release for **every published package**. Release body is extracted via awk from each package's `CHANGELOG.md` for the just-published version (the changeset entries — Patch/Minor/Major Changes bullets with PR links). Idempotent: skips private packages, missing tags, and existing releases.
- Body also includes an npm-install hint, the direct tarball URL, and a homebrew-install hint for `@thesvg/cli` specifically.

## Verified locally
- `awk` extraction on `packages/icons/CHANGELOG.md` version `3.0.10` returns exactly the `### Patch Changes` bullet for #438.
- Both workflow YAMLs parse clean.

## Test plan after merge
1. Manually fire: `gh workflow run homebrew-tap-update.yml -R glincker/thesvg` — confirms the `HOMEBREW_TAP_TOKEN` secret works end-to-end.
2. On next CLI publish: verify GH release pages appear for all bumped packages, with notes showing the changeset bullets.
3. Verify `glincker/homebrew-thesvg` receives a PR with the new CLI version + SHA.
4. Confirm no more workflow-eval failures on routine pushes to main.
