### PR TITLE
fix: mobile polish followup (safe-area, blur, statusBarStyle, submit inputs)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,6 +88,17 @@
   --border: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 12%);
   --ring: oklch(0.5 0 0);
+  /* Header height token used by the sticky toolbar and main min-h.
+     On mobile the header is two rows (logo+actions + full-width search)
+     ~= 7.25rem; safe-area-inset-top extends it on notched devices
+     beyond the 0.5rem we already reserve, so subtract that. */
+  --header-h: calc(7.25rem + max(0px, env(safe-area-inset-top) - 0.5rem));
+}
+
+@media (min-width: 640px) {
+  :root {
+    --header-h: 3.75rem;
+  }
 }
 
 @layer base {
@@ -96,9 +107,10 @@
   }
   body {
     @apply bg-background text-foreground;
-    /* Guard against any descendant that incidentally overshoots the
-       viewport. Belt-and-suspenders for narrow phones (360-393px). */
-    overflow-x: hidden;
+    /* `clip` (not `hidden`) so the body remains the default scroll
+       container on iOS Safari and `position:fixed` descendants keep
+       viewport-relative placement on older iOS. */
+    overflow-x: clip;
   }
   html {
     @apply font-sans;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -91,7 +91,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     title: "theSVG",
-    statusBarStyle: "black-translucent",
+    statusBarStyle: "default",
   },
 };
 
@@ -141,7 +141,7 @@ export default function RootLayout({
           <Suspense>
             <Header />
           </Suspense>
-          <main className="min-h-[calc(100dvh-7.25rem)] sm:min-h-[calc(100dvh-3.75rem)]">{children}</main>
+          <main className="min-h-[calc(100dvh-var(--header-h))]">{children}</main>
           <Footer />
         </ThemeProvider>
       </body>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -313,7 +313,7 @@ export function Header() {
       className="sticky top-0 z-50 w-full px-2 pt-2 pb-0 sm:px-3 sm:pt-2.5"
       style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
     >
-      <div className="mx-auto max-w-[1800px] rounded-2xl border border-black/[0.06] bg-background/90 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl dark:border-white/[0.08] dark:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]">
+      <div className="mx-auto max-w-[1800px] rounded-2xl border border-black/[0.06] bg-background/95 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl backdrop-saturate-150 supports-[backdrop-filter]:bg-background/75 sm:supports-[backdrop-filter]:bg-background/85 dark:border-white/[0.08] dark:bg-black/85 dark:supports-[backdrop-filter]:bg-black/55 sm:dark:supports-[backdrop-filter]:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]">
         {/* On mobile (<sm) the row wraps and the search drops to a second
             row using `order-last`, so phones like Realme/iPhone SE get a
             true full-width input instead of being squeezed between Submit
@@ -458,7 +458,7 @@ export function Header() {
               <div
                 ref={dropdownRef}
                 id={listboxId}
-                className="absolute top-full right-0 left-0 z-50 mt-1.5 overflow-hidden rounded-xl border border-border/40 bg-background/95 shadow-[0_8px_30px_-4px_rgba(0,0,0,0.15)] backdrop-blur-2xl backdrop-saturate-150 sm:mx-auto sm:max-w-xl dark:border-white/[0.1] dark:bg-[rgba(10,10,10,0.95)] dark:shadow-[0_8px_30px_-4px_rgba(0,0,0,0.6)]"
+                className="absolute top-full right-0 left-0 z-50 mt-1.5 overflow-hidden rounded-xl border border-border/40 bg-background shadow-[0_8px_30px_-4px_rgba(0,0,0,0.15)] backdrop-blur-2xl backdrop-saturate-150 sm:mx-auto sm:max-w-xl sm:bg-background/95 dark:border-white/[0.1] dark:bg-[#0a0a0a] dark:shadow-[0_8px_30px_-4px_rgba(0,0,0,0.6)] sm:dark:bg-[rgba(10,10,10,0.95)]"
                 role="listbox"
               >
                 {hasQuery ? (

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -316,10 +316,11 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
         ) : (
           /* Filtered view */
           <>
-            {/* Sticky toolbar - count + controls. Header is taller on
-                mobile because the search occupies its own row, so the
-                sticky offset bumps up at <sm. */}
-            <div className="sticky top-[7.25rem] z-20 border-b border-border/30 bg-background/95 backdrop-blur-xl sm:top-[3.75rem]">
+            {/* Sticky toolbar pinned to the bottom of the live header.
+                Header height is exposed as `--header-h` and switches at
+                sm so this offset stays correct on both mobile (two-row
+                + safe-area) and desktop (single row). */}
+            <div className="sticky top-[var(--header-h)] z-20 border-b border-border/30 bg-background backdrop-blur-2xl sm:bg-background/95">
               <div className="mx-auto flex max-w-7xl items-center gap-1.5 px-3 py-1.5 sm:gap-2 sm:px-4">
                 {/* Count label */}
                 <p className="flex-1 text-sm text-muted-foreground">

--- a/src/components/submit/submit-form.tsx
+++ b/src/components/submit/submit-form.tsx
@@ -407,14 +407,14 @@ function CategorySelector({
               onAddCategory();
             }
           }}
-          className="h-9 text-sm sm:h-7 sm:text-xs"
+          className="h-10 text-base sm:h-7 sm:text-xs"
         />
         <Button
           type="button"
           size="sm"
           variant="outline"
           onClick={onAddCategory}
-          className="h-9 shrink-0 text-sm sm:h-7 sm:text-xs"
+          className="h-10 shrink-0 text-base sm:h-7 sm:text-xs"
         >
           Add
         </Button>


### PR DESCRIPTION
Follow-up on PR #553 addressing the Greptile review notes that came in after merge, plus visual polish from a live mobile pass.

## Greptile review fixes

**P1 - sticky toolbar offset now scales with safe-area-inset-top.** The toolbar at `top-[7.25rem]` on `<sm` did not account for the extra 47px or so that notched devices add via `env(safe-area-inset-top)` (header `paddingTop: max(0.5rem, env(safe-area-inset-top))` extends the visible header beyond 7.25rem). On notched iPhones the toolbar scrolled into the visible header area on every page. Same root cause on `<main>` `min-h-[calc(100dvh-7.25rem)]`.

Both now share a single CSS token `--header-h` declared in `globals.css`:

```css
:root {
  --header-h: calc(7.25rem + max(0px, env(safe-area-inset-top) - 0.5rem));
}
@media (min-width: 640px) {
  :root { --header-h: 3.75rem; }
}
```

Used by:
- `home-content.tsx` sticky toolbar: `top-[var(--header-h)]`
- `layout.tsx` main: `min-h-[calc(100dvh-var(--header-h))]`

**P2 - overflow-x: clip not hidden.** `overflow-x: hidden` on `<body>` disables the body as the default scroll container on iOS Safari. Fixed-position descendants (dialogs, popovers) can lose viewport-relative placement on older iOS. Switched to `overflow-x: clip` which prevents horizontal overflow without affecting the body's scroll role.

**P2 - statusBarStyle "default" instead of "black-translucent".** When the app is saved to the home screen on a light-mode device, white status bar icons become invisible against the `#ffffff` header. `default` renders dark icons in light mode and white in dark mode.

## CodeRabbit nit

`submit-form.tsx` custom-category input + Add button used `h-9 text-sm` on mobile (14px), under the 16px threshold that prevents iOS Safari from auto-zooming on focus, the exact issue PR #553 fixed elsewhere. Bumped both to `h-10 text-base sm:h-7 sm:text-xs` to match the `<Input>` mobile baseline.

## Live mobile polish

From a real device pass on the merged branch:

- **Stronger header blur on mobile.** Header outer now uses tiered `supports-[backdrop-filter]` opacity so the frost reads denser when filters work (`bg-background/75`) and degrades to a near-solid surface when they do not. Added `backdrop-saturate-150` for crisper contrast against the icon grid scrolling under it.
- **Search dropdown is opaque on mobile.** The dropdown panel previously used `bg-background/95`, which let the page content bleed through during scroll on phones, looking glitchy. Now `bg-background` on mobile, `sm:bg-background/95` on desktop where the spotlight effect reads correctly.

## Files
- `src/app/globals.css` - `--header-h` token, `overflow-x: clip`
- `src/app/layout.tsx` - `statusBarStyle: default`, main uses `--header-h`
- `src/components/home-content.tsx` - sticky toolbar uses `--header-h`, stronger blur on mobile
- `src/components/header.tsx` - header outer chrome blur tiers, dropdown opaque on mobile
- `src/components/submit/submit-form.tsx` - custom category input + Add button at `h-10 text-base` on mobile

## Test plan
- [x] Verified at 360 / 375 / 393 / 412 / 768 / 1024 widths on the live dev server.
- [x] tsc clean, no new `any` types, no inline styles introduced.
- [ ] After merge: visual check on a notched device confirming sticky toolbar no longer overlaps the header.
- [ ] After merge: home screen install on a light-mode iPhone confirming status bar icons are visible.

Stacked on #553. Reviewers will see net polish only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated iOS status bar appearance for improved mobile experience
  * Improved header height calculation with responsive adjustments for optimal spacing
  * Refined header and dropdown styling in dark mode
  * Updated sticky toolbar positioning for better content alignment
  * Enhanced custom category input sizing and typography

<!-- end of auto-generated comment: release notes by coderabbit.ai -->