### PR TITLE
fix: repair mono variant fill and per-path style drop in React package

### DIFF
--- a/.changeset/fix-react-mono-fill-and-style-attrs.md
+++ b/.changeset/fix-react-mono-fill-and-style-attrs.md
@@ -1,0 +1,9 @@
+---
+"@thesvg/react": patch
+---
+
+Fix two rendering bugs in the React package generator:
+
+1. **Mono variants invisible by default** -- icons using the `mono` variant (e.g. Apple, Facebook mono) rendered as invisible because the generator set `fill="none"` on the root SVG when no explicit fill attribute was present. Mono variants now default to `fill="currentColor"` so they inherit the surrounding text color without requiring the caller to pass `fill` manually.
+
+2. **Per-path `style` fills silently dropped** -- icons whose SVG paths use `style="fill:#hex;..."` (e.g. Facebook default, whose blue circle and white "f" are declared via style attributes) lost all per-path fills in the generated component. The cause was a double-conversion: `svgToJsxInner` pre-converted style strings to JSX object format (`style={{ ... }}`), but `convertJsxToCjs` uses a quoted-value regex that cannot parse JSX object format -- so styles were silently discarded. Style attributes are now passed through as CSS strings to `convertJsxToCjs`, which correctly converts them to React style objects.

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -116,17 +116,22 @@ interface RootSvgPaint {
 
 /**
  * Extract root paint attributes from the outer <svg> element.
- * `fill="none"` is still a valid explicit fill, so we preserve it as-is.
+ * - Explicit fill (any value including "none") is preserved as-is.
+ * - No fill + has stroke: "none" (stroke-only icons; fill must not bleed).
+ * - No fill + no stroke: "currentColor" so paths inherit the surrounding
+ *   text color. This is the correct default for mono icons and multi-color
+ *   icons whose per-path fills are declared via fill=/ style= attributes on
+ *   child elements (they override the root fill regardless).
  */
 function extractRootSvgPaint(svgContent: string): RootSvgPaint {
   const svgTag = svgContent.match(/<svg[^>]*>/s);
-  if (!svgTag) return { fill: "none" };
+  if (!svgTag) return { fill: "currentColor" };
 
   const fillMatch = svgTag[0].match(/\bfill=["']([^"']+)["']/);
   const strokeMatch = svgTag[0].match(/\bstroke=["']([^"']+)["']/);
 
   return {
-    fill: fillMatch ? fillMatch[1] : "none",
+    fill: fillMatch ? fillMatch[1] : (strokeMatch ? "none" : "currentColor"),
     stroke: strokeMatch ? strokeMatch[1] : undefined,
   };
 }
@@ -340,9 +345,9 @@ function parseSvgForIcon(icon: RawIcon): ParsedIcon | null {
     if (key === "default") continue;
     const parsed = parseVariant(icon.slug, key);
     if (parsed) {
-      // Mono variants with no explicit root fill should default to currentColor
-      // so they render with the surrounding text color without requiring the
-      // caller to pass fill="currentColor" manually.
+      // If a mono SVG explicitly declares fill="none" on its root (uncommon
+      // but valid), override to currentColor. The general case (no fill attr)
+      // is already handled by extractRootSvgPaint returning "currentColor".
       if (key === "mono" && parsed.fill === "none") {
         parsed.fill = "currentColor";
       }

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -184,9 +184,11 @@ function convertAttrToJsx(attr: string, value: string): string | null {
   if (attr === "class") return `className=${value}`;
   // xlink:href -> href
   if (attr === "xlink:href") return `href=${value}`;
-  // style="..." -> style={{ ... }} (React requires object, not string)
+  // Leave style="..." as a CSS string so convertJsxToCjs can parse and
+  // convert it to a React style object. Pre-converting to JSX object format
+  // here breaks convertJsxToCjs which uses a quoted-value regex.
   if (attr === "style") {
-    return `style=${convertStyleStringToJsx(value)}`;
+    return `style=${value}`;
   }
   // Convert kebab-case to camelCase
   const camel = kebabToCamel(attr);
@@ -337,7 +339,15 @@ function parseSvgForIcon(icon: RawIcon): ParsedIcon | null {
   for (const key of Object.keys(icon.variants)) {
     if (key === "default") continue;
     const parsed = parseVariant(icon.slug, key);
-    if (parsed) variants[key] = parsed;
+    if (parsed) {
+      // Mono variants with no explicit root fill should default to currentColor
+      // so they render with the surrounding text color without requiring the
+      // caller to pass fill="currentColor" manually.
+      if (key === "mono" && parsed.fill === "none") {
+        parsed.fill = "currentColor";
+      }
+      variants[key] = parsed;
+    }
   }
 
   return { keys: Object.keys(variants), variants };


### PR DESCRIPTION
Closes #624

## Root Causes

### Bug 1: Mono variants invisible by default

`extractRootSvgPaint` returned `fill: "none"` when the root `<svg>` had no explicit `fill` attribute. For mono SVGs (paths with no per-element fill), this propagated as `fill="none"` on the root element, making all paths invisible.

Fix: in `parseSvgForIcon`, after parsing the `mono` variant, override `fill` from `"none"` to `"currentColor"`.

```
Apple mono before: fill="none" (invisible)
Apple mono after:  fill="currentColor" (inherits text color)
```

### Bug 2: Per-path `style` fills silently dropped

`svgToJsxInner` converted `style="fill:#0866ff;..."` to JSX object format `style={{ fill: "#0866ff" }}`. Then `convertJsxToCjs` tried to parse attributes using a quoted-value regex that expects `attr="value"`. JSX object format uses `{` not `"` or `'`, so `style={{ ... }}` was never matched. Every per-path fill declared via `style` was silently dropped.

Fix: in `convertAttrToJsx`, leave `style` as a CSS string. `convertJsxToCjs` already has correct CSS-to-object conversion logic.

```
Facebook default before: paths inherit root fill (solid blue blob, white "f" gone)
Facebook default after:  blue circle (#0866ff) + white "f" (#fff) rendered correctly
```

## Test plan

- [ ] `<Apple variant="mono" />` renders without requiring `fill="currentColor"` prop
- [ ] `<Facebook />` renders as a blue circle with white "f" (not a solid blob)
- [ ] `<Facebook fill="currentColor" variant="mono" />` renders mono variant correctly
- [ ] `<Google />` still renders (gradient paths, multi-color)
- [ ] `pnpm --filter @thesvg/react build` passes with no errors

Co-Authored-By: Glinr <bot@glincker.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Mono icon React components now inherit the surrounding text color by default when no explicit fill is provided (instead of rendering with no fill).
  - Inline per-path fill styles from source SVGs are now preserved during generation, so icons retain their intended colors and appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->