### PR TITLE
feat(submit): require license selection upfront with self-guided helper

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,96 @@
+# Icon Licensing Guide
+
+This guide walks you through picking the right license when you submit an icon to thesvg.org. Every accepted icon has a `license` field in its `icons.json` entry, and the submit form now requires you to pick one upfront so we don't have to chase you on the issue thread.
+
+If after reading this you're still not sure, pick **"Other / unsure — needs maintainer review"**. We'll verify and label your submission for triage.
+
+---
+
+## Important: license vs. trademark
+
+These are two different things and both apply to brand icons:
+
+- **License** controls who can copy and modify the SVG file.
+- **Trademark** controls who can use the logo to represent a brand.
+
+A logo can have a permissive license (the SVG is free to copy) **and** still be a registered trademark (you can't use it to imply endorsement). All brand marks on thesvg.org are subject to the original owner's trademark rights — see [TRADEMARK.md](./TRADEMARK.md) for the full policy.
+
+The form is only asking about the **license** of the SVG file itself, not whether you have permission to use the brand.
+
+---
+
+## Pick by question
+
+### Did you draw this icon yourself, from scratch, with no copying?
+**Pick:** `CC0 1.0 (public domain)`
+
+You're waiving all rights and letting anyone use it for any purpose. Best for personal projects, generic icons, and brand kits you've designed and want to gift to the community.
+
+### Is this the official logo of an open-source project?
+**Check the project's repo for a LICENSE file in the brand assets folder** (often `assets/`, `branding/`, or `logo/`). Common cases:
+
+| What the project says | Pick |
+|---|---|
+| Their brand assets are CC0 or public domain | `CC0 1.0` |
+| Apache-licensed project, no separate brand policy | `Apache 2.0` |
+| MIT-licensed project, no separate brand policy | `MIT` |
+| CC BY (Creative Commons attribution) | `CC BY 4.0` |
+| CC BY-SA (share-alike, e.g. Wikipedia assets) | `CC BY-SA 4.0` |
+| They have a "brand guidelines" doc with usage restrictions | `Other / unsure` |
+
+### Is this a corporate / company brand mark?
+**Pick:** `Other / unsure — needs maintainer review`
+
+Most companies don't license their logos under a public open-source license — they just publish brand guidelines (e.g. "Don't change the colors, don't put it on top of other logos"). Picking "Other" lets us:
+
+1. Verify the brand guidelines URL you provide actually permits the usage.
+2. Label the issue `license-unsure` so it routes correctly.
+3. Document the restriction in the `icons.json` entry instead of pretending it's MIT.
+
+### Is this a fork / modification of an existing icon?
+Same license as the original. If the original is MIT, your modification stays MIT. If you can't find the original's license, pick `Other / unsure`.
+
+---
+
+## What we accept
+
+The form lists the licenses we accept routinely:
+
+**Public-domain dedications**
+- **CC0 1.0** — no rights reserved
+- **The Unlicense** — public-domain dedication, common for small OSS projects
+
+**Permissive**
+- **MIT** — attribution only
+- **Apache 2.0** — permissive with explicit patent grant
+- **BSD 3-Clause** — attribution + no-endorsement clause
+- **ISC** — functionally equivalent to MIT
+
+**Creative Commons attribution family**
+- **CC BY 4.0** — attribution required
+- **CC BY-SA 4.0** — attribution + share-alike (Wikipedia-style)
+- **CC BY-ND 4.0** — attribution, no derivatives (common for corporate brand kits)
+
+**Weak copyleft**
+- **Mozilla Public License 2.0** — file-level copyleft
+
+**Other / custom — needs maintainer review**
+Pick this when:
+- The license doesn't match any option above (e.g. a custom company brand-usage license).
+- The brand has guidelines but no formal SPDX license.
+- You're not sure and want a maintainer to confirm.
+
+You'll be prompted for a short description (e.g. "Acme Brand Guidelines v2 — non-commercial use only"). We do **not** accept proprietary "all rights reserved" submissions without explicit owner permission.
+
+---
+
+## What happens after you submit
+
+- **Permissive license (CC0 / MIT / Apache / CC BY / CC BY-SA):** the SVG is added to the registry with that license recorded.
+- **Other / unsure:** the GitHub issue is auto-labeled `license-unsure`, and a maintainer reviews ownership / permission before merging. You'll see a comment on the issue if we need anything else from you.
+
+---
+
+## Reporting an incorrect license
+
+If you find an icon in the registry whose license is wrong (e.g. tagged MIT but should be Other), please open an issue with the slug and what you believe the correct license is. We treat license accuracy as a first-class concern — see [LEGAL.md](./LEGAL.md) for takedown procedure.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,96 +1,182 @@
 # Icon Licensing Guide
 
-This guide walks you through picking the right license when you submit an icon to thesvg.org. Every accepted icon has a `license` field in its `icons.json` entry, and the submit form now requires you to pick one upfront so we don't have to chase you on the issue thread.
+How licensing works on **thesvg.org**, what you promise when you submit, and what we promise when we publish. Plain language, with sources you can verify.
 
-If after reading this you're still not sure, pick **"Other / unsure — needs maintainer review"**. We'll verify and label your submission for triage.
+> **Not legal advice.** This document explains how we operate. If the brand you're submitting belongs to someone else and you're unsure about your rights, talk to a lawyer or the brand owner before submitting. See [DISCLAIMER.md](./DISCLAIMER.md) for the full project disclaimer.
 
----
+## Table of contents
 
-## Important: license vs. trademark
-
-These are two different things and both apply to brand icons:
-
-- **License** controls who can copy and modify the SVG file.
-- **Trademark** controls who can use the logo to represent a brand.
-
-A logo can have a permissive license (the SVG is free to copy) **and** still be a registered trademark (you can't use it to imply endorsement). All brand marks on thesvg.org are subject to the original owner's trademark rights — see [TRADEMARK.md](./TRADEMARK.md) for the full policy.
-
-The form is only asking about the **license** of the SVG file itself, not whether you have permission to use the brand.
+1. [License vs. trademark — read this first](#1-license-vs-trademark--read-this-first)
+2. [What you promise when you submit](#2-what-you-promise-when-you-submit)
+3. [What we promise when we publish](#3-what-we-promise-when-we-publish)
+4. [Pick a license by question](#4-pick-a-license-by-question)
+5. [The licenses we accept](#5-the-licenses-we-accept)
+6. [The "Other / custom" path](#6-the-other--custom-path)
+7. [What we never accept](#7-what-we-never-accept)
+8. [If you find a wrong license — takedown procedure](#8-if-you-find-a-wrong-license--takedown-procedure)
 
 ---
 
-## Pick by question
+## 1. License vs. trademark — read this first
 
-### Did you draw this icon yourself, from scratch, with no copying?
-**Pick:** `CC0 1.0 (public domain)`
+These are two different things, and **both** can apply to a brand icon. Confusing them is the single most common mistake on the submission form.
 
-You're waiving all rights and letting anyone use it for any purpose. Best for personal projects, generic icons, and brand kits you've designed and want to gift to the community.
+| | License | Trademark |
+|---|---|---|
+| **Controls** | Who can copy / modify / redistribute the **SVG file** | Who can use the **brand mark** to identify goods or services |
+| **Set by** | The author or publisher of the file | The brand owner, often via national / EU registration |
+| **Source of truth** | The `LICENSE` file shipped with the asset | The brand's "Brand Guidelines" or "Trademark Usage Policy" page |
+| **Authoritative reference** | [SPDX License List](https://spdx.org/licenses/) | [USPTO Trademark Basics](https://www.uspto.gov/trademarks/basics), [EUIPO Trademark Basics](https://euipo.europa.eu/ohimportal/en/trade-marks-in-the-european-union) |
 
-### Is this the official logo of an open-source project?
-**Check the project's repo for a LICENSE file in the brand assets folder** (often `assets/`, `branding/`, or `logo/`). Common cases:
+A logo can have a **permissive license** (the SVG is free to copy) **and** still be a **registered trademark** (you can't use it to imply endorsement, sell merchandise, or pass off your product as the brand). All brand marks on thesvg.org are subject to the original owner's trademark rights — see [TRADEMARK.md](./TRADEMARK.md) for our full policy.
+
+**The submission form is only asking about the *license* of the SVG file itself, not whether you have permission to use the brand commercially.**
+
+---
+
+## 2. What you promise when you submit
+
+By picking a license on the form, you're asserting:
+
+1. **You have the right to license this asset.** Either you created it, it's already published under that license by the brand owner, or it's in the public domain.
+2. **The license is accurate.** If you pick `MIT`, you're saying the upstream source actually publishes the brand mark under MIT (not just the project's code — many OSS projects have permissive code but restricted brand assets).
+3. **You'll respond if we ask follow-up questions.** Especially for the "Other / custom" path, where a maintainer will reach out on the GitHub issue.
+
+If you're unsure about any of these, pick **"Other / custom — needs maintainer review"** and we'll figure it out together before merging. **Picking incorrectly creates legal exposure for both you and us** — that's why the form blocks submission until a license is chosen.
+
+---
+
+## 3. What we promise when we publish
+
+When your icon lands in the registry, we:
+
+1. **Record your declared license verbatim** in the `icons.json` entry. Downstream consumers (apps, packages, jsDelivr, the npm package `@thesvg/icons`) inherit that field as-is. The license is part of the public API.
+2. **Surface the license on the icon's detail page** at `thesvg.org/icon/<slug>` so anyone using the icon can see what they're agreeing to.
+3. **Promptly remove or relicense an icon** if we discover the declared license is wrong — see [section 8](#8-if-you-find-a-wrong-license--takedown-procedure).
+4. **Never relicense your asset more permissively than you declared.** If you submit a CC BY-ND icon, we'll never quietly re-publish it as MIT.
+
+What we **don't** do: We don't audit every submission against the brand owner's trademark policy at intake. We rely on submitters to be honest, on community reports for corrections, and on the [takedown procedure](./LEGAL.md) for disputes. Submitters and downstream users are responsible for trademark compliance — see [TRADEMARK.md](./TRADEMARK.md).
+
+---
+
+## 4. Pick a license by question
+
+### Q1. Did you draw this icon yourself, from scratch, with no copying?
+
+**Pick:** [`CC0 1.0`](https://creativecommons.org/publicdomain/zero/1.0/) (public domain dedication)
+
+You're waiving all rights and letting anyone use it for any purpose. Best for personal projects, generic icons, and brand kits you've designed and want to gift to the community. CC0 is the closest thing to true public domain that's legally enforceable in jurisdictions where you can't "release to public domain" by simple declaration.
+
+### Q2. Is this the official logo of an open-source project?
+
+Look in the project's repository for a `LICENSE` file inside the brand-assets folder — commonly `assets/`, `branding/`, `logo/`, or `media/`. **The project's source code license is not automatically the same as the brand asset license.** Many projects deliberately restrict their brand mark even when the code is permissive.
 
 | What the project says | Pick |
 |---|---|
-| Their brand assets are CC0 or public domain | `CC0 1.0` |
-| Apache-licensed project, no separate brand policy | `Apache 2.0` |
-| MIT-licensed project, no separate brand policy | `MIT` |
-| CC BY (Creative Commons attribution) | `CC BY 4.0` |
-| CC BY-SA (share-alike, e.g. Wikipedia assets) | `CC BY-SA 4.0` |
-| They have a "brand guidelines" doc with usage restrictions | `Other / unsure` |
+| Brand assets explicitly CC0 / public domain | [`CC0 1.0`](https://creativecommons.org/publicdomain/zero/1.0/) |
+| Apache-licensed project, no separate brand policy | [`Apache 2.0`](https://spdx.org/licenses/Apache-2.0.html) |
+| MIT-licensed project, no separate brand policy | [`MIT`](https://spdx.org/licenses/MIT.html) |
+| BSD-licensed project, no separate brand policy | [`BSD-3-Clause`](https://spdx.org/licenses/BSD-3-Clause.html) |
+| ISC-licensed project, no separate brand policy | [`ISC`](https://spdx.org/licenses/ISC.html) |
+| MPL 2.0 project (Firefox / Mozilla) | [`MPL-2.0`](https://spdx.org/licenses/MPL-2.0.html) |
+| CC BY 4.0 (Creative Commons attribution) | [`CC BY 4.0`](https://creativecommons.org/licenses/by/4.0/) |
+| CC BY-SA 4.0 (share-alike, e.g. Wikipedia assets) | [`CC BY-SA 4.0`](https://creativecommons.org/licenses/by-sa/4.0/) |
+| CC BY-ND 4.0 (no derivatives — common for corporate kits) | [`CC BY-ND 4.0`](https://creativecommons.org/licenses/by-nd/4.0/) |
+| Brand guidelines doc with usage restrictions, no SPDX license | [Other / custom](#6-the-other--custom-path) |
 
-### Is this a corporate / company brand mark?
-**Pick:** `Other / unsure — needs maintainer review`
+### Q3. Is this a corporate / company brand mark?
 
-Most companies don't license their logos under a public open-source license — they just publish brand guidelines (e.g. "Don't change the colors, don't put it on top of other logos"). Picking "Other" lets us:
+**Pick:** [Other / custom](#6-the-other--custom-path)
 
-1. Verify the brand guidelines URL you provide actually permits the usage.
-2. Label the issue `license-unsure` so it routes correctly.
-3. Document the restriction in the `icons.json` entry instead of pretending it's MIT.
+Most companies don't license their logos under a public open-source license. They publish brand guidelines instead — see for example [Google's Brand Resource Center](https://about.google/brand-resource-center/), [Microsoft's Trademark Usage Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks), or [Apple's Guidelines for Using Apple Trademarks](https://www.apple.com/legal/intellectualproperty/guidelinesfor3rdparties.html). Picking "Other / custom" lets us:
 
-### Is this a fork / modification of an existing icon?
-Same license as the original. If the original is MIT, your modification stays MIT. If you can't find the original's license, pick `Other / unsure`.
+1. Read the linked brand guidelines and verify the usage you're proposing is permitted.
+2. Label the issue `license-unsure` so it routes to a maintainer for confirmation.
+3. Document the actual policy in the `icons.json` entry instead of pretending it's MIT.
 
----
+### Q4. Is this a fork / modification of an existing icon?
 
-## What we accept
-
-The form lists the licenses we accept routinely:
-
-**Public-domain dedications**
-- **CC0 1.0** — no rights reserved
-- **The Unlicense** — public-domain dedication, common for small OSS projects
-
-**Permissive**
-- **MIT** — attribution only
-- **Apache 2.0** — permissive with explicit patent grant
-- **BSD 3-Clause** — attribution + no-endorsement clause
-- **ISC** — functionally equivalent to MIT
-
-**Creative Commons attribution family**
-- **CC BY 4.0** — attribution required
-- **CC BY-SA 4.0** — attribution + share-alike (Wikipedia-style)
-- **CC BY-ND 4.0** — attribution, no derivatives (common for corporate brand kits)
-
-**Weak copyleft**
-- **Mozilla Public License 2.0** — file-level copyleft
-
-**Other / custom — needs maintainer review**
-Pick this when:
-- The license doesn't match any option above (e.g. a custom company brand-usage license).
-- The brand has guidelines but no formal SPDX license.
-- You're not sure and want a maintainer to confirm.
-
-You'll be prompted for a short description (e.g. "Acme Brand Guidelines v2 — non-commercial use only"). We do **not** accept proprietary "all rights reserved" submissions without explicit owner permission.
+Same license as the original — most permissive licenses require this (Apache, MPL, all CC licenses). If you can't find the original's license, pick [Other / custom](#6-the-other--custom-path).
 
 ---
 
-## What happens after you submit
+## 5. The licenses we accept
 
-- **Permissive license (CC0 / MIT / Apache / CC BY / CC BY-SA):** the SVG is added to the registry with that license recorded.
-- **Other / unsure:** the GitHub issue is auto-labeled `license-unsure`, and a maintainer reviews ownership / permission before merging. You'll see a comment on the issue if we need anything else from you.
+All ten licenses below are listed in the [SPDX License List](https://spdx.org/licenses/) and most are approved by the [Open Source Initiative](https://opensource.org/licenses/). Links go to the canonical text — read it before picking.
+
+### Public-domain dedications
+
+- **[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/)** — "No Rights Reserved." Best legally-enforceable public-domain dedication. ([SPDX](https://spdx.org/licenses/CC0-1.0.html))
+- **[The Unlicense](https://unlicense.org/)** — public-domain dedication common in small OSS projects. ([SPDX](https://spdx.org/licenses/Unlicense.html), [OSI-approved](https://opensource.org/license/unlicense))
+
+### Permissive
+
+- **[MIT](https://opensource.org/license/mit)** — short and permissive, attribution only. The most common OSS license. ([SPDX](https://spdx.org/licenses/MIT.html))
+- **[Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)** — permissive with an explicit patent grant. Common for cloud / infra brands. ([SPDX](https://spdx.org/licenses/Apache-2.0.html), [OSI-approved](https://opensource.org/license/apache-2-0))
+- **[BSD 3-Clause](https://opensource.org/license/bsd-3-clause)** — permissive with attribution + no-endorsement clause. ([SPDX](https://spdx.org/licenses/BSD-3-Clause.html))
+- **[ISC](https://opensource.org/license/isc-license-txt)** — functionally equivalent to MIT, shorter text. ([SPDX](https://spdx.org/licenses/ISC.html))
+
+### Creative Commons attribution family
+
+The CC family is published by the [Creative Commons](https://creativecommons.org/) non-profit. Each license has a [machine-readable summary](https://creativecommons.org/share-your-work/cclicenses/) and full legal code.
+
+- **[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)** — attribution required, otherwise unrestricted. ([SPDX](https://spdx.org/licenses/CC-BY-4.0.html))
+- **[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)** — attribution + share-alike. Wikipedia uses this for most of its assets. ([SPDX](https://spdx.org/licenses/CC-BY-SA-4.0.html))
+- **[CC BY-ND 4.0](https://creativecommons.org/licenses/by-nd/4.0/)** — attribution, **no derivatives**. Picking this means the logo cannot be modified, only used as-is. Common for corporate brand kits. ([SPDX](https://spdx.org/licenses/CC-BY-ND-4.0.html))
+
+### Weak copyleft
+
+- **[Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/)** — file-level copyleft. Used by Firefox, Thunderbird, and Mozilla-adjacent projects. ([SPDX](https://spdx.org/licenses/MPL-2.0.html), [OSI-approved](https://opensource.org/license/mpl-2-0))
 
 ---
 
-## Reporting an incorrect license
+## 6. The "Other / custom" path
 
-If you find an icon in the registry whose license is wrong (e.g. tagged MIT but should be Other), please open an issue with the slug and what you believe the correct license is. We treat license accuracy as a first-class concern — see [LEGAL.md](./LEGAL.md) for takedown procedure.
+Pick **"Other / custom — needs maintainer review"** when any of these apply:
+
+- The asset has a real license, but it's not in the list above (e.g. a custom company brand-usage policy, EPL, AGPL, a CC license we don't pre-stock).
+- The brand has published guidelines but no formal SPDX license at all.
+- You're not sure and want a maintainer to confirm before merging.
+
+When you pick Other:
+
+1. You'll be prompted for a short description (≤120 chars). Examples:
+   - `"Acme Brand Guidelines v2 — non-commercial only"`
+   - `"Custom — written permission from owner, see issue thread"`
+   - `"EPL-2.0"`
+2. The auto-generated GitHub issue is labeled [`license-unsure`](https://github.com/GLINCKER/thesvg/issues?q=label%3Alicense-unsure).
+3. A maintainer reviews the source link, the brand guidelines, and the description before merging. They may request more info on the issue thread.
+4. If the license is verifiable and acceptable, the asset is merged with the declared text recorded verbatim in `icons.json`.
+
+**This path is not a way to bypass the rules — it's a way to be honest about ambiguity.** A clearly-labeled `license-unsure` submission is much easier to handle than a "yeah, just say MIT" submission that we have to take down later.
+
+---
+
+## 7. What we never accept
+
+- **"All rights reserved"** assets without explicit, documented owner permission. Even if you uploaded it, we can't republish it without rights.
+- **Assets where the license forbids redistribution.** Some brand assets are licensed only for internal company use — those can't go into a public registry.
+- **Mislabeled licenses.** Submitting a CC BY-ND asset as MIT, for example. This creates legal exposure for you, for us, and for every downstream consumer.
+- **Assets you found on the internet with no traceable source.** "I got it from Google Images" is not a license declaration.
+
+---
+
+## 8. If you find a wrong license — takedown procedure
+
+License accuracy is a first-class concern for us. If you spot an icon whose declared license is wrong (e.g. marked MIT when it should be Other / proprietary):
+
+1. **Open an issue** at [github.com/GLINCKER/thesvg/issues](https://github.com/GLINCKER/thesvg/issues/new) titled `[License] <slug> — <what's wrong>`.
+2. Include: the icon slug, the declared license in the registry, what you believe the correct license is, and a link to the authoritative source.
+3. We aim to respond within 72 hours. For verifiable mistakes we either relicense the entry or remove the asset entirely.
+
+For formal takedown requests from rights-holders or their representatives, see the procedure in [LEGAL.md](./LEGAL.md).
+
+---
+
+## Related policies
+
+- [DISCLAIMER.md](./DISCLAIMER.md) — project disclaimer
+- [LEGAL.md](./LEGAL.md) — DMCA / takedown procedure
+- [TRADEMARK.md](./TRADEMARK.md) — trademark policy
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — general contribution guide
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) — community standards

--- a/src/components/submit/submit-form.tsx
+++ b/src/components/submit/submit-form.tsx
@@ -18,6 +18,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { validateSvg, type ValidationResult } from "@/lib/svg-validation";
+import {
+  LICENSE_OPTIONS,
+  MAX_OTHER_LICENSE_LENGTH,
+  OTHER_LICENSE_ID,
+  validateLicenseSelection,
+} from "@/lib/license-options";
 
 const GITHUB_ISSUES_URL =
   "https://github.com/glincker/thesvg/issues/new";
@@ -82,7 +88,12 @@ interface FormState {
   hex: string;
   categories: string[];
   newCategory: string;
+  licenseId: string;
+  licenseOther: string;
 }
+
+const LICENSING_GUIDE_URL =
+  "https://github.com/GLINCKER/thesvg/blob/main/LICENSING.md";
 
 function toKebabCase(str: string): string {
   return str
@@ -188,6 +199,151 @@ function SvgPreview({ dataUrl, name }: { dataUrl: string; name: string }) {
   );
 }
 
+interface LicenseSelectorProps {
+  licenseId: string;
+  onLicenseChange: (id: string) => void;
+  otherText: string;
+  onOtherTextChange: (text: string) => void;
+  validation: ReturnType<typeof validateLicenseSelection>;
+  onSuggest: (id: string) => void;
+}
+
+function LicenseSelector({
+  licenseId,
+  onLicenseChange,
+  otherText,
+  onOtherTextChange,
+  validation,
+  onSuggest,
+}: LicenseSelectorProps) {
+  const [helperOpen, setHelperOpen] = useState(false);
+  const isOther = licenseId === OTHER_LICENSE_ID;
+  const showOtherEmptyError =
+    !validation.ok && validation.reason === "other_empty" && isOther;
+  const showOtherTooLongError =
+    !validation.ok && validation.reason === "other_too_long" && isOther;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label htmlFor="license-select" className="text-sm font-medium">
+          License <span className="text-red-500">*</span>
+        </label>
+        <div className="flex items-center gap-3 text-xs">
+          <button
+            type="button"
+            onClick={() => setHelperOpen((v) => !v)}
+            className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            {helperOpen ? "Hide" : "Help me pick"}
+          </button>
+          <a
+            href={LICENSING_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Licensing guide
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </div>
+
+      {helperOpen && (
+        <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs">
+          <p className="mb-2 font-medium text-foreground">Pick the option that fits:</p>
+          <div className="flex flex-col gap-1.5">
+            <button
+              type="button"
+              onClick={() => onSuggest("CC0-1.0")}
+              className="rounded px-2 py-1 text-left transition-colors hover:bg-accent"
+            >
+              <strong>I drew it myself</strong>
+              <span className="ml-1 text-muted-foreground">→ CC0 1.0</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onSuggest("MIT")}
+              className="rounded px-2 py-1 text-left transition-colors hover:bg-accent"
+            >
+              <strong>Logo of an MIT / Apache / BSD open-source project</strong>
+              <span className="ml-1 text-muted-foreground">→ match the project&rsquo;s license</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onSuggest("CC-BY-4.0")}
+              className="rounded px-2 py-1 text-left transition-colors hover:bg-accent"
+            >
+              <strong>Brand kit explicitly published as CC BY</strong>
+              <span className="ml-1 text-muted-foreground">→ CC BY 4.0 (or CC BY-SA / CC BY-ND)</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onSuggest(OTHER_LICENSE_ID)}
+              className="rounded px-2 py-1 text-left transition-colors hover:bg-accent"
+            >
+              <strong>Company brand mark, custom license, or unsure</strong>
+              <span className="ml-1 text-muted-foreground">→ Other / custom (we&rsquo;ll verify)</span>
+            </button>
+          </div>
+        </div>
+      )}
+
+      <select
+        id="license-select"
+        value={licenseId}
+        onChange={(e) => onLicenseChange(e.target.value)}
+        required
+        className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring"
+      >
+        <option value="">Select a license…</option>
+        {LICENSE_OPTIONS.map((opt) => (
+          <option key={opt.id} value={opt.id}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      {licenseId && (
+        <p className="text-xs text-muted-foreground">
+          {LICENSE_OPTIONS.find((o) => o.id === licenseId)?.description}
+        </p>
+      )}
+
+      {isOther && (
+        <div className="space-y-1.5">
+          <label htmlFor="license-other" className="text-xs font-medium">
+            Describe the license <span className="text-red-500">*</span>
+          </label>
+          <Input
+            id="license-other"
+            value={otherText}
+            onChange={(e) => onOtherTextChange(e.target.value)}
+            placeholder="e.g. Acme Brand Guidelines v2 — non-commercial use only"
+            maxLength={MAX_OTHER_LICENSE_LENGTH}
+            className="text-sm"
+            aria-invalid={showOtherEmptyError || showOtherTooLongError}
+            aria-describedby={showOtherEmptyError ? "license-other-error" : undefined}
+          />
+          {showOtherEmptyError && (
+            <p id="license-other-error" className="text-xs text-red-500">
+              A short description is required when picking Other.
+            </p>
+          )}
+          {showOtherTooLongError && (
+            <p className="text-xs text-red-500">
+              Keep the description under {MAX_OTHER_LICENSE_LENGTH} characters.
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Your issue will be auto-labeled <code>license-unsure</code> so a maintainer reviews it before merge.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function CategorySelector({
   categories,
   selected,
@@ -285,6 +441,8 @@ export function SubmitForm({
     hex: "",
     categories: [],
     newCategory: "",
+    licenseId: "",
+    licenseOther: "",
   });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -414,6 +572,11 @@ export function SubmitForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const licenseValidation = validateLicenseSelection(
+    form.licenseId,
+    form.licenseOther,
+  );
+
   function buildSubmissionBody(): string {
     const validation = fileState?.validation;
     const checksText = validation
@@ -421,6 +584,13 @@ export function SubmitForm({
           .map((c) => `- [${c.passed ? "x" : " "}] ${c.name}: ${c.message}`)
           .join("\n")
       : "No file uploaded";
+
+    const resolvedLicense = licenseValidation.ok
+      ? licenseValidation.resolved
+      : "UNSPECIFIED";
+    const licenseLine = licenseValidation.ok && licenseValidation.needsTriage
+      ? `${resolvedLicense} (submitter picked Other — needs maintainer confirmation)`
+      : resolvedLicense;
 
     const timestamp = new Date().toISOString();
     const lines = [
@@ -433,6 +603,7 @@ export function SubmitForm({
       `- **Brand Guidelines**: ${form.guidelinesUrl || "-"}`,
       `- **Brand Hex Color**: ${form.hex ? `#${form.hex.replace(/^#/, "")}` : "-"}`,
       `- **Categories**: ${form.categories.length ? form.categories.join(", ") : "-"}`,
+      `- **License**: ${licenseLine}`,
       ``,
       `### SVG Validation`,
       checksText,
@@ -454,7 +625,7 @@ export function SubmitForm({
           variants: {
             default: `/icons/${form.slug || "your-brand"}/default.svg`,
           },
-          license: "TODO",
+          license: resolvedLicense,
           url: form.websiteUrl || "https://yourbrand.com",
           ...(form.guidelinesUrl ? { guidelines: form.guidelinesUrl } : {}),
         },
@@ -475,7 +646,13 @@ export function SubmitForm({
       `[Icon Request] ${form.iconName || "New Icon"} (via thesvg.org)`
     );
     const body = encodeURIComponent(buildSubmissionBody());
-    return `${GITHUB_ISSUES_URL}?title=${title}&body=${body}&labels=icon-request,submitted-via-thesvg`;
+    // Add license-unsure when the submitter explicitly picked "Other" so
+    // triage routes the issue to a maintainer for license confirmation
+    // before merge.
+    const extraLabels = licenseValidation.ok && licenseValidation.needsTriage
+      ? ",license-unsure"
+      : "";
+    return `${GITHUB_ISSUES_URL}?title=${title}&body=${body}&labels=icon-request,submitted-via-thesvg${extraLabels}`;
   }
 
   async function handleCopy() {
@@ -488,7 +665,10 @@ export function SubmitForm({
     }
   }
 
-  const canSubmit = fileState !== null && form.iconName.trim() !== "";
+  const canSubmit =
+    fileState !== null &&
+    form.iconName.trim() !== "" &&
+    licenseValidation.ok;
 
   return (
     <div className="space-y-6">
@@ -684,6 +864,16 @@ export function SubmitForm({
           </div>
         </div>
 
+        {/* License */}
+        <LicenseSelector
+          licenseId={form.licenseId}
+          onLicenseChange={(id) => updateField("licenseId", id)}
+          otherText={form.licenseOther}
+          onOtherTextChange={(val) => updateField("licenseOther", val)}
+          validation={licenseValidation}
+          onSuggest={(id) => updateField("licenseId", id)}
+        />
+
         {/* Categories */}
         <CategorySelector
           categories={allCategories}
@@ -713,6 +903,9 @@ export function SubmitForm({
                 has_guidelines_url: !!form.guidelinesUrl,
                 has_hex_color: form.hex.length === 6,
                 validation_passed: fileState?.validation?.valid ?? false,
+                license: licenseValidation.ok ? licenseValidation.resolved : null,
+                license_needs_triage:
+                  licenseValidation.ok && licenseValidation.needsTriage,
               });
             }
           }}
@@ -751,7 +944,7 @@ export function SubmitForm({
 
       {!canSubmit && (
         <p className="text-xs text-muted-foreground">
-          Upload an SVG file and enter an icon name to enable submission.
+          Upload an SVG file, enter an icon name, and pick a license to enable submission.
         </p>
       )}
     </div>

--- a/src/lib/license-options.test.mjs
+++ b/src/lib/license-options.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * Tests for the submission license selector validator.
+ *
+ * No test runner dep — uses Node's built-in `node:test` (Node ≥ 20).
+ * Run with: `node --test --experimental-strip-types src/lib/license-options.test.mjs`
+ * or via the eponymous wrapper script if the package adds one later.
+ *
+ * The tests target the pure validator only; UI behavior is exercised
+ * separately when the page is opened in a browser.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LICENSE_OPTIONS,
+  MAX_OTHER_LICENSE_LENGTH,
+  OTHER_LICENSE_ID,
+  validateLicenseSelection,
+} from "./license-options.ts";
+
+test("LICENSE_OPTIONS has unique ids", () => {
+  const ids = LICENSE_OPTIONS.map((o) => o.id);
+  const unique = new Set(ids);
+  assert.equal(unique.size, ids.length, "duplicate license id found");
+});
+
+test("LICENSE_OPTIONS contains the well-known SPDX ids we expect", () => {
+  const ids = new Set(LICENSE_OPTIONS.map((o) => o.id));
+  // Locking these in so a future refactor can't silently drop one and
+  // break the public icons.json contract.
+  for (const required of [
+    "CC0-1.0",
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "CC-BY-4.0",
+    "CC-BY-SA-4.0",
+    "CC-BY-ND-4.0",
+    "MPL-2.0",
+    "Unlicense",
+    "Other",
+  ]) {
+    assert.ok(ids.has(required), `missing license id: ${required}`);
+  }
+});
+
+test("exactly one option is the triage escape hatch", () => {
+  const triaged = LICENSE_OPTIONS.filter((o) => o.needsTriage);
+  assert.equal(triaged.length, 1);
+  assert.equal(triaged[0].id, OTHER_LICENSE_ID);
+});
+
+test("empty selection is rejected as missing", () => {
+  const r = validateLicenseSelection("", "");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "missing");
+});
+
+test("whitespace-only selection is rejected as missing", () => {
+  const r = validateLicenseSelection("   ", "");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "missing");
+});
+
+test("non-string license id is rejected (defensive)", () => {
+  // Simulating a tampered or programmatic call
+  const r = validateLicenseSelection(undefined, "");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "missing");
+});
+
+test("unknown license id is rejected", () => {
+  const r = validateLicenseSelection("GPL-99", "");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unknown");
+});
+
+test("each accepted license resolves to its id and is not triaged", () => {
+  for (const opt of LICENSE_OPTIONS) {
+    if (opt.id === OTHER_LICENSE_ID) continue;
+    const r = validateLicenseSelection(opt.id, "");
+    assert.equal(r.ok, true, `${opt.id} should be accepted`);
+    if (r.ok) {
+      assert.equal(r.resolved, opt.id);
+      assert.equal(r.needsTriage, false);
+    }
+  }
+});
+
+test("Other without description is rejected", () => {
+  const r = validateLicenseSelection(OTHER_LICENSE_ID, "");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "other_empty");
+});
+
+test("Other with whitespace-only description is rejected", () => {
+  const r = validateLicenseSelection(OTHER_LICENSE_ID, "   \t  ");
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "other_empty");
+});
+
+test("Other with description resolves to the trimmed text and is triaged", () => {
+  const r = validateLicenseSelection(
+    OTHER_LICENSE_ID,
+    "  Acme Brand Guidelines v2 — non-commercial only  ",
+  );
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.resolved, "Acme Brand Guidelines v2 — non-commercial only");
+    assert.equal(r.needsTriage, true);
+  }
+});
+
+test("Other with description over MAX length is rejected", () => {
+  const tooLong = "x".repeat(MAX_OTHER_LICENSE_LENGTH + 1);
+  const r = validateLicenseSelection(OTHER_LICENSE_ID, tooLong);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "other_too_long");
+});
+
+test("Other with description at exactly MAX length is accepted", () => {
+  const max = "x".repeat(MAX_OTHER_LICENSE_LENGTH);
+  const r = validateLicenseSelection(OTHER_LICENSE_ID, max);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.resolved.length, MAX_OTHER_LICENSE_LENGTH);
+  }
+});

--- a/src/lib/license-options.ts
+++ b/src/lib/license-options.ts
@@ -1,0 +1,140 @@
+/**
+ * Submission-time license selection.
+ *
+ * The submit form previously left the license field as a placeholder in
+ * the generated issue body, which meant every accepted icon required a
+ * maintainer-led round-trip on the issue thread to ask "what license?".
+ * Front-loading this choice on the form cuts that round-trip.
+ *
+ * Kept as a pure module (no React) so the validation logic can be tested
+ * with `node --test` without a DOM or component runner.
+ */
+
+export interface LicenseOption {
+  /** SPDX-like id used in icons.json `license` field. */
+  id: string;
+  /** Short label shown in the form. */
+  label: string;
+  /** One-line helper text under the option. */
+  description: string;
+  /**
+   * When true, the auto-generated GitHub issue gets a `license-unsure`
+   * label so triage routes it for ownership confirmation before merge.
+   * Reserved for the "Other / unsure" branch.
+   */
+  needsTriage?: boolean;
+}
+
+/**
+ * The five licenses we routinely accept for icon submissions, plus an
+ * explicit "Other / unsure" escape hatch so we don't reject borderline
+ * cases — those just get labeled for review instead of merged blindly.
+ *
+ * Order matters: most common first.
+ */
+export const LICENSE_OPTIONS: readonly LicenseOption[] = [
+  // Public-domain dedications
+  {
+    id: "CC0-1.0",
+    label: "CC0 1.0 (public domain)",
+    description: "I made this myself and waive all rights, or it's already public domain.",
+  },
+  {
+    id: "Unlicense",
+    label: "The Unlicense (public domain)",
+    description: "Public-domain dedication, common for small OSS projects.",
+  },
+  // Permissive
+  {
+    id: "MIT",
+    label: "MIT",
+    description: "Permissive, attribution-only. Common for open-source project logos.",
+  },
+  {
+    id: "Apache-2.0",
+    label: "Apache 2.0",
+    description: "Permissive with explicit patent grant. Common for cloud / infra brands.",
+  },
+  {
+    id: "BSD-3-Clause",
+    label: "BSD 3-Clause",
+    description: "Permissive, attribution + no-endorsement clause.",
+  },
+  {
+    id: "ISC",
+    label: "ISC",
+    description: "Permissive, functionally equivalent to MIT.",
+  },
+  // Creative Commons attribution family
+  {
+    id: "CC-BY-4.0",
+    label: "CC BY 4.0",
+    description: "Attribution required. Common for community brand kits.",
+  },
+  {
+    id: "CC-BY-SA-4.0",
+    label: "CC BY-SA 4.0",
+    description: "Attribution + share-alike. Wikipedia-style.",
+  },
+  {
+    id: "CC-BY-ND-4.0",
+    label: "CC BY-ND 4.0",
+    description: "Attribution, no derivatives. Common for corporate brand kits where the logo can't be modified.",
+  },
+  // Weak copyleft
+  {
+    id: "MPL-2.0",
+    label: "Mozilla Public License 2.0",
+    description: "File-level copyleft. Used by Mozilla and some adjacent projects.",
+  },
+  // Free-text escape hatch
+  {
+    id: "Other",
+    label: "Other / custom — needs maintainer review",
+    description: "Pick this for company brand marks, custom licenses, or anything you can't confirm. We'll verify before merging.",
+    needsTriage: true,
+  },
+] as const;
+
+const OPTIONS_BY_ID = new Map(LICENSE_OPTIONS.map((o) => [o.id, o]));
+
+/** The id sentinel that requires a free-text description. */
+export const OTHER_LICENSE_ID = "Other";
+
+/** Hard cap on the free-text "other" description to keep issue bodies sane. */
+export const MAX_OTHER_LICENSE_LENGTH = 120;
+
+export type LicenseValidation =
+  | { ok: true; resolved: string; needsTriage: boolean }
+  | { ok: false; reason: "missing" | "unknown" | "other_empty" | "other_too_long" };
+
+/**
+ * Validate a (licenseId, otherText) pair. Returns the string that should
+ * land in icons.json `license`, plus a flag for whether the submission
+ * needs maintainer license review.
+ *
+ * Pure — call from React, call from a test, call from a script.
+ */
+export function validateLicenseSelection(
+  licenseId: string,
+  otherText: string,
+): LicenseValidation {
+  if (typeof licenseId !== "string" || licenseId.trim() === "") {
+    return { ok: false, reason: "missing" };
+  }
+  const option = OPTIONS_BY_ID.get(licenseId);
+  if (!option) {
+    return { ok: false, reason: "unknown" };
+  }
+  if (option.id === OTHER_LICENSE_ID) {
+    const trimmed = (otherText ?? "").trim();
+    if (trimmed.length === 0) {
+      return { ok: false, reason: "other_empty" };
+    }
+    if (trimmed.length > MAX_OTHER_LICENSE_LENGTH) {
+      return { ok: false, reason: "other_too_long" };
+    }
+    return { ok: true, resolved: trimmed, needsTriage: true };
+  }
+  return { ok: true, resolved: option.id, needsTriage: false };
+}


### PR DESCRIPTION
## Summary

Every accepted icon submission today triggers a maintainer-led round-trip on the issue thread to ask *"what license?"* because the form ships with a placeholder license value in the generated body. This PR front-loads the choice on the form so that round-trip disappears.

### What submitters see
- Required **License** dropdown with 10 SPDX options + an explicit **Other / custom** escape hatch:
  - Public-domain: CC0, Unlicense
  - Permissive: MIT, Apache-2.0, BSD-3-Clause, ISC
  - CC attribution family: CC BY 4.0, CC BY-SA 4.0, CC BY-ND 4.0
  - Weak copyleft: MPL-2.0
- **"Help me pick"** disclosure with 4 yes/no chips that snap to a recommendation ("I drew it myself" → CC0, "MIT/Apache OSS project" → match the project, "CC BY brand kit" → CC BY 4.0, "Company brand / unsure" → Other).
- **"Licensing guide"** link in the header → new `LICENSING.md` at repo root covering the license-vs-trademark distinction, pick-by-question flow, the full accepted list, and what happens for the Other / triage path.
- **Other** branch requires a short description (≤120 chars), validates inline, and adds the `license-unsure` label to the auto-generated GitHub issue so triage routes it to a maintainer.

### Internal changes
- Submission is gated on a valid license; helper text updated.
- License is included in the `icons.json` entry in the issue body (no more placeholder) and in the `submit_form_completed` PostHog payload, with a `license_needs_triage` boolean for measuring how often the Other branch fires.
- Logic extracted to a pure `src/lib/license-options.ts` module so it can be tested without React.

## Tests

Used Node's built-in `node:test` runner — no new dev deps. **13 tests, all passing:**

```
node --test --experimental-strip-types src/lib/license-options.test.mjs
# tests 13
# pass 13
# fail 0
```

Covered:
- Empty / whitespace / non-string id → `missing`
- Unknown id → `unknown`
- Every accepted SPDX license resolves to itself, `needsTriage: false`
- Other with empty / whitespace text → `other_empty`
- Other over MAX length → `other_too_long`; at exact MAX → accepted
- Other with description → trimmed result, `needsTriage: true`
- Contract lock: all expected SPDX ids present; exactly one option is the triage escape hatch; all ids unique

## Test plan

- [x] `tsc --noEmit` clean
- [x] `node --test` all 13 pass
- [x] Browser: `/submit` renders the new selector with all 11 options, Help-me-pick chips snap to suggestions, Other branch reveals the description input, Submit button stays disabled until a license is picked.
- [ ] After merge: confirm a real submission populates the `License:` field in the generated issue body (was `TBD` before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License selection added to the submission flow; submissions require a validated license (including an “Other/custom” path that flags items for maintainer review).
  * Submissions now surface license info and mark items needing triage.

* **Documentation**
  * Comprehensive licensing guide added, including license selection flow, accepted licenses, unsupported cases, and takedown/correction procedures.

* **Tests**
  * New tests covering license options and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->