### PR TITLE
fix: lucide-react 1.17 compat — restore Github and Codepen glyphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "fuse.js": "^7.4.0",
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.17.0",
     "next": "16.2.7",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.378.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^7.4.0
         version: 7.4.0
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.7)
+        specifier: ^1.17.0
+        version: 1.17.0(react@19.2.7)
       next:
         specifier: 16.2.7
         version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3200,8 +3200,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -7482,7 +7482,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@19.2.7):
+  lucide-react@1.17.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { Github, Mail, MessageSquare, Shield } from "lucide-react";
+import { Mail, MessageSquare, Shield } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import { TRADEMARK_POLICY_URL } from "@/lib/constants";
 
 export const metadata: Metadata = {

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -6,13 +6,13 @@ import {
   Blocks,
   Code,
   Code2,
-  Github,
   Package,
   Palette,
   Sparkles,
   Terminal,
   Zap,
 } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { getCategoryCounts, getFormattedIconCount } from "@/lib/icons";

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -5,10 +5,10 @@ import {
   FileCode,
   GitBranch,
   GitPullRequest,
-  Github,
   Upload,
   Zap,
 } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import type { Metadata } from "next";
 import { getAllCategories, getCategoryCounts, getIconCount } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
-import { ArrowUpRight, Github, Download, Layers, Package } from "lucide-react";
+import { ArrowUpRight, Download, Layers, Package } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import Link from "next/link";
 import { TRADEMARK_POLICY_URL } from "@/lib/constants";
 import {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,7 +3,8 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { ArrowRight, Cloud, FileText, Github, Menu, Moon, Package, Plus, Search, Shapes, Sparkles, Sun, X } from "lucide-react";
+import { ArrowRight, Cloud, FileText, Menu, Moon, Package, Plus, Search, Shapes, Sparkles, Sun, X } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import { useTheme } from "next-themes";
 import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";

--- a/src/components/icons/detail/open-in-editor-menu.tsx
+++ b/src/components/icons/detail/open-in-editor-menu.tsx
@@ -6,12 +6,12 @@ import {
   Check,
   ChevronDown,
   ClipboardCopy,
-  Codepen,
   Download as DownloadIcon,
   ExternalLink,
   Loader2,
   Pencil,
 } from "lucide-react";
+import { Codepen } from "@/components/icons/shared/brand-icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,

--- a/src/components/icons/shared/brand-icons.tsx
+++ b/src/components/icons/shared/brand-icons.tsx
@@ -1,0 +1,63 @@
+import { forwardRef, type SVGProps } from "react";
+
+type IconProps = SVGProps<SVGSVGElement> & {
+  size?: number | string;
+};
+
+const baseProps = {
+  xmlns: "http://www.w3.org/2000/svg",
+  width: 24,
+  height: 24,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+/**
+ * Local replacements for brand glyphs that were dropped from lucide-react v1.0.
+ * These are simple line-icon versions intended for UI chrome (matching the
+ * lucide visual style), not the rich brand SVGs in /public/icons. Used for
+ * GitHub repo links, Codepen deep-links, and similar affordances.
+ */
+
+export const Github = forwardRef<SVGSVGElement, IconProps>(function Github(
+  { size = 24, ...props },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      {...baseProps}
+      width={size}
+      height={size}
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+});
+
+export const Codepen = forwardRef<SVGSVGElement, IconProps>(function Codepen(
+  { size = 24, ...props },
+  ref,
+) {
+  return (
+    <svg
+      ref={ref}
+      {...baseProps}
+      width={size}
+      height={size}
+      {...props}
+    >
+      <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2" />
+      <line x1="12" y1="22" x2="12" y2="15.5" />
+      <polyline points="22 8.5 12 15.5 2 8.5" />
+      <polyline points="2 15.5 12 8.5 22 15.5" />
+      <line x1="12" y1="2" x2="12" y2="8.5" />
+    </svg>
+  );
+});

--- a/src/components/submit/submit-form.tsx
+++ b/src/components/submit/submit-form.tsx
@@ -7,13 +7,13 @@ import {
   CheckCircle,
   ClipboardCopy,
   ExternalLink,
-  Github,
   Loader2,
   Palette,
   Upload,
   X,
   XCircle,
 } from "lucide-react";
+import { Github } from "@/components/icons/shared/brand-icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";

--- a/src/components/viewer/deep-link-actions.tsx
+++ b/src/components/viewer/deep-link-actions.tsx
@@ -5,10 +5,10 @@ import {
   ArrowUpRight,
   Check,
   ClipboardCopy,
-  Codepen,
   Download,
   ExternalLink,
 } from "lucide-react";
+import { Codepen } from "@/components/icons/shared/brand-icons";
 import { cn } from "@/lib/utils";
 import {
   DEEP_LINK_TARGETS,


### PR DESCRIPTION
Replaces #481 (Dependabot bump of `lucide-react` from `0.577.0` to `1.17.0`).

## What broke

`lucide-react` 1.0 was a major rewrite that **removed all brand logos** (GitHub, Codepen, and other trademarked marks) from the icon set. The 1.17.0 build therefore fails `pnpm exec tsc --noEmit` with:

```
src/app/contact/page.tsx(2,10): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/app/extensions/page.tsx(9,3): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/app/submit/page.tsx(8,3): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/components/footer.tsx(1,24): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/components/header.tsx(6,39): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/components/icons/detail/open-in-editor-menu.tsx(9,3): error TS2305: Module '"lucide-react"' has no exported member 'Codepen'.
src/components/submit/submit-form.tsx(10,3): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
src/components/viewer/deep-link-actions.tsx(8,3): error TS2305: Module '"lucide-react"' has no exported member 'Codepen'.
```

## Fix

Adds a small local module `src/components/icons/shared/brand-icons.tsx` exporting `Github` and `Codepen` as React components that mirror the lucide visual style (24x24, currentColor, stroke-linecap round, strokeWidth 2). All eight import sites swap the named import from `lucide-react` to the local module — JSX call sites stay byte-identical.

The richer multi-variant brand SVGs in `public/icons/github/` and `public/icons/codepen/` remain the source of truth for icon detail pages and downloads. The local stand-ins are only for UI chrome (repo links, deep-link affordances) where the line-icon style is wanted.

## Verification

- `pnpm exec tsc --noEmit` — passes
- `pnpm lint` — 0 errors, 19 warnings (all pre-existing on `main`)

## Test plan

- [ ] `Lint & Build` workflow passes on this PR
- [ ] Footer, header, submit, and contact pages still render the GitHub icon
- [ ] Icon detail "Open in editor" menu still shows the Codepen mark

Closes #481.