### PR TITLE
fix(icons): escape reserved-word slugs in generated identifiers

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -46,6 +46,7 @@
   ],
   "scripts": {
     "build": "tsx scripts/build-icons.ts",
+    "test": "tsx --test scripts/lib/*.test.ts",
     "audit": "node scripts/security-audit.mjs",
     "validate": "node scripts/validate-dist.mjs",
     "prepublishOnly": "npm run build && npm run audit && npm run validate"

--- a/packages/icons/scripts/build-icons.ts
+++ b/packages/icons/scripts/build-icons.ts
@@ -21,6 +21,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { toSafeIdentifier } from "./lib/safe-identifier.ts";
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -272,74 +274,8 @@ function generateTypesDeclaration(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Utilities
+// Utilities (toSafeIdentifier lives in ./lib/safe-identifier.ts)
 // ---------------------------------------------------------------------------
-
-/**
- * Reserved words (and a few globals) that are illegal as a binding name. A slug
- * like "await" would otherwise emit `const await = ...`, which is a syntax
- * error and breaks the whole package build (and any consumer's type-check).
- */
-const RESERVED_IDENTIFIERS = new Set([
-  "await",
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "implements",
-  "import",
-  "in",
-  "instanceof",
-  "interface",
-  "let",
-  "new",
-  "null",
-  "package",
-  "private",
-  "protected",
-  "public",
-  "return",
-  "static",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-  "yield",
-]);
-
-/**
- * Turn a slug into a valid JS identifier.
- * Slugs can start with digits (e.g. "01dotai") or contain hyphens/dots.
- * Strategy: prefix with "i_" if it starts with a digit or is a reserved word,
- * replace non-word chars with "_".
- */
-function toSafeIdentifier(slug: string): string {
-  let id = slug.replace(/[^a-zA-Z0-9_]/g, "_");
-  if (/^[0-9]/.test(id) || RESERVED_IDENTIFIERS.has(id)) id = `i_${id}`;
-  return id;
-}
 
 // ---------------------------------------------------------------------------
 // Main

--- a/packages/icons/scripts/build-icons.ts
+++ b/packages/icons/scripts/build-icons.ts
@@ -276,14 +276,68 @@ function generateTypesDeclaration(): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Reserved words (and a few globals) that are illegal as a binding name. A slug
+ * like "await" would otherwise emit `const await = ...`, which is a syntax
+ * error and breaks the whole package build (and any consumer's type-check).
+ */
+const RESERVED_IDENTIFIERS = new Set([
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+/**
  * Turn a slug into a valid JS identifier.
  * Slugs can start with digits (e.g. "01dotai") or contain hyphens/dots.
- * Strategy: prefix with "i_" if it starts with a digit, replace non-word
- * chars with "_".
+ * Strategy: prefix with "i_" if it starts with a digit or is a reserved word,
+ * replace non-word chars with "_".
  */
 function toSafeIdentifier(slug: string): string {
   let id = slug.replace(/[^a-zA-Z0-9_]/g, "_");
-  if (/^[0-9]/.test(id)) id = `i_${id}`;
+  if (/^[0-9]/.test(id) || RESERVED_IDENTIFIERS.has(id)) id = `i_${id}`;
   return id;
 }
 

--- a/packages/icons/scripts/lib/safe-identifier.test.ts
+++ b/packages/icons/scripts/lib/safe-identifier.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { RESERVED_IDENTIFIERS, toSafeIdentifier } from "./safe-identifier.ts";
+
+test("passes a normal alphanumeric slug through unchanged", () => {
+  assert.equal(toSafeIdentifier("github"), "github");
+  assert.equal(toSafeIdentifier("react"), "react");
+  assert.equal(toSafeIdentifier("vercel"), "vercel");
+});
+
+test("replaces hyphens with underscores", () => {
+  assert.equal(toSafeIdentifier("react-native"), "react_native");
+  assert.equal(toSafeIdentifier("aws-amazon-s3"), "aws_amazon_s3");
+});
+
+test("replaces dots with underscores", () => {
+  assert.equal(toSafeIdentifier("01.ai"), "i_01_ai");
+  assert.equal(toSafeIdentifier("nuxt.js"), "nuxt_js");
+});
+
+test("prefixes leading-digit slugs with i_", () => {
+  assert.equal(toSafeIdentifier("01dotai"), "i_01dotai");
+  assert.equal(toSafeIdentifier("1password"), "i_1password");
+  assert.equal(toSafeIdentifier("4chan"), "i_4chan");
+});
+
+test("escapes the await reserved word (the original PR 503 bug)", () => {
+  assert.equal(toSafeIdentifier("await"), "i_await");
+});
+
+test("escapes strict-mode restricted bindings arguments and eval", () => {
+  assert.equal(toSafeIdentifier("arguments"), "i_arguments");
+  assert.equal(toSafeIdentifier("eval"), "i_eval");
+});
+
+test("escapes every reserved word in the set", () => {
+  for (const word of RESERVED_IDENTIFIERS) {
+    assert.equal(
+      toSafeIdentifier(word),
+      `i_${word}`,
+      `reserved word "${word}" should be prefixed`,
+    );
+  }
+});
+
+test("escapes future-reserved words that may show up as slugs", () => {
+  assert.equal(toSafeIdentifier("class"), "i_class");
+  assert.equal(toSafeIdentifier("for"), "i_for");
+  assert.equal(toSafeIdentifier("new"), "i_new");
+  assert.equal(toSafeIdentifier("default"), "i_default");
+  assert.equal(toSafeIdentifier("yield"), "i_yield");
+});
+
+test("does not escape words that merely contain a reserved word", () => {
+  assert.equal(toSafeIdentifier("classroom"), "classroom");
+  assert.equal(toSafeIdentifier("foreach"), "foreach");
+  assert.equal(toSafeIdentifier("newrelic"), "newrelic");
+});
+
+test("handles slugs that become reserved after non-word stripping", () => {
+  assert.equal(toSafeIdentifier("class"), "i_class");
+});
+
+test("is idempotent for already-safe identifiers", () => {
+  const safe = toSafeIdentifier("react");
+  assert.equal(toSafeIdentifier(safe), safe);
+});

--- a/packages/icons/scripts/lib/safe-identifier.ts
+++ b/packages/icons/scripts/lib/safe-identifier.ts
@@ -1,0 +1,73 @@
+/**
+ * Reserved words (plus the strict-mode restricted bindings `arguments` and
+ * `eval`) that are illegal as a binding name in ES module code. A slug like
+ * "await" would otherwise emit `const await = ...`, which is a syntax error
+ * and breaks the whole package build (and any consumer's type-check).
+ *
+ * ES modules are always strict-mode, so the strict-mode reserved set applies
+ * here in full.
+ */
+export const RESERVED_IDENTIFIERS = new Set([
+  // ECMAScript reserved words
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+  // Strict-mode restricted bindings (modules are strict)
+  "arguments",
+  "eval",
+]);
+
+/**
+ * Turn a slug into a valid JS identifier.
+ * Slugs can start with digits (e.g. "01dotai") or contain hyphens/dots.
+ * Strategy: prefix with "i_" if it starts with a digit or is a reserved word,
+ * replace non-word chars with "_".
+ */
+export function toSafeIdentifier(slug: string): string {
+  let id = slug.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (/^[0-9]/.test(id) || RESERVED_IDENTIFIERS.has(id)) id = `i_${id}`;
+  return id;
+}


### PR DESCRIPTION
## Problem

The `await` icon ships a broken module: `packages/icons/dist/await.js` and `await.d.ts` emit

```ts
const await = { ... };
export default await;
declare const await: IconModule;
```

`await` is a reserved word, so this is a **syntax error**. It breaks the package build and every consumer's type-check - `skipLibCheck` skips type *checking* but not *parsing*, so any project that pulls in `@thesvg/icons` (e.g. via `thesvg/<icon>`) fails its Next.js / `tsc` build:

```
node_modules/@thesvg/icons/dist/await.d.ts:17:21
Type error: Expression expected.
```

## Cause

`toSafeIdentifier()` in `packages/icons/scripts/build-icons.ts` only guards slugs that *start with a digit*; it does not guard JS reserved words, so slug `await` becomes the identifier `await`.

## Fix

Add a `RESERVED_IDENTIFIERS` set and prefix matches with `i_` - exactly the existing strategy for leading digits. `await` is the only current offender, but the set future-proofs any new reserved-word slug (`class`, `for`, `new`, `default`, ...).

After `bun run build` the icon emits valid `const i_await` / `declare const i_await`, and the index re-export becomes `export { default as i_await } from "./await.js"`.

## Verification

- `bun run build` (packages/icons): 6084 icons, exit 0
- `bun run validate`: exit 0 (6086 ESM / CJS / DTS files)
- Regenerated `await.{js,d.ts}` now parse cleanly

Note: this changes the await icon's exported binding name from the (previously unusable) `await` to `i_await`. Since the old name never parsed, no working consumer relied on it.