### PR TITLE
fix(readme): wordmark renders in both dark and light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://thesvg.org">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" />
-      <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" alt="theSVG" height="48" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" />
+      <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" alt="theSVG" height="48" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
## Problem

The README `<picture>` had the sources inverted: `prefers-color-scheme: dark` pointed at `logo-wordmark.svg` (light variant, black ink) and `prefers-color-scheme: light` pointed at `logo-wordmark-dark.svg` (dark variant, white ink). Result: the wordmark was invisible in whichever theme the viewer was in. Reported in dark mode where the black outline disappears against GitHub's dark surface.

## Fix

Swap the sources so the variant matches the surface it's designed for:

- dark mode → `logo-wordmark-dark.svg` (white ink, orange SVG)
- light mode → `logo-wordmark.svg` (black ink, orange SVG)
- img fallback → `logo-wordmark.svg` (renders correctly on neutral white surfaces)

This matches the convention we documented in CONTRIBUTING.md: a variant suffixed `-dark` is designed to be placed on a dark background.

## Test plan
- [x] GitHub README in dark mode shows the white-ink wordmark with orange SVG
- [x] GitHub README in light mode shows the black-ink wordmark with orange SVG
- [ ] npm package pages render the light-variant fallback on white

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README logo display to show the light wordmark SVG by default with improved dark/light theme asset support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->