### PR TITLE
fix: mobile responsiveness pass and native-feel polish

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,9 +96,14 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* Guard against any descendant that incidentally overshoots the
+       viewport. Belt-and-suspenders for narrow phones (360-393px). */
+    overflow-x: hidden;
   }
   html {
     @apply font-sans;
+    /* iOS double-tap zoom dampens text resize jumps. */
+    -webkit-text-size-adjust: 100%;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -88,6 +88,24 @@ export const metadata: Metadata = {
       "application/rss+xml": "https://thesvg.org/feed.xml",
     },
   },
+  appleWebApp: {
+    capable: true,
+    title: "theSVG",
+    statusBarStyle: "black-translucent",
+  },
+};
+
+// Mobile-friendly viewport so the layout uses the full notched area,
+// scales correctly at common phone widths (360 - 430), and still allows
+// the user to zoom for accessibility (no maximum-scale lockdown).
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
 };
 
 export default function RootLayout({
@@ -123,7 +141,7 @@ export default function RootLayout({
           <Suspense>
             <Header />
           </Suspense>
-          <main className="min-h-[calc(100vh-3.75rem)]">{children}</main>
+          <main className="min-h-[calc(100dvh-7.25rem)] sm:min-h-[calc(100dvh-3.75rem)]">{children}</main>
           <Footer />
         </ThemeProvider>
       </body>

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -200,15 +200,15 @@ function Step({
   iconColor: string;
 }) {
   return (
-    <div className={`flex gap-3 rounded-xl bg-gradient-to-br ${accent} p-4 transition-all hover:shadow-md`}>
+    <div className={`flex min-w-0 gap-3 rounded-xl bg-gradient-to-br ${accent} p-4 transition-all hover:shadow-md`}>
       <div className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background/80 ${iconColor} shadow-sm`}>
         {icon}
       </div>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <h3 className="text-sm font-medium">
           <span className="text-muted-foreground/60">#{number}</span> {title}
         </h3>
-        <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+        <p className="mt-0.5 text-xs break-words text-muted-foreground">{description}</p>
       </div>
     </div>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -59,11 +59,11 @@ function GcpLogo({ className }: { className?: string }) {
 
 function SubmitButton() {
   return (
-    <Link href="/submit" className="group/submit relative">
-      <span className="relative inline-flex h-8 items-center gap-1.5 overflow-hidden rounded-lg bg-gradient-to-b from-orange-400 to-orange-600 px-3.5 text-xs font-semibold text-white shadow-[0_1px_3px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.2)] transition-all duration-200 hover:from-orange-400 hover:to-orange-500 hover:shadow-[0_3px_12px_rgba(249,115,22,0.4),inset_0_1px_0_rgba(255,255,255,0.25)] active:scale-[0.97] active:shadow-[0_0px_1px_rgba(0,0,0,0.3),inset_0_2px_4px_rgba(0,0,0,0.1)]">
+    <Link href="/submit" className="group/submit relative" aria-label="Submit an icon">
+      <span className="relative inline-flex h-9 items-center gap-1.5 overflow-hidden rounded-lg bg-gradient-to-b from-orange-400 to-orange-600 px-3 text-xs font-semibold text-white shadow-[0_1px_3px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.2)] transition-all duration-200 hover:from-orange-400 hover:to-orange-500 hover:shadow-[0_3px_12px_rgba(249,115,22,0.4),inset_0_1px_0_rgba(255,255,255,0.25)] active:scale-[0.97] active:shadow-[0_0px_1px_rgba(0,0,0,0.3),inset_0_2px_4px_rgba(0,0,0,0.1)] sm:h-8 sm:px-3.5">
         {/* Shimmer */}
         <span className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/15 to-transparent transition-transform duration-700 group-hover/submit:translate-x-full" />
-        <Plus className="relative h-3.5 w-3.5 transition-transform duration-200 group-hover/submit:rotate-90" />
+        <Plus className="relative h-4 w-4 transition-transform duration-200 group-hover/submit:rotate-90 sm:h-3.5 sm:w-3.5" />
         <span className="relative hidden sm:inline">Submit Icon</span>
       </span>
     </Link>
@@ -309,22 +309,30 @@ export function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-50 w-full px-2 pt-2 pb-0 sm:px-3 sm:pt-2.5">
+    <header
+      className="sticky top-0 z-50 w-full px-2 pt-2 pb-0 sm:px-3 sm:pt-2.5"
+      style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
+    >
       <div className="mx-auto max-w-[1800px] rounded-2xl border border-black/[0.06] bg-background/90 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl dark:border-white/[0.08] dark:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]">
-        <div className="flex h-12 items-center gap-3 px-2.5 sm:px-4">
+        {/* On mobile (<sm) the row wraps and the search drops to a second
+            row using `order-last`, so phones like Realme/iPhone SE get a
+            true full-width input instead of being squeezed between Submit
+            and the icon cluster. On sm+ the layout returns to one row with
+            the search as `flex-1`. */}
+        <div className="flex flex-wrap items-center gap-2 px-2.5 py-2 sm:h-12 sm:flex-nowrap sm:gap-3 sm:py-0 sm:px-4">
           {/* Left: menu + logo */}
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8 md:hidden"
+              className="h-11 w-11 md:hidden"
               onClick={toggleSidebar}
               aria-label="Toggle menu"
             >
-              <Menu className="h-4 w-4" />
+              <Menu className="h-5 w-5" />
             </Button>
 
-            <Link href="/" className="group/logo flex items-center gap-1.5">
+            <Link href="/" className="group/logo flex items-center gap-1.5" aria-label="theSVG home">
               <img
                 src="/logo-transparent.svg"
                 alt="theSVG"
@@ -394,9 +402,15 @@ export function Header() {
             </Link>
           </nav>
 
-          {/* Center: search with dropdown */}
-          <form onSubmit={handleSearchSubmit} className="relative flex-1">
-            <div className="relative mx-auto max-w-xl">
+          {/* Center: search with dropdown. On mobile the form takes the
+              full row (`order-last w-full`) so the input is never narrower
+              than ~310px on a 360px device. On sm+ it reverts to `flex-1`
+              with the historical `max-w-xl` centering. */}
+          <form
+            onSubmit={handleSearchSubmit}
+            className="relative order-last w-full basis-full sm:order-none sm:w-auto sm:flex-1 sm:basis-auto"
+          >
+            <div className="relative w-full sm:mx-auto sm:max-w-xl">
               <Search className="absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
               <input
                 ref={inputRef}
@@ -406,7 +420,9 @@ export function Header() {
                 onFocus={() => setFocused(true)}
                 onKeyDown={handleKeyNav}
                 placeholder={dynamicPlaceholder}
-                className="h-9 w-full rounded-xl border border-border bg-muted/40 pr-16 pl-9 text-sm shadow-sm outline-none transition-all placeholder:text-muted-foreground/50 focus:border-primary/40 focus:bg-background focus:shadow-[0_2px_12px_-2px_rgba(0,0,0,0.08)] focus:ring-1 focus:ring-ring/30 dark:border-white/[0.08] dark:bg-white/[0.04] dark:focus:border-white/[0.15] dark:focus:bg-white/[0.06] dark:focus:shadow-[0_2px_12px_-2px_rgba(0,0,0,0.3)]"
+                /* text-base (16px) on mobile prevents iOS auto-zoom on
+                   focus; sm+ keeps the historical 14px. */
+                className="h-11 w-full rounded-xl border border-border bg-muted/40 pr-12 pl-9 text-base shadow-sm outline-none transition-all placeholder:text-muted-foreground/50 focus:border-primary/40 focus:bg-background focus:shadow-[0_2px_12px_-2px_rgba(0,0,0,0.08)] focus:ring-1 focus:ring-ring/30 sm:h-9 sm:pr-16 sm:text-sm dark:border-white/[0.08] dark:bg-white/[0.04] dark:focus:border-white/[0.15] dark:focus:bg-white/[0.06] dark:focus:shadow-[0_2px_12px_-2px_rgba(0,0,0,0.3)]"
                 aria-label="Search icons"
                 role="combobox"
                 aria-expanded={showDropdown}
@@ -436,12 +452,13 @@ export function Header() {
               </div>
             </div>
 
-            {/* Search dropdown */}
+            {/* Search dropdown - spans the input on mobile, capped at the
+                input width (max-w-xl) on sm+. */}
             {showDropdown && (
               <div
                 ref={dropdownRef}
                 id={listboxId}
-                className="absolute top-full right-0 left-0 z-50 mx-auto mt-1.5 max-w-xl overflow-hidden rounded-xl border border-border/40 bg-background/95 shadow-[0_8px_30px_-4px_rgba(0,0,0,0.15)] backdrop-blur-2xl backdrop-saturate-150 dark:border-white/[0.1] dark:bg-[rgba(10,10,10,0.95)] dark:shadow-[0_8px_30px_-4px_rgba(0,0,0,0.6)]"
+                className="absolute top-full right-0 left-0 z-50 mt-1.5 overflow-hidden rounded-xl border border-border/40 bg-background/95 shadow-[0_8px_30px_-4px_rgba(0,0,0,0.15)] backdrop-blur-2xl backdrop-saturate-150 sm:mx-auto sm:max-w-xl dark:border-white/[0.1] dark:bg-[rgba(10,10,10,0.95)] dark:shadow-[0_8px_30px_-4px_rgba(0,0,0,0.6)]"
                 role="listbox"
               >
                 {hasQuery ? (
@@ -628,8 +645,10 @@ export function Header() {
             )}
           </form>
 
-          {/* Right: actions */}
-          <div className="flex shrink-0 items-center gap-1">
+          {/* Right: actions. On mobile we keep only Submit + GitHub +
+              theme toggle so the top row stays slim and the search row
+              below can claim the full width. */}
+          <div className="ml-auto flex shrink-0 items-center gap-0.5 sm:ml-0 sm:gap-1">
             <Link
               href="/extensions"
               className="hidden items-center rounded-lg px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground lg:inline-flex"
@@ -639,7 +658,7 @@ export function Header() {
 
             <SubmitButton />
 
-            <div className="ml-1 flex items-center gap-1">
+            <div className="ml-1 flex items-center gap-0.5 sm:gap-1">
               <a
                 href="https://www.npmjs.com/package/thesvg"
                 target="_blank"
@@ -719,14 +738,14 @@ export function Header() {
                 rel="noopener noreferrer"
                 aria-label="View on GitHub"
                 title="GitHub repository"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-border/50 text-muted-foreground transition-all hover:border-foreground/20 hover:bg-accent hover:text-foreground dark:border-white/[0.08] dark:hover:border-white/20 dark:hover:bg-white/[0.06]"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border/50 text-muted-foreground transition-all hover:border-foreground/20 hover:bg-accent hover:text-foreground sm:h-8 sm:w-8 dark:border-white/[0.08] dark:hover:border-white/20 dark:hover:bg-white/[0.06]"
               >
                 <Github className="h-4 w-4" />
               </a>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8"
+                className="h-9 w-9 sm:h-8 sm:w-8"
                 onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
                 aria-label="Toggle theme"
               >

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -316,8 +316,10 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
         ) : (
           /* Filtered view */
           <>
-            {/* Sticky toolbar - count + controls */}
-            <div className="sticky top-[3.75rem] z-20 border-b border-border/30 bg-background/95 backdrop-blur-xl">
+            {/* Sticky toolbar - count + controls. Header is taller on
+                mobile because the search occupies its own row, so the
+                sticky offset bumps up at <sm. */}
+            <div className="sticky top-[7.25rem] z-20 border-b border-border/30 bg-background/95 backdrop-blur-xl sm:top-[3.75rem]">
               <div className="mx-auto flex max-w-7xl items-center gap-1.5 px-3 py-1.5 sm:gap-2 sm:px-4">
                 {/* Count label */}
                 <p className="flex-1 text-sm text-muted-foreground">

--- a/src/components/icons/icon-detail.tsx
+++ b/src/components/icons/icon-detail.tsx
@@ -147,10 +147,17 @@ export function IconDetail({ icon, onClose }: IconDetailProps) {
 
   return (
     <Dialog open={!!icon} onOpenChange={() => onClose()}>
-      <DialogContent className="max-h-[85vh] max-w-[calc(100%-2rem)] gap-0 overflow-hidden rounded-2xl border-border/30 bg-background/95 p-0 shadow-2xl backdrop-blur-2xl sm:max-w-lg">
+      {/* On mobile the modal uses a slim margin (max-w-[calc(100%-1rem)])
+          so the content reaches near both edges and never causes a
+          horizontal scroll, with safe-area-inset padding for notched
+          devices. sm+ caps the width at lg as before. */}
+      <DialogContent className="max-h-[90vh] max-w-[calc(100%-1rem)] gap-0 overflow-hidden rounded-2xl border-border/30 bg-background/95 p-0 shadow-2xl backdrop-blur-2xl sm:max-h-[85vh] sm:max-w-lg">
         <DialogTitle className="sr-only">{icon.title}</DialogTitle>
 
-        <div className="max-h-[85vh] overflow-y-auto">
+        <div
+          className="max-h-[90vh] overflow-y-auto sm:max-h-[85vh]"
+          style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+        >
           {/* Preview area */}
           <div className="icon-preview-bg relative flex items-center justify-center px-8 py-10">
             <img

--- a/src/components/submit/submit-form.tsx
+++ b/src/components/submit/submit-form.tsx
@@ -294,7 +294,8 @@ function LicenseSelector({
         value={licenseId}
         onChange={(e) => onLicenseChange(e.target.value)}
         required
-        className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm shadow-sm outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring"
+        /* text-base on mobile prevents iOS auto-zoom on focus. */
+        className="h-11 w-full rounded-lg border border-border bg-background px-3 text-base shadow-sm outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring sm:h-9 sm:py-2 sm:text-sm"
       >
         <option value="">Select a license…</option>
         {LICENSE_OPTIONS.map((opt) => (
@@ -371,7 +372,7 @@ function CategorySelector({
               type="button"
               onClick={() => onToggle(cat)}
               className={cn(
-                "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+                "min-h-[32px] rounded-full border px-3 py-1 text-xs font-medium transition-colors",
                 active
                   ? "border-foreground bg-foreground text-background"
                   : "border-border bg-card text-muted-foreground hover:border-foreground/50 hover:text-foreground"
@@ -389,7 +390,7 @@ function CategorySelector({
               key={cat}
               type="button"
               onClick={() => onToggle(cat)}
-              className="rounded-full border border-orange-500/50 bg-orange-500/10 px-2.5 py-0.5 text-xs font-medium text-orange-600 transition-colors hover:bg-orange-500/20 dark:text-orange-400"
+              className="min-h-[32px] rounded-full border border-orange-500/50 bg-orange-500/10 px-3 py-1 text-xs font-medium text-orange-600 transition-colors hover:bg-orange-500/20 dark:text-orange-400"
             >
               {cat} &times;
             </button>
@@ -406,14 +407,14 @@ function CategorySelector({
               onAddCategory();
             }
           }}
-          className="h-7 text-xs"
+          className="h-9 text-sm sm:h-7 sm:text-xs"
         />
         <Button
           type="button"
           size="sm"
           variant="outline"
           onClick={onAddCategory}
-          className="h-7 shrink-0 text-xs"
+          className="h-9 shrink-0 text-sm sm:h-7 sm:text-xs"
         >
           Add
         </Button>
@@ -910,7 +911,7 @@ export function SubmitForm({
             }
           }}
           className={cn(
-            "inline-flex h-9 items-center justify-center gap-2 rounded-lg px-4 text-sm font-medium transition-colors",
+            "inline-flex h-11 items-center justify-center gap-2 rounded-lg px-4 text-sm font-medium transition-colors sm:h-9",
             canSubmit
               ? "bg-foreground text-background hover:bg-foreground/90"
               : "pointer-events-none cursor-not-allowed bg-muted text-muted-foreground"
@@ -926,7 +927,7 @@ export function SubmitForm({
           variant="outline"
           onClick={handleCopy}
           disabled={!canSubmit}
-          className="h-9 gap-2"
+          className="h-11 gap-2 sm:h-9"
         >
           {copied ? (
             <>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        // h-10 on mobile gives ~40px tap targets and the text-base (16px)
+        // default prevents iOS Safari from auto-zooming inputs on focus.
+        // md+ keeps the compact h-8 / text-sm sizing this design uses
+        // throughout desktop forms.
+        "h-10 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:h-8 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #544.

## Problem

On Android 11 / Realme 6i / Brave (the reporter's setup), the header search input is squeezed to roughly 140px because `header.tsx` is one flex row: menu + logo on the left, Submit + npm/raycast/figma/vscode/github + theme on the right, and the search input as `flex-1` with a `max-w-xl` wrapper between them. Several right-side icons are `hidden sm:inline-flex`, but Submit + GitHub + theme alone still claim about 120px on a 360px viewport, so the input becomes unusable.

The dropdown panel had the same `max-w-xl mx-auto` cap, so suggestions floated awkwardly in the center even on phones.

## Fix

- On `<sm` the header row uses `flex-wrap`, and the search form is `order-last w-full basis-full` so it drops to its own row beneath the chrome. From `sm` upward, the form reverts to `flex-1` with the historical `max-w-xl` centering.
- The dropdown is `mx-auto sm:max-w-xl` only on `sm+`, so on mobile it spans the input.
- Input is `h-11 text-base` on mobile (no iOS auto-zoom on focus, ~44px touch target), `h-9 text-sm` on `sm+`.
- Touch targets across the header (menu, GitHub, theme, Submit) bump to 36-44px on mobile.

## Broader audit findings

- Added `viewport` export with `viewport-fit=cover`, theme-color metas, and `appleWebApp` config in `src/app/layout.tsx`.
- `src/components/ui/input.tsx` now defaults to `h-10 text-base` on mobile, `md:h-8 md:text-sm` on desktop (stops iOS auto-zoom across every form in the app).
- License `<select>`, custom-category Input + Add button, and the Submit / Copy actions in `submit-form.tsx` all picked up taller mobile heights.
- Submit page Step cards added `min-w-0` / `flex-1` / `break-words` so descriptions wrap inside the gradient card at 360px (they were clipping previously).
- Sticky toolbar in `home-content.tsx` and the layout's `main` min-height use `sm:`-prefixed offsets so the taller two-row mobile header doesn't overlap content.
- Icon detail Dialog widens to `calc(100%-1rem)` on mobile and pads `env(safe-area-inset-bottom)` so the View full details CTA isn't hidden behind the home indicator on notched phones.
- `globals.css` adds `body { overflow-x: hidden }` as a viewport-overflow guard and `html { -webkit-text-size-adjust: 100% }` to stop iOS Safari font scaling on orientation change.
- Header itself uses `paddingTop: max(0.5rem, env(safe-area-inset-top))` so the floating chip clears the status bar on notched devices.

## Test plan

Verified locally with Playwright at viewports 360 / 375 / 393 / 412 / 768 / 1024 across `/`, `/submit`, `/recents`, `/extensions`, `/icon/github`:

- [x] No horizontal scroll on any tested page on mobile widths
- [x] Search input fills the full row on `<sm` (measured ~322px wide at 360px vs ~140px before)
- [x] Search dropdown panel spans the input on mobile and stays capped at `max-w-xl` on `sm+`
- [x] Search results page (`/?q=node`) renders cleanly with no overlap between sticky header and sticky toolbar
- [x] Sidebar drawer opens/closes correctly on mobile and is dismissable
- [x] Submit page step cards wrap text inside the card at 360px
- [x] Icon detail modal reaches near both edges on mobile with safe-area padding
- [x] `pnpm build` succeeds, `tsc --noEmit` clean, `pnpm lint` no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for notched mobile devices with optimized viewport configuration.
  * Added Apple Web App support for improved iOS installation experience.

* **Bug Fixes**
  * Improved mobile layout responsiveness across header, forms, and content areas.
  * Fixed text wrapping and overflow issues on smaller screens.
  * Enhanced safe-area inset handling for devices with notches or home indicators.
  * Optimized touch target sizes and spacing for mobile usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->