### PR TITLE
fix: make sidebar category list scroll independently

### DIFF
--- a/.changeset/sidebar-independent-scroll.md
+++ b/.changeset/sidebar-independent-scroll.md
@@ -1,0 +1,11 @@
+---
+"thesvg": patch
+---
+
+Make the sidebar category list scroll independently
+
+The sidebar is a fixed-height flex column, but the categories ScrollArea
+had `flex-1` without `min-h-0`, so it could not shrink below its content
+height and the list overflowed the sidebar instead of scrolling. Adding
+`min-h-0` lets the ScrollArea shrink within the column so the long
+category list scrolls on its own while the top navigation stays in place.

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -264,7 +264,7 @@ export function Sidebar({
         Categories
       </p>
 
-      <ScrollArea className="flex-1 overflow-hidden px-3 pb-3">
+      <ScrollArea className="min-h-0 flex-1 overflow-hidden px-3 pb-3">
         <div className="flex flex-col gap-px">
           {categories.map((category) => (
             <button


### PR DESCRIPTION
## Description

Fixes #657. The sidebar's category list could not be scrolled when it exceeded the viewport height, so items at the bottom were unreachable.

### Root cause
The `<aside>` sidebar is a fixed-height flex column (`h-[calc(100vh-4.75rem)]`). The Categories `ScrollArea` (`src/components/layout/sidebar.tsx:267`) had `flex-1` but no `min-h-0`. In a flex column, a `flex-1` child will not shrink below its content's intrinsic height unless `min-height` is relaxed, so the base-ui ScrollArea viewport never became constrained and the list overflowed instead of scrolling.

### Fix
Add `min-h-0` to the ScrollArea so `flex-1` can shrink and the scroll viewport takes over:

```
"flex-1 overflow-hidden px-3 pb-3"  ->  "min-h-0 flex-1 overflow-hidden px-3 pb-3"
```

One Tailwind class, no inline styles, keeps the existing design (top nav stays put, only the long category list scrolls). Applies on both desktop and mobile since the same component renders in both.

## Type
- [x] Bug fix

## Related Issues
Closes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the sidebar category list so it scrolls independently within the sidebar.
  * Prevented the category area from expanding and causing overflow, keeping the top navigation visible and stationary.
  * Improved sidebar layout behavior in fixed-height views for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->