### PR TITLE
fix: call hooks before early return in IconPageClient

### DIFF
--- a/.changeset/fix-icon-page-hooks-order.md
+++ b/.changeset/fix-icon-page-hooks-order.md
@@ -1,0 +1,9 @@
+---
+"thesvg": patch
+---
+
+Fix conditional hook call in IconPageClient
+
+`useMemo` was called after an early `return null`, which violates the
+rules of hooks and could throw when an icon slug has no match. Hooks now
+run before the early return, with null-guarded memo bodies.

--- a/src/components/icons/icon-page-client.tsx
+++ b/src/components/icons/icon-page-client.tsx
@@ -7,11 +7,11 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 
 export function IconPageClient({ slug }: { slug: string }) {
   const icon = useMemo(() => getIconBySlug(slug), [slug]);
-  if (!icon) return null;
 
   const categoryCounts = useMemo(() => getCategoryCounts(), []);
 
   const relatedIcons = useMemo(() => {
+    if (!icon) return [];
     const primaryCategory = icon.categories[0] ?? null;
     return primaryCategory
       ? getIconsByCategory(primaryCategory)
@@ -22,6 +22,13 @@ export function IconPageClient({ slug }: { slug: string }) {
 
   const { versionCounterpartSlug, versionCounterpartYear, versionCounterpartIsNewer } =
     useMemo(() => {
+      if (!icon) {
+        return {
+          versionCounterpartSlug: null,
+          versionCounterpartYear: null,
+          versionCounterpartIsNewer: false,
+        };
+      }
       const yearMatch = /^(.+)-(\d{4})$/.exec(icon.slug);
       if (yearMatch) {
         const originalSlug = yearMatch[1];
@@ -59,7 +66,9 @@ export function IconPageClient({ slug }: { slug: string }) {
         versionCounterpartYear: null,
         versionCounterpartIsNewer: false,
       };
-    }, [icon.slug]);
+    }, [icon]);
+
+  if (!icon) return null;
 
   return (
     <SidebarShell categoryCounts={categoryCounts}>


### PR DESCRIPTION
## Description

Fixes the repo-wide **Lint & Build** failure. `src/components/icons/icon-page-client.tsx` called `useMemo` **after** an early `return null`, producing three `react-hooks/rules-of-hooks` errors that fail `pnpm lint`:

> React Hook "useMemo" is called conditionally. React Hooks must be called in the exact same order in every render.

Besides failing CI, this is a real latent bug: when a slug has no matching icon, the hook order changes between renders, which React can throw on.

### Fix
- Moved all `useMemo` calls above the early return.
- Guarded the memo bodies for a null `icon` (returns empty/defaults).
- Moved `if (!icon) return null;` below the hooks.
- Updated the last memo's deps from `[icon.slug]` to `[icon]`.

Behavior is unchanged: a missing icon still renders `null`.

### Verification
- `pnpm lint`: `0 errors` (was 3). Remaining items are pre-existing warnings only.
- `pnpm exec tsc --noEmit`: exit 0.

This unblocks Lint & Build for all open PRs.

## Type
- [x] Bug fix

## Related
Unblocks CI for #661, #662, #663, #664.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed icon pages so loading logic follows React hook rules when an icon slug has no match.
  * Improved fallback behavior by showing empty related results and safe default counterpart data until an icon is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->