### PR TITLE
fix: announcement bar overlap + brand-first sidebar categories

### DIFF
--- a/.changeset/announcement-layout-and-brand-categories.md
+++ b/.changeset/announcement-layout-and-brand-categories.md
@@ -1,0 +1,15 @@
+---
+"thesvg": patch
+---
+
+Fix announcement bar overlap and prioritize brand categories in the sidebar
+
+- The top announcement bar no longer overlaps the header and sidebar. The bar
+  publishes its height as a `--banner-h` CSS variable, and the sticky header and
+  fixed sidebar offset by it, so they always sit below the bar (and revert
+  cleanly when it is dismissed). Also polished the bar styling (pulse dot,
+  subtle orange gradient, clearer link and dismiss affordance).
+- The sidebar Categories list now counts brand and community icons only, so
+  cloud architecture taxonomy (Compute, Integration, Kubernetes, General, ...)
+  no longer buries brand categories. Architecture categories still appear when
+  the AWS/Azure/GCP/Kubernetes collection is selected.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,6 +48,9 @@
 }
 
 :root {
+  /* Height of the top announcement bar; the sticky header and fixed sidebar
+     offset by this. The AnnouncementBanner updates it at runtime (0 when hidden). */
+  --banner-h: 0px;
   --background: oklch(0.985 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/src/components/announcement-banner.tsx
+++ b/src/components/announcement-banner.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { X } from "lucide-react";
+import { ArrowRight, X } from "lucide-react";
 
 const STORAGE_KEY = "thesvg-announcement-glinr-studios-dismissed";
 
 export function AnnouncementBanner() {
   const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     try {
@@ -16,6 +17,27 @@ export function AnnouncementBanner() {
       // storage blocked
     }
   }, []);
+
+  // Publish the banner's height as a CSS variable so the sticky header and the
+  // fixed sidebar can offset themselves and never overlap the bar. Resets to 0
+  // when the bar is hidden/dismissed.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (!visible) {
+      root.style.setProperty("--banner-h", "0px");
+      return;
+    }
+    const el = ref.current;
+    if (!el) return;
+    const apply = () => root.style.setProperty("--banner-h", `${el.offsetHeight}px`);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty("--banner-h", "0px");
+    };
+  }, [visible]);
 
   function dismiss() {
     setVisible(false);
@@ -29,25 +51,32 @@ export function AnnouncementBanner() {
   if (!visible) return null;
 
   return (
-    <div className="relative z-50 flex items-center justify-center gap-2 bg-foreground/[0.04] px-4 py-1.5 text-center text-xs text-muted-foreground backdrop-blur-sm dark:bg-white/[0.04]">
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" aria-hidden="true" />
-      <span>
+    <div
+      ref={ref}
+      className="sticky top-0 z-[60] flex items-center justify-center gap-x-2 gap-y-1 border-b border-orange-500/15 bg-gradient-to-r from-orange-500/[0.06] via-background/70 to-orange-500/[0.06] px-10 py-2 text-center text-xs text-muted-foreground backdrop-blur-md dark:border-orange-500/20 dark:bg-black/50"
+    >
+      <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-orange-500/60" />
+        <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-orange-500" />
+      </span>
+      <span className="leading-snug">
         thesvg is joining{" "}
         <span className="font-semibold text-foreground">GLINR Studios</span>
-        {" "}in Q3 2026. The platform stays fully open source.
+        {" "}in Q3 2026, staying fully open source.
       </span>
       <Link
         href="/blog/thesvg-joining-glinr-studios"
-        className="ml-1 shrink-0 font-medium text-orange-500 underline underline-offset-2 hover:text-orange-400"
+        className="group inline-flex shrink-0 items-center gap-0.5 font-medium text-orange-500 transition-colors hover:text-orange-400"
       >
         Read more
+        <ArrowRight className="h-3 w-3 transition-transform duration-200 group-hover:translate-x-0.5" />
       </Link>
       <button
         onClick={dismiss}
         aria-label="Dismiss announcement"
-        className="ml-2 shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:text-foreground"
+        className="absolute right-2.5 rounded-md p-1 text-muted-foreground/50 transition-colors hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-white/[0.06]"
       >
-        <X className="h-3 w-3" />
+        <X className="h-3.5 w-3.5" />
       </button>
     </div>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -311,7 +311,7 @@ export function Header() {
 
   return (
     <header
-      className="sticky top-0 z-50 hidden w-full px-2 pt-2 pb-0 sm:px-3 sm:pt-2.5 lg:block"
+      className="sticky top-[var(--banner-h,0px)] z-50 hidden w-full px-2 pt-2 pb-0 sm:px-3 sm:pt-2.5 lg:block"
       style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
     >
       <div className="mx-auto max-w-[1800px] rounded-2xl border border-black/[0.06] bg-background/90 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl dark:border-white/[0.08] dark:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]">

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -87,7 +87,7 @@ export function Sidebar({
       className={cn(
         mobile
           ? "flex h-full w-full flex-col bg-background pt-6"
-          : "fixed top-[4.25rem] left-2 z-30 hidden h-[calc(100vh-4.75rem)] w-54 flex-col rounded-2xl border border-black/[0.06] bg-background/90 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl md:flex dark:border-white/[0.08] dark:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]"
+          : "fixed top-[calc(4.25rem+var(--banner-h,0px))] left-2 z-30 hidden h-[calc(100vh-4.75rem-var(--banner-h,0px))] w-54 flex-col rounded-2xl border border-black/[0.06] bg-background/90 shadow-[0_4px_24px_-4px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.03)] backdrop-blur-2xl md:flex dark:border-white/[0.08] dark:bg-black/60 dark:shadow-[0_4px_24px_-4px_rgba(0,0,0,0.5),0_0_0_1px_rgba(255,255,255,0.05)]"
       )}
     >
       {/* Navigation */}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -2,6 +2,20 @@ import iconsData from "@/data/icons.json";
 
 export type Collection = "brands" | "aws" | "gcp" | "azure" | "emojis" | "k8s" | "community";
 
+/**
+ * Cloud architecture collections. Their icons carry vendor taxonomy categories
+ * (Compute, Networking, Integration, Kubernetes, ...) that would otherwise swamp
+ * the brand categories in the sidebar. We exclude them from the default category
+ * list so brand categories stay front and center; their categories still surface
+ * when the user explicitly selects one of these collections.
+ */
+export const ARCHITECTURE_COLLECTIONS: ReadonlySet<Collection> = new Set([
+  "aws",
+  "azure",
+  "gcp",
+  "k8s",
+]);
+
 export interface IconEntry {
   slug: string;
   title: string;
@@ -67,7 +81,12 @@ export function getAllCategories(): string[] {
 
 export function getCategoryCounts(collection?: Collection): { name: string; count: number }[] {
   const counts = new Map<string, number>();
-  const source = collection ? icons.filter((i) => i.collection === collection) : icons;
+  // Default view: count brand-relevant collections only, so cloud architecture
+  // taxonomy (Compute, Integration, Kubernetes, ...) does not bury brand
+  // categories. When a specific collection is requested, count just that one.
+  const source = collection
+    ? icons.filter((i) => i.collection === collection)
+    : icons.filter((i) => !ARCHITECTURE_COLLECTIONS.has(i.collection));
   for (const icon of source) {
     for (const c of icon.categories) {
       counts.set(c, (counts.get(c) || 0) + 1);


### PR DESCRIPTION
## Summary

Fixes two UI issues reported after the announcement bar was added.

### 1. Announcement bar overlapping header + sidebar
The top announcement bar pushed the navbar down, but the sticky header (`top-0`) and fixed sidebar (`top-[4.25rem]`) used hardcoded offsets that ignored the bar, so the sidebar overlapped the header.

**Fix:** the bar now publishes its height as a `--banner-h` CSS variable (via `ResizeObserver`, reset to 0 when dismissed). The header sticks at `top-[var(--banner-h)]` and the sidebar offsets both its `top` and `height` by it. A `:root { --banner-h: 0px }` default keeps pre-hydration and dismissed states correct.

Verified in-browser: `--banner-h` = 34px, header computed `top: 34px`, sidebar computed `top: 102px` (34 + 68) -> no overlap; banner stays pinned on scroll.

**Polish:** pulse dot, subtle orange gradient background + hairline border, `Read more ->` with arrow, clearer dismiss button.

### 2. AWS/Azure categories crowding out brands
The sidebar Categories list counted all icons, so cloud architecture taxonomy dominated: `General (332)`, `Compute (97)`, `Integration (72)`, `Kubernetes (38)`, `Storage (118 vs 1 brand)`, etc. — mostly zero-brand categories burying real brand ones.

**Fix:** `getCategoryCounts()` (default) now counts **brand + community** collections only (new `ARCHITECTURE_COLLECTIONS` excludes `aws/azure/gcp/k8s`). Architecture categories still appear when that collection is selected (`home-content` already recomputes per collection).

Verified: default list dropped from architecture-inflated to brand-focused; `Storage` now shows `1` (brand) not `118`; General/Compute/Integration/Kubernetes gone from the default view.

## Verification
- `pnpm build`: exit 0
- `pnpm exec tsc --noEmit`: exit 0
- lint: 0 errors on changed files
- In-browser layout + category checks (above)

## Type
- [x] Bug fix
- [x] UX improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a top announcement bar with improved visual treatment, clearer links, and a dismiss button.

* **Bug Fixes**
  * Fixed the announcement bar from overlapping the header and sidebar.
  * Kept the sidebar and header positioned correctly when the banner is shown or hidden.
  * Improved category counts so brand/community categories are easier to find without hiding architecture categories in their collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->