### PR TITLE
feat: add workbuddy icon

### DIFF
--- a/public/icons/workbuddy/default.svg
+++ b/public/icons/workbuddy/default.svg
@@ -1,0 +1,37 @@
+<svg width="280" height="280" viewBox="0 0 280 280" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_744_3208)">
+<rect width="280" height="280" rx="60.4211" fill="url(#paint0_linear_744_3208)"/>
+<g filter="url(#filter0_f_744_3208)">
+<circle cx="88.2504" cy="244.86" r="98.5668" fill="#32E6B9" fill-opacity="0.4" style="fill:#32E6B9;fill:color(display-p3 0.1961 0.9020 0.7255);fill-opacity:0.4;"/>
+</g>
+<g filter="url(#filter1_f_744_3208)">
+<circle cx="223.384" cy="290.328" r="90.0931" fill="#FFE355" fill-opacity="0.49" style="fill:#FFE355;fill:color(display-p3 1.0000 0.8891 0.3348);fill-opacity:0.49;"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M204.15 6.89352C206.896 4.43111 207.061 4.33611 209.074 4.21524C212.336 3.97692 215.324 5.54248 220.41 10.1729C232.291 20.9692 248.834 43.1654 259.119 62.1205L263.093 69.4768L268.707 72.2672C274.126 75.0055 283.015 80.6198 286.728 83.6308C288.407 85.0191 288.642 85.0483 290.388 84.3692C298.267 81.3008 309.553 85.3675 319.508 94.9178C328.47 103.507 337.052 118.181 340.34 130.429C340.82 132.4 341.458 136.638 341.69 139.794C342.44 150.876 338.886 159.726 332.042 163.733C330.644 164.54 330.551 164.759 330.59 168.245C330.905 184.841 326.432 201.406 317.445 217.561C307.301 235.7 289.238 254.464 264.791 272.142C251.663 281.695 220.604 299.792 206.561 306.145C172.92 321.29 145.952 327.1 122.527 324.23C108.554 322.537 92.7397 317.083 83.3819 310.752C80.9182 309.049 80.5286 308.944 78.6462 309.483C68.6285 312.36 55.5086 306.447 44.3628 294.075C39.9174 289.129 32.743 276.986 30.417 270.488C25.0365 255.281 26.1061 241.558 33.273 233.363C35.1245 231.252 35.1835 231.163 34.7791 227.614C34.1112 221.804 33.808 213.206 34.1131 207.656L34.3541 202.472L26.5713 188.706C14.5194 167.262 6.8648 149.255 3.91152 135.497C2.35249 127.954 2.44923 124.607 4.36401 122.131C5.52945 120.635 9.35191 119.087 13.9599 118.236C25.5602 116.199 50.8596 118.043 79.0059 123.012L81.9295 123.517L88.3537 117.834C99.0194 108.386 106.105 103.089 119.168 94.9439C132.783 86.4254 148.148 79.4181 165.452 73.8693L171.004 72.09L174.054 64.0775C184.981 35.233 196.172 13.9675 204.15 6.89352ZM112.625 154.702C100.275 161.832 94.0999 165.397 89.5627 169.393C71.1894 185.572 64.3228 211.198 72.145 234.396C74.0767 240.125 77.642 246.3 84.7719 258.65C91.9018 270.999 95.4667 277.173 99.4619 281.711C115.641 300.084 141.267 306.95 164.466 299.128C170.194 297.197 176.369 293.631 188.719 286.501L259.76 245.486C272.109 238.356 278.284 234.791 282.821 230.796C301.194 214.617 308.061 188.99 300.239 165.792C298.307 160.063 294.742 153.889 287.612 141.54C280.482 129.19 276.917 123.015 272.922 118.478C256.743 100.104 231.116 93.2378 207.918 101.06C202.19 102.992 196.015 106.557 183.666 113.687L112.625 154.702Z" fill="url(#paint1_linear_744_3208)"/>
+<rect x="119.473" y="204.341" width="28.0633" height="58.2852" rx="14.0316" transform="rotate(-30 119.473 204.341)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="195.186" y="160.627" width="28.0633" height="58.2852" rx="14.0316" transform="rotate(-30 195.186 160.627)" fill="white" style="fill:white;fill-opacity:1;"/>
+</g>
+<defs>
+<filter id="filter0_f_744_3208" x="-104.414" y="52.1958" width="385.327" height="385.328" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="47.0486" result="effect1_foregroundBlur_744_3208"/>
+</filter>
+<filter id="filter1_f_744_3208" x="56.2884" y="123.233" width="334.191" height="334.192" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="38.5013" result="effect1_foregroundBlur_744_3208"/>
+</filter>
+<linearGradient id="paint0_linear_744_3208" x1="140" y1="0" x2="140" y2="280" gradientUnits="userSpaceOnUse">
+<stop stop-color="#0EC8A9" style="stop-color:#0EC8A9;stop-color:color(display-p3 0.0565 0.7837 0.6625);stop-opacity:1;"/>
+<stop offset="1" stop-color="#01C886" style="stop-color:#01C886;stop-color:color(display-p3 0.0021 0.7858 0.5246);stop-opacity:1;"/>
+</linearGradient>
+<linearGradient id="paint1_linear_744_3208" x1="106.647" y1="62.5482" x2="237.632" y2="289.42" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.8" style="stop-color:white;stop-opacity:0.8;"/>
+<stop offset="0.437689" stop-color="white" style="stop-color:white;stop-opacity:1;"/>
+</linearGradient>
+<clipPath id="clip0_744_3208">
+<rect width="280" height="280" rx="60.4211" fill="white" style="fill:white;fill-opacity:1;"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -110265,22 +110265,6 @@
     "collection": "brands"
   },
   {
-    "slug": "workbuddy",
-    "title": "workbuddy",
-    "aliases": [],
-    "hex": "000000",
-    "categories": [
-      "Software"
-    ],
-    "variants": {
-      "default": "/icons/workbuddy/default.svg"
-    },
-    "license": "MIT",
-    "url": "https://workbuddy.cn",
-    "dateAdded": "2026-06-10",
-    "collection": "brands"
-  },
-  {
     "slug": "workday",
     "title": "Workday",
     "aliases": [],
@@ -110295,6 +110279,22 @@
     "license": "MIT",
     "url": "https://www.workday.com",
     "dateAdded": "2026-03-22",
+    "collection": "brands"
+  },
+  {
+    "slug": "workbuddy",
+    "title": "workbuddy",
+    "aliases": [],
+    "hex": "000000",
+    "categories": [
+      "Software"
+    ],
+    "variants": {
+      "default": "/icons/workbuddy/default.svg"
+    },
+    "license": "MIT",
+    "url": "https://workbuddy.cn",
+    "dateAdded": "2026-06-10",
     "collection": "brands"
   },
   {

--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -110265,6 +110265,22 @@
     "collection": "brands"
   },
   {
+    "slug": "workbuddy",
+    "title": "workbuddy",
+    "aliases": [],
+    "hex": "000000",
+    "categories": [
+      "Software"
+    ],
+    "variants": {
+      "default": "/icons/workbuddy/default.svg"
+    },
+    "license": "MIT",
+    "url": "https://workbuddy.cn",
+    "dateAdded": "2026-06-10",
+    "collection": "brands"
+  },
+  {
     "slug": "workday",
     "title": "Workday",
     "aliases": [],


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

## Type

- [ ] New icon(s)
- [ ] Icon update/fix
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance/chore

## Checklist

- [ ] My changes follow the project's conventions
- [ ] I've tested the build: `cd packages/icons && npm run build`
- [ ] Security audit passes: `npm run audit`
- [ ] Dist validation passes: `npm run validate`

### For icon submissions:

- [ ] SVG has a valid `viewBox` attribute
- [ ] SVG is under 50KB
- [ ] No embedded `<script>` tags or event handlers
- [ ] Icon accurately represents the official brand
- [ ] `icons.json` entry is complete (slug, title, hex, categories, variants)

## Related Issues

<!-- Closes #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the WorkBuddy brand icon to the collection. It’s available in the Software category, distributed under the MIT license, and includes an SVG variant for use in apps and sites. A reference URL is included for more information; the icon was added to the brands collection on 2026-06-10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->