### PR TITLE
fix: preserve data-* and aria-* attributes in React codegen

### DIFF
--- a/.changeset/react-preserve-data-aria-attrs.md
+++ b/.changeset/react-preserve-data-aria-attrs.md
@@ -1,0 +1,14 @@
+---
+"@thesvg/react": patch
+---
+
+Preserve data-* and aria-* attributes in generated React components
+
+The SVG-to-JSX codegen camelCased every hyphenated attribute, turning
+`data-circle` into `dataCircle` (and `data-name` into `dataName`, etc.).
+React does not recognize camelCased data/aria props and logs a runtime
+warning ("React does not recognize the `dataCircle` prop on a DOM
+element"). The codegen now leaves `data-*` and `aria-*` attributes
+hyphenated so React accepts them as valid DOM attributes. Fixes the
+warning on icons such as `nextdotjs` (and 200+ other icons carrying
+`data-*` attributes).

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -195,6 +195,12 @@ function convertAttrToJsx(attr: string, value: string): string | null {
   if (attr === "style") {
     return `style=${value}`;
   }
+  // React recognizes data-* and aria-* attributes only when they stay
+  // hyphenated. camelCasing them (data-circle -> dataCircle) makes React
+  // reject them as unknown DOM props, so leave these untouched.
+  if (attr.startsWith("data-") || attr.startsWith("aria-")) {
+    return `${attr}=${value}`;
+  }
   // Convert kebab-case to camelCase
   const camel = kebabToCamel(attr);
   return `${camel}=${value}`;


### PR DESCRIPTION
## Description

Fixes #658. The `@thesvg/react` SVG-to-JSX codegen camelCased every hyphenated attribute via `kebabToCamel`, so `data-circle` became `dataCircle` (and `data-name` -> `dataName`, etc.). React only recognizes `data-*`/`aria-*` props when they stay hyphenated, so it logged:

> React does not recognize the `dataCircle` prop on a DOM element.

### Fix
Added a guard in `convertAttrToJsx` (packages/react/scripts/build-components.ts) to return `data-*` and `aria-*` attributes unchanged, before the generic camelCase fallback.

### Verification
Rebuilt the package and checked the affected output:
- `dist/nextdotjs.js`: `dataCircle` count `0` -> emits `data-circle` (the reported `<circle data-circle="true">`).
- Across `dist/`: files leaking `dataName`/`dataCircle`/`dataComponent` went from 264 to **0**; 274 files now carry correctly-hyphenated `data-*` attributes.
- The reporter's example icon (React) had no data attrs; the actual culprit was `nextdotjs`. This fix covers all 200+ icons with `data-*` attributes.

The fix is scoped to attribute-name handling only (+6 lines); `dist/` is gitignored and regenerated at publish time.

> Note for maintainers: the standalone `packages/react/scripts/validate-output.ts` reports a large number of pre-existing "root fill -> none" mismatches unrelated to this change. Worth a separate look, but out of scope here.

## Type
- [x] Bug fix

## Related Issues
Closes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated React props now preserve `data-*` and `aria-*` attribute names instead of converting them to camelCase.
  * This reduces runtime warnings and helps SVG icons render correctly when these attributes are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->