### PR TITLE
fix(ci): publish workflow must handle tags that exist on remote only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,19 +94,31 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Tag each package with its current version if not already tagged
+          # Tag each package with its current version if not already tagged.
+          #
+          # The runner's checkout doesn't always fetch every historical
+          # tag, so a local-only `git rev-parse` check would create a
+          # duplicate tag and the subsequent push would be rejected by
+          # the remote. Check both local and remote, and pull the tag
+          # down if it already lives upstream - the downstream
+          # "Create GitHub releases per package" step uses local
+          # `git rev-parse` and needs the tag to exist in this clone.
           for PKG_DIR in packages/*/; do
             PKG_DIR="${PKG_DIR%/}"
             [ -f "$PKG_DIR/package.json" ] || continue
             PKG_NAME=$(node -p "require('./$PKG_DIR/package.json').name")
             PKG_VERSION=$(node -p "require('./$PKG_DIR/package.json').version")
             TAG="$PKG_NAME@$PKG_VERSION"
-            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "Tag already present locally: $TAG"
+            elif git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "Tag already present on remote: $TAG (fetching)"
+              # Use `tag` form rather than a refspec - scoped names contain
+              # `@` which trips the `<src>:<dst>` parser.
+              git fetch origin tag "$TAG"
+            else
               echo "Creating tag: $TAG"
               git tag "$TAG"
-              # Tag push must succeed — the per-package GitHub release step
-              # below uses --verify-tag and will fail if the tag isn't on
-              # the remote.
               git push origin "$TAG"
             fi
           done


### PR DESCRIPTION
## Problem

In yesterday's 3.0.11 release the "Publish to npm" workflow failed at the "Create git tags" step:

\`\`\`
Creating tag: @thesvg/cli@0.5.4
! [rejected]   @thesvg/cli@0.5.4 -> @thesvg/cli@0.5.4 (already exists)
error: failed to push some refs
\`\`\`

That failure aborted the step, so the downstream "Create GitHub releases per package" never ran and no per-package release pages were created.

## Cause

The existence check used a local-only \`git rev-parse\`. The runner's checkout doesn't always fetch every historical tag, so when a package's version hadn't changed (cli stayed at 0.5.4 across the round-3 cleanup release) the check treated the tag as missing, attempted to create and push, and got rejected.

## Fix

Check local first, then fall back to \`git ls-remote --tags --exit-code\`. If the tag is on the remote but not local, fetch it. The downstream release-creation step still uses \`git rev-parse\` so the tag must end up in the local clone.

One subtle catch: the natural \`git fetch origin "refs/tags/\$TAG:refs/tags/\$TAG"\` refspec misparses when the tag name contains \`@\` (scoped package names always do), producing a corrupted ref like \`refs/tags/@thesvg/cli@0.5efs/tags/...\`. Switched to the explicit \`git fetch origin tag "\$TAG"\` form which handles the \`@\` cleanly.

## Verification

Tested locally against the actual production tag state:

- Tag on remote only (\`@thesvg/cli@0.5.4\` with the local tag removed): ls-remote hits, fetch succeeds, downstream rev-parse passes
- Brand new tag (\`@thesvg/test@99.99.99\`): both checks miss, create-and-push branch taken
- Refspec form with \`@\` in the tag name: rejected with parser corruption, confirming the choice of \`tag\` form

YAML lint passes.

## Why now

v3.0.11 just shipped and we noticed the missing per-package GitHub releases. Want this in place before the next publish so the per-package release flow lights up again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process reliability by enhancing tag validation during package publishing, reducing duplicate-tag failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->