### PR TITLE
docs: refresh sponsor tiers with drawing-toolkit theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for full guidelines.
 
 ## Sponsor
 
-theSVG runs on hosting, bandwidth, and maintainer time. If the catalog saves you a couple of hours a year, [pick a tier](./SPONSORS.md) and lock that value in. Tiers start at $5/mo and stack from `<path>` up to `<svg>`.
+theSVG runs on hosting, bandwidth, and maintainer time. If the catalog saves you a couple of hours a year, [pick a tier](./SPONSORS.md) and lock that value in. Tiers start at $5/mo and stack from Sketch up to Canvas.
 
 [Sponsor on GitHub](https://github.com/sponsors/glincker)
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -6,35 +6,35 @@ theSVG is free, open, and built in the open. If it saves you a few hours a year,
 
 ## Tiers
 
-Themed around the SVG primitives themselves. Each tier stacks on the one above it.
+Each tier stacks on the one above it.
 
-### `<path>` ,  $5/mo
+### ✏️ Sketch, $5/mo
 
-Every SVG starts with one. You get a permanent line in this file and our quiet thanks every time we ship a release.
+Where every brand starts.
 
-### `<rect>` ,  $10/mo
+### 🖌️ Stroke, $10/mo
 
-Solid foundation. Adds a "Sponsor" badge next to your handle in repo discussions and PR reviews, so the people you help know you helped pay for it.
+Bold lines, bolder support.
 
-### `<circle>` ,  $25/mo
+### 🎨 Palette, $25/mo
 
-Perfect support, from every direction. You get early access to new collections (GCP, Azure, and the design-system packs) before they hit `main`, plus a vote on the next collection we onboard.
+Pick the next collection with us.
 
-### `<g>` ,  $50/mo
+### 🖼️ Frame, $50/mo
 
-You bring others along. Your team's logo appears in the README sponsor row and on the contributors wall at thesvg.org/about.
+Your team, framed in the README.
 
-### `<defs>` ,  $100/mo
+### 📐 Artboard, $100/mo
 
-Define what comes next. Logo placement in the thesvg.org footer (sitewide, on every icon page, every search result), plus quarterly office hours with the maintainers if you want roadmap input.
+Footer placement plus quarterly office hours.
 
-### `<svg>` ,  $250/mo
+### 🖥️ Canvas, $250/mo
 
-The whole canvas is yours. Co-branded collection landing page (e.g. `thesvg.org/c/your-company`), priority on icon submissions from your team, and a direct Slack channel with the maintainers.
+Your own corner of thesvg.org.
 
 ## Current sponsors
 
-We list every sponsor here within 48 hours of their first payment. If you'd rather stay anonymous, tell us in your sponsorship note and we'll skip you.
+We list every sponsor here within 48 hours of their first payment. If you'd rather stay anonymous, mention it in your sponsorship note and we'll skip you.
 
 <!-- sponsors:start -->
 


### PR DESCRIPTION
## Summary

The pixel-size tiers I shipped in #561 leaned on colored squares (orange, blue, purple, etc.) which read as decoration not identity. Per feedback ("not colors here"), swapped to a drawing-toolkit ladder where each tier is a real creative-tool noun:

- ✏️ Sketch, \$5/mo - Where every brand starts.
- 🖌️ Stroke, \$10/mo - Bold lines, bolder support.
- 🎨 Palette, \$25/mo - Pick the next collection with us.
- 🖼️ Frame, \$50/mo - Your team, framed in the README.
- 📐 Artboard, \$100/mo - Footer placement plus quarterly office hours.
- 🖥️ Canvas, \$250/mo - Your own corner of thesvg.org.

Each description is one short line so it reads punchy in the GitHub Sponsors picker. Detail (current sponsors, what the money funds, etc.) stays in the body.

## Test plan

- [ ] Render `SPONSORS.md` on github.com and confirm emoji + short copy renders cleanly
- [ ] Confirm README `## Sponsor` section reads naturally with new "Sketch up to Canvas" phrasing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Redesigned sponsor tier naming structure with a new intuitive, stackable system for improved clarity and user experience
* Added explicit monthly pricing information for complete transparency across all sponsorship levels
* Updated comprehensive sponsor tier descriptions with enhanced details and improved visual presentation
* Refined sponsorship program documentation and contributor recognition guidelines for better navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->