### PR TITLE
feat(extensions): ship new mark to VS Code marketplace + bump Raycast changelog

### DIFF
--- a/extensions/raycast/CHANGELOG.md
+++ b/extensions/raycast/CHANGELOG.md
@@ -1,5 +1,10 @@
 # theSVG Raycast Extension Changelog
 
+## [1.1.1] - 2026-06-11
+
+### Updated
+- Refreshed extension icon to match the new theSVG mark (orange overlap on dark background, with `@dark` light-mode variant)
+
 ## [1.1.0] - 2026-04-10
 
 ### Fixed

--- a/extensions/vscode/CHANGELOG.md
+++ b/extensions/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.4
+
+- Updated marketplace icon to the new theSVG mark (orange overlap, dark background)
+
 ## 0.1.3
 
 - Remove the default keybinding. Invoke via the command palette (`theSVG: Search Icons`) or bind your own under `Preferences: Open Keyboard Shortcuts`. Avoids shadowing any built-in VS Code chord.

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
   "description": "Search and copy 6,030+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "glincker",
   "license": "MIT",
   "icon": "assets/icon.png",


### PR DESCRIPTION
## Summary

Triggers the VS Code marketplace publish for the new theSVG mark that #560 introduced, and stages the matching Raycast changelog entry so the next `ray publish` carries it to the Raycast store.

- `extensions/vscode/package.json` bumps to `0.1.4` (workflow auto-detects this on merge and runs `vsce publish` with `VSCE_PAT`)
- `extensions/vscode/CHANGELOG.md` gets a one-line `0.1.4` entry
- `extensions/raycast/CHANGELOG.md` gets a `1.1.1` entry covering the same icon refresh

Local `npm run package` confirmed the 0.1.4 vsix builds clean and includes the new `assets/icon.png` (3.89 KB, 180x180).

## Follow-up after merge

1. Verify the `vscode-release.yml` workflow runs against `main` and publishes 0.1.4 to the marketplace
2. From `extensions/raycast/`, run `ray publish` to open the upstream PR to `raycast/extensions` carrying the icon change

## Test plan

- [ ] Confirm `Release - VS Code Extension` workflow goes green after merge
- [ ] Verify `glincker.thesvg` shows version 0.1.4 with the new mark on the marketplace
- [ ] After running `ray publish`, link the resulting `raycast/extensions` PR back here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Extension icons refreshed to align with the new theSVG mark design
  * VSCode extension updated to version 0.1.4 with refreshed marketplace icon
  * Raycast extension icon now includes a dark light-mode variant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->