### PR TITLE
fix(ci): repair release.yml so npm publish runs

### DIFF
--- a/.github/release-body-header.md
+++ b/.github/release-body-header.md
@@ -1,0 +1,19 @@
+<p align="center">
+  <a href="https://thesvg.org">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" />
+      <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" alt="thesvg logo" height="60" />
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://thesvg.org">Browse</a> &middot;
+  <a href="https://www.npmjs.com/package/thesvg">npm</a> &middot;
+  <a href="https://github.com/glincker/thesvg">GitHub</a> &middot;
+  <a href="https://thesvg.org/blog">Blog</a> &middot;
+  <a href="https://thesvg.org/submit">Submit an icon</a>
+</p>
+
+---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,27 +150,7 @@ jobs:
           else
             BODY_FILE="$(mktemp)"
             {
-              cat <<'HEADER'
-<p align="center">
-  <a href="https://thesvg.org">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark-dark.svg" />
-      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" />
-      <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/logo-wordmark.svg" alt="thesvg logo" height="60" />
-    </picture>
-  </a>
-</p>
-
-<p align="center">
-  <a href="https://thesvg.org">Browse</a> &middot;
-  <a href="https://www.npmjs.com/package/thesvg">npm</a> &middot;
-  <a href="https://github.com/glincker/thesvg">GitHub</a> &middot;
-  <a href="https://thesvg.org/blog">Blog</a> &middot;
-  <a href="https://thesvg.org/submit">Submit an icon</a>
-</p>
-
----
-HEADER
+              cat "${GITHUB_WORKSPACE}/.github/release-body-header.md"
 
               echo ""
               echo "## Packages in this release"


### PR DESCRIPTION
## Problem

The npm publish has been silently broken. `npm view thesvg version` returns **3.0.18**, but main is at **3.2.0** — so 3.1.x and 3.2.0 never published. Every `release.yml` run fails with "This run likely failed because of a workflow file issue" and executes **zero jobs**.

## Root cause

In the "Create combined GitHub release" step, a `cat <<'HEADER' … HEADER` heredoc has its body at **column 0**, inside a `run: |` block. Unindented lines terminate the YAML block scalar, so the workflow fails to compile. A YAML parser chokes exactly at the first heredoc line (`<p align="center">`).

## Fix

- Extracted the static release-notes header into `.github/release-body-header.md`.
- Replaced the heredoc with `cat "${GITHUB_WORKSPACE}/.github/release-body-header.md"`.
- Output is byte-for-byte identical; only the YAML now compiles.

Verified locally: `yaml.safe_load(release.yml)` parses OK (previously errored at the heredoc line).

## After merge

Trigger a publish to ship the pending versions:
```
gh workflow run release.yml
```
The publish step already guards with `npm view <pkg>@<version>` so it only publishes the not-yet-published 3.2.0 set. (Requires the `npm-publish` environment approval + npm auth, which are already configured for the workflow.)

## Type
- [x] CI / infrastructure fix

> Note: touches `.github/` (protected). Opened as a reviewed PR rather than a direct push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to load the release notes header from a dedicated file, keeping the generated release content consistent.
  * Added a standardized release header with branding and quick links at the top of release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->