### PR TITLE
feat: add variant prop support to React package

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -64,6 +64,25 @@ import VisualStudioCode from '@thesvg/react/visual-studio-code';
 Each icon is a separate module so bundlers that do not support tree-shaking
 (e.g. CommonJS environments) will still include only the icons you import.
 
+### Selecting a variant
+
+Many brands ship more than one mark (a monochrome version, a wordmark, a
+light/dark optimized variant). Pass the `variant` prop to choose one. It
+defaults to `"default"`, so existing usage is unchanged:
+
+```tsx
+import { Github } from '@thesvg/react';
+
+<Github />                    {/* default mark */}
+<Github variant="mono" />     {/* monochrome */}
+<Github variant="wordmark" /> {/* text logo */}
+```
+
+The accepted variant names are typed per icon, so your editor autocompletes
+only the variants that icon actually has, and an unknown variant is a type
+error. At runtime an unrecognized variant safely falls back to `"default"`.
+Icons that ship a single mark only accept `variant="default"`.
+
 ### With Next.js App Router
 
 Icons work as Server Components by default. No `"use client"` directive needed:
@@ -112,6 +131,7 @@ Every component accepts all standard SVG props via `SVGProps<SVGSVGElement>`:
 | `style`     | `CSSProperties` | -            | Inline styles (prefer className)    |
 | `fill`      | `string` | `"none"`               | SVG fill color                      |
 | `viewBox`   | `string` | from original SVG      | Override the viewBox                |
+| `variant`   | `string` | `"default"`            | Which icon variant to render (per-icon typed union) |
 | `ref`       | `Ref<SVGSVGElement>` | -          | Forwarded ref                       |
 | `aria-label`| `string` | -                      | Accessible label                    |
 | ...         | ...      | -                      | Any other `SVGProps<SVGSVGElement>`  |

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -294,7 +294,7 @@ function toSafeIdentifier(slug: string): string {
 // Code generators
 // ---------------------------------------------------------------------------
 
-/** Pre-parsed SVG data shared between ESM and CJS generators to avoid double work. */
+/** Pre-parsed SVG data for a single variant, shared between ESM and CJS generators. */
 interface ParsedSvg {
   viewBox: string;
   fill: string;
@@ -302,17 +302,48 @@ interface ParsedSvg {
   childNodes: (CjsNode | string)[];
 }
 
-/** Parse an icon's SVG once for reuse by both ESM and CJS generators. */
-function parseSvgForIcon(icon: RawIcon): ParsedSvg | null {
+/** An icon's full variant set: every selectable variant parsed once. */
+interface ParsedIcon {
+  /** Ordered variant keys, always starting with "default". */
+  keys: string[];
+  /** Variant key -> parsed SVG. Always contains a "default" entry. */
+  variants: Record<string, ParsedSvg>;
+}
+
+/** Parse one variant SVG file. Returns null when the file is missing/empty. */
+function parseVariant(slug: string, variant: string): ParsedSvg | null {
+  const svgContent = readSvg(slug, variant);
+  if (!svgContent) return null;
+  const { inner, viewBox, fill, stroke } = svgToJsxInner(svgContent);
+  return { viewBox, fill, stroke, childNodes: convertJsxToCjs(inner) };
+}
+
+/**
+ * Parse every variant declared for an icon, once, for reuse by both the ESM
+ * and CJS generators. The "default" key always maps to the icon's primary SVG
+ * (default -> color -> mono -> ... fallback) so `<Icon />` renders unchanged.
+ * Additional declared variants (mono, wordmark, light, dark, ...) are added
+ * when their SVG file exists and parses. Returns null when no SVG is found.
+ */
+function parseSvgForIcon(icon: RawIcon): ParsedIcon | null {
   const svgContent = primarySvg(icon.slug, icon.variants);
   if (!svgContent) return null;
 
   const { inner, viewBox, fill, stroke } = svgToJsxInner(svgContent);
-  const childNodes = convertJsxToCjs(inner);
-  return { viewBox, fill, stroke, childNodes };
+  const variants: Record<string, ParsedSvg> = {
+    default: { viewBox, fill, stroke, childNodes: convertJsxToCjs(inner) },
+  };
+
+  for (const key of Object.keys(icon.variants)) {
+    if (key === "default") continue;
+    const parsed = parseVariant(icon.slug, key);
+    if (parsed) variants[key] = parsed;
+  }
+
+  return { keys: Object.keys(variants), variants };
 }
 
-function generateEsmComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
+function generateEsmComponent(icon: RawIcon, parsed: ParsedIcon | null): string {
   const componentName = toPascalCase(icon.slug);
 
   if (!parsed) {
@@ -324,7 +355,7 @@ function generateEsmComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
       `import { forwardRef } from 'react';`,
       ``,
       `const ${componentName} = forwardRef(`,
-      `  function ${componentName}(props, ref) {`,
+      `  function ${componentName}({ variant, ...props }, ref) {`,
       `    return null;`,
       `  }`,
       `);`,
@@ -334,20 +365,22 @@ function generateEsmComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
     ].join("\n");
   }
 
-  const { viewBox, fill, stroke, childNodes } = parsed;
-
   return [
     `// @thesvg/react — ${icon.title}`,
     `// Auto-generated. Do not edit.`,
+    `// Variants: ${parsed.keys.join(", ")}`,
     ``,
     `import { forwardRef, createElement } from 'react';`,
     ``,
+    `const _variants = ${JSON.stringify(parsed.variants)};`,
+    ``,
     `const ${componentName} = forwardRef(`,
-    `  function ${componentName}({ viewBox = '${viewBox}', ...props }, ref) {`,
+    `  function ${componentName}({ variant = 'default', viewBox, ...props }, ref) {`,
+    `    const _v = _variants[variant] || _variants.default;`,
     `    return createElement(`,
     `      'svg',`,
-    `      Object.assign({ ref, viewBox, fill: '${fill}',${stroke ? ` stroke: '${stroke}',` : ""} xmlns: 'http://www.w3.org/2000/svg' }, props),`,
-    `      ...${JSON.stringify(childNodes)}`,
+    `      Object.assign({ ref, viewBox: viewBox || _v.viewBox, fill: _v.fill, stroke: _v.stroke, xmlns: 'http://www.w3.org/2000/svg' }, props),`,
+    `      ..._v.childNodes`,
     `        .map(function _c(el) {`,
     `          if (typeof el === 'string') return el;`,
     `          return createElement(el.type, el.props, ...(el.children || []).map(_c));`,
@@ -361,7 +394,7 @@ function generateEsmComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
   ].join("\n");
 }
 
-function generateCjsComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
+function generateCjsComponent(icon: RawIcon, parsed: ParsedIcon | null): string {
   const componentName = toPascalCase(icon.slug);
 
   if (!parsed) {
@@ -375,7 +408,7 @@ function generateCjsComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
       ``,
       `const react_1 = require("react");`,
       ``,
-      `const ${componentName} = react_1.forwardRef(function ${componentName}(_props, _ref) {`,
+      `const ${componentName} = react_1.forwardRef(function ${componentName}({ variant: _variant, ..._props }, _ref) {`,
       `  return null;`,
       `});`,
       `${componentName}.displayName = '${componentName}';`,
@@ -384,22 +417,24 @@ function generateCjsComponent(icon: RawIcon, parsed: ParsedSvg | null): string {
     ].join("\n");
   }
 
-  const { viewBox, fill, stroke, childNodes } = parsed;
-
   return [
     `"use strict";`,
     `// @thesvg/react — ${icon.title}`,
     `// Auto-generated. Do not edit.`,
+    `// Variants: ${parsed.keys.join(", ")}`,
     ``,
     `Object.defineProperty(exports, "__esModule", { value: true });`,
     ``,
     `const react_1 = require("react");`,
     ``,
-    `const ${componentName} = react_1.forwardRef(function ${componentName}({ viewBox = '${viewBox}', ...props }, ref) {`,
+    `const _variants = ${JSON.stringify(parsed.variants)};`,
+    ``,
+    `const ${componentName} = react_1.forwardRef(function ${componentName}({ variant = 'default', viewBox, ...props }, ref) {`,
+    `  const _v = _variants[variant] || _variants.default;`,
     `  return react_1.createElement(`,
     `    'svg',`,
-    `    Object.assign({ ref, viewBox, fill: '${fill}',${stroke ? ` stroke: '${stroke}',` : ""} xmlns: 'http://www.w3.org/2000/svg' }, props),`,
-    `    ...${JSON.stringify(childNodes)}`,
+    `    Object.assign({ ref, viewBox: viewBox || _v.viewBox, fill: _v.fill, stroke: _v.stroke, xmlns: 'http://www.w3.org/2000/svg' }, props),`,
+    `    ..._v.childNodes`,
     `      .map(function _c(el) {`,
     `        if (typeof el === 'string') return el;`,
     `        return react_1.createElement(el.type, el.props, ...(el.children || []).map(_c));`,
@@ -539,17 +574,26 @@ function findMatchingCloseTag(html: string, tagName: string): number {
   return -1;
 }
 
-function generateDtsComponent(icon: RawIcon): string {
+function generateDtsComponent(icon: RawIcon, parsed: ParsedIcon | null): string {
   const componentName = toPascalCase(icon.slug);
+  // Per-icon union of the variants that actually resolved. Falls back to
+  // "default" so the prop is always present and typed, even for null icons.
+  const variantKeys = parsed && parsed.keys.length > 0 ? parsed.keys : ["default"];
+  const variantUnion = variantKeys.map((k) => `'${k}'`).join(" | ");
   return [
     `// @thesvg/react — ${icon.title}`,
     `// Auto-generated. Do not edit.`,
     ``,
     `import type { SVGProps, ForwardRefExoticComponent, RefAttributes } from 'react';`,
     ``,
-    `export type SvgIconProps = SVGProps<SVGSVGElement>;`,
+    `export type ${componentName}Variant = ${variantUnion};`,
     ``,
-    `declare const ${componentName}: ForwardRefExoticComponent<SvgIconProps & RefAttributes<SVGSVGElement>>;`,
+    `export interface ${componentName}Props extends SVGProps<SVGSVGElement> {`,
+    `  /** Which icon variant to render. Defaults to "default". */`,
+    `  variant?: ${componentName}Variant;`,
+    `}`,
+    ``,
+    `declare const ${componentName}: ForwardRefExoticComponent<${componentName}Props & RefAttributes<SVGSVGElement>>;`,
     `export default ${componentName};`,
   ].join("\n");
 }
@@ -733,7 +777,7 @@ function main(): void {
     // Write CJS component (pre-compiled to createElement calls)
     writeFileSync(join(DIST, `${icon.slug}.cjs`), generateCjsComponent(icon, parsed) + "\n");
     // Write type declarations
-    writeFileSync(join(DIST, `${icon.slug}.d.ts`), generateDtsComponent(icon) + "\n");
+    writeFileSync(join(DIST, `${icon.slug}.d.ts`), generateDtsComponent(icon, parsed) + "\n");
 
     entries.push({ slug: icon.slug, componentName });
 


### PR DESCRIPTION
Closes #607.

## Summary

`@thesvg/react` components could only render an icon's primary (default) SVG. This adds a `variant` prop so consumers can select any variant a brand ships (`mono`, `wordmark`, `light`, `dark`, ...), matching what the core `thesvg` package and the CDN already expose.

```tsx
import { Github } from '@thesvg/react';

<Github />                    // default mark (unchanged)
<Github variant="mono" />     // monochrome
<Github variant="wordmark" /> // text logo
```

## How it works

The generator (`scripts/build-components.ts`) now parses every declared variant for each icon and embeds them in the component as a `_variants` map. The component accepts `variant` (default `"default"`), resolves the matching variant, and renders it. Changes are codegen-only; `dist/` is built at publish time.

## Type safety

Each component ships a per-icon typed union, so editors autocomplete only the variants that icon actually has and an unknown variant is a compile error:

```ts
export type GithubVariant = 'default' | 'mono' | 'light' | 'dark' | 'wordmark';
export interface GithubProps extends SVGProps<SVGSVGElement> { variant?: GithubVariant; }
```

Single-variant icons get `variant?: 'default'`.

## Backwards compatibility

- `<Icon />` renders the default mark exactly as before (verified: identical output).
- Unknown variant falls back to `default` at runtime.
- `variant` is destructured out before forwarding, so it never reaches the DOM (no React unknown-attribute warning).

## Verification

- `tsx scripts/build-components.ts`: 6152 components built, internal validation PASS.
- Render smoke test (react-dom/server) on `Github`: `default !== mono`, unknown variant falls back to default, `variant` not leaked to DOM, `width`/other props still applied.
- Type check: `variant="wordmark"` accepted, `variant="nope"` rejected by the union.
- Scope: 4214 of 6152 icons have more than one variant, so this unlocks variant selection for the majority of the catalog.

## Note

`scripts/validate-output.ts` reports pre-existing root-fill warnings on `main` (it greps the dist `.js` for a literal `<svg>` tag that the `createElement` codegen has never emitted). That check is unrelated to this PR, is not run in CI, and behaves identically before and after this change. Left as-is to keep the PR focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting icon variants with a new `variant` prop.
  * Icons now expose per-icon variant names, with autocomplete and type checking for invalid values.
  * Unrecognized variants fall back to the default icon version.

* **Documentation**
  * Expanded the React docs with guidance on choosing icon variants, usage examples, and prop details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->