### PR TITLE
chore: verified quality pass (lint, search, React validator)

### DIFF
--- a/.changeset/quality-pass-lint-search-validator.md
+++ b/.changeset/quality-pass-lint-search-validator.md
@@ -1,0 +1,24 @@
+---
+"thesvg": patch
+"@thesvg/react": patch
+---
+
+Quality pass: lint hygiene, search fixes, and a correct React validator
+
+- **Lint**: ignore generated extension build dirs (`.output`, `.wxt`, `build`) so
+  ESLint stops scanning them. This drops the repo from 2361 problems (4 errors)
+  to 13 (0 errors, all intentional). Also removed genuinely dead imports/vars,
+  redundant eslint-disable directives, and hoisted a `PLACEHOLDER_BRANDS`
+  constant to module scope (fixes an exhaustive-deps warning).
+- **Search UX**: a single character no longer blanks the icon grid (aligned with
+  Fuse's `minMatchCharLength`), and the Fuse index is no longer rebuilt on every
+  keystroke while a category/favorites filter is active (memoized search base).
+- **Manifest recovery**: a transient icon-manifest load failure now clears when
+  filters change, so the grid recovers without a full page reload.
+- **@thesvg/react validator**: `validate-output.ts` compared the source SVG root
+  fill against a `<svg>` tag that no longer exists in the compiled
+  `createElement` output, producing 3185 false "fill -> none" errors. It now
+  reads the root paint from the serialized `_variants` object and mirrors the
+  build's default-fill logic. The build also cleans `dist` first so orphaned
+  components from removed slugs no longer ship or trip the validator. Validator
+  now passes on all 6,415 components.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,10 @@ const eslintConfig = defineConfig([
     "scripts/**",
     "docs-local/**",
     "extensions/**/dist/**",
+    // Generated extension build artifacts (WXT: .output/.wxt, Figma: build)
+    "extensions/**/.output/**",
+    "extensions/**/.wxt/**",
+    "extensions/**/build/**",
   ]),
   {
     rules: {
@@ -22,6 +26,11 @@ const eslintConfig = defineConfig([
       "@next/next/no-img-element": "off",
       // Common pattern for client-side detection (navigator, window) - downgrade to warn
       "react-hooks/set-state-in-effect": "warn",
+      // Underscore-prefixed identifiers signal intentional-unused (e.g. _categoryCounts)
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
     },
   },
 ]);

--- a/extensions/figma/src/ui.ts
+++ b/extensions/figma/src/ui.ts
@@ -23,7 +23,6 @@ let currentQuery = "";
 let currentCategory = "all";
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 let lastResults: IconEntry[] = [];
-let cachedRecents: RecentEntry[] = [];
 
 // ---- DOM refs ----
 const searchInput = document.getElementById("search") as HTMLInputElement;
@@ -166,7 +165,6 @@ function renderGrid(icons: IconEntry[]) {
 }
 
 function renderRecents(recents: RecentEntry[]) {
-  cachedRecents = recents;
   if (recents.length === 0) {
     recentsSection.style.display = "none";
     return;

--- a/packages/cli/src/utils/writer.ts
+++ b/packages/cli/src/utils/writer.ts
@@ -1,6 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, resolve, dirname } from "node:path";
+import { join, resolve } from "node:path";
 
 export type OutputFormat = "svg" | "jsx" | "vue";
 

--- a/packages/icons/scripts/enrich-svgl-variants.ts
+++ b/packages/icons/scripts/enrich-svgl-variants.ts
@@ -19,12 +19,10 @@
 import {
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { copyFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -204,15 +202,6 @@ function normalizeForMatch(s: string): string {
 // ---------------------------------------------------------------------------
 // svgl data parser
 // ---------------------------------------------------------------------------
-
-/**
- * Extract the file-stem (without extension) from a svgl route string.
- * e.g. "/library/astro-icon-dark.svg" -> "astro-icon-dark"
- */
-function stemFromRoute(route: string): string {
-  const b = basename(route, ".svg");
-  return b;
-}
 
 /**
  * Given a svgl entry, derive candidates for each of our variant keys.

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -50,16 +50,6 @@ interface SearchResult {
   categories: string[];
 }
 
-interface IconDetail {
-  slug: string;
-  name: string;
-  variants: string[];
-  categories: string[];
-  hex: string;
-  license: string;
-  url?: string;
-}
-
 // --- Data loading ---
 
 // icons.json is bundled at build time; no network dependency at startup.

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -19,7 +19,7 @@
  *     index.d.ts     Type barrel
  */
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -142,30 +142,6 @@ function extractRootSvgPaint(svgContent: string): RootSvgPaint {
  */
 function kebabToCamel(attr: string): string {
   return attr.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
-}
-
-/**
- * Convert a CSS style string like "mask-type:alpha;display:inline"
- * into a JSX style object expression like `{{ maskType: "alpha", display: "inline" }}`.
- */
-function convertStyleStringToJsx(styleStr: string): string {
-  // Strip surrounding quotes if present
-  const raw = styleStr.replace(/^["']|["']$/g, "");
-  const declarations = raw
-    .split(";")
-    .map((d) => d.trim())
-    .filter((d) => d.length > 0);
-
-  const entries = declarations.map((decl) => {
-    const colonIdx = decl.indexOf(":");
-    if (colonIdx === -1) return null;
-    const prop = decl.slice(0, colonIdx).trim();
-    const val = decl.slice(colonIdx + 1).trim();
-    const camelProp = kebabToCamel(prop);
-    return `${camelProp}: "${val}"`;
-  }).filter(Boolean);
-
-  return `{{ ${entries.join(", ")} }}`;
 }
 
 /**
@@ -781,6 +757,9 @@ function main(): void {
   const rawIcons: RawIcon[] = JSON.parse(readFileSync(ICONS_JSON, "utf8")) as RawIcon[];
   console.log(`Found ${rawIcons.length} icons.`);
 
+  // Clean stale output first so components for removed/renamed slugs (orphans)
+  // don't linger in dist and get shipped or flagged by the validator.
+  rmSync(DIST, { recursive: true, force: true });
   mkdirSync(DIST, { recursive: true });
 
   const entries: Array<{ slug: string; componentName: string }> = [];

--- a/packages/react/scripts/validate-output.ts
+++ b/packages/react/scripts/validate-output.ts
@@ -28,6 +28,9 @@ interface RootPaint {
   stroke?: string;
 }
 
+// Source-side paint. Mirror build-components.ts extractRootSvgPaint so a missing
+// root fill defaults the same way the build does (currentColor, or none for a
+// stroke-only icon) — otherwise the comparison below reports false mismatches.
 function extractRootPaint(content: string): RootPaint {
   const svgTag = content.match(/<svg[^>]*>/s);
   if (!svgTag) return {};
@@ -36,9 +39,19 @@ function extractRootPaint(content: string): RootPaint {
   const strokeMatch = svgTag[0].match(/\bstroke=["']([^"']+)["']/);
 
   return {
-    fill: fillMatch?.[1],
+    fill: fillMatch ? fillMatch[1] : (strokeMatch ? "none" : "currentColor"),
     stroke: strokeMatch?.[1],
   };
+}
+
+// Output-side paint. The generated component is a React.createElement tree, not
+// SVG markup, so the root paint lives in the serialized `_variants.default`
+// object (JSON.stringify order: viewBox, fill, [stroke], childNodes).
+function extractCompiledPaint(content: string): RootPaint {
+  const m = content.match(
+    /"default":\{"viewBox":"[^"]*","fill":"([^"]*)"(?:,"stroke":"([^"]*)")?/,
+  );
+  return m ? { fill: m[1], stroke: m[2] } : {};
 }
 
 function primarySvgPath(slug: string): string | null {
@@ -119,7 +132,7 @@ for (const file of files) {
 
     if (svgPath) {
       const sourcePaint = extractRootPaint(readFileSync(svgPath, "utf8"));
-      const outputPaint = extractRootPaint(content);
+      const outputPaint = extractCompiledPaint(content);
 
       if ((sourcePaint.fill ?? "none") !== (outputPaint.fill ?? "none")) {
         console.error(

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { ArrowLeft, Calendar, Link2, Tag } from "lucide-react";
+import { ArrowLeft, Calendar, Tag } from "lucide-react";
 import { ShareButtons } from "@/components/blog/share-buttons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { getCategoryCounts } from "@/lib/icons";

--- a/src/app/category/google-2026/opengraph-image.tsx
+++ b/src/app/category/google-2026/opengraph-image.tsx
@@ -124,7 +124,7 @@ export default async function Image() {
         >
           {heroSvgs.map(({ slug, svg }) =>
             svg ? (
-              // eslint-disable-next-line @next/next/no-img-element
+               
               <img
                 key={slug}
                 src={`data:image/svg+xml;base64,${Buffer.from(svg).toString("base64")}`}

--- a/src/app/icon/[slug]/opengraph-image.tsx
+++ b/src/app/icon/[slug]/opengraph-image.tsx
@@ -170,7 +170,7 @@ export default async function Image({ params }: ImageProps) {
           }}
         >
           {svgContent ? (
-            // eslint-disable-next-line @next/next/no-img-element
+             
             <img
               src={`data:image/svg+xml;base64,${Buffer.from(svgContent).toString("base64")}`}
               width={160}

--- a/src/app/icon/[slug]/page.tsx
+++ b/src/app/icon/[slug]/page.tsx
@@ -78,7 +78,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     .filter((k) => icon.variants[k as keyof typeof icon.variants])
     .map((k) => k === "default" ? "color" : k);
   const categoryList = icon.categories.join(", ");
-  const cdnImage = `${CDN_BASE}/${slug}/default.svg`;
 
   const collectionText =
     icon.collection === "aws"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -238,7 +238,7 @@ export function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
+                { }
                 <img
                   src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1176978&theme=dark"
                   alt="theSVG on Product Hunt"
@@ -246,7 +246,7 @@ export function Footer() {
                   height={43}
                   className="hidden opacity-60 transition-opacity hover:opacity-100 dark:block"
                 />
-                {/* eslint-disable-next-line @next/next/no-img-element */}
+                { }
                 <img
                   src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1176978&theme=light"
                   alt="theSVG on Product Hunt"
@@ -288,7 +288,7 @@ export function Footer() {
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 opacity-60 transition-opacity hover:opacity-100"
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  { }
                   <img
                     src="/icons/glincker/light.svg"
                     alt="GLINCKER"
@@ -296,7 +296,7 @@ export function Footer() {
                     height={20}
                     className="hidden dark:block"
                   />
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  { }
                   <img
                     src="/icons/glincker/dark.svg"
                     alt="GLINCKER"
@@ -313,7 +313,7 @@ export function Footer() {
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 opacity-60 transition-opacity hover:opacity-100"
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  { }
                   <img
                     src="/icons/askverdict-ai/light.svg"
                     alt="AskVerdict"
@@ -321,7 +321,7 @@ export function Footer() {
                     height={20}
                     className="hidden dark:block"
                   />
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  { }
                   <img
                     src="/icons/askverdict-ai/dark.svg"
                     alt="AskVerdict"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,6 +17,8 @@ import type { IconEntry } from "@/lib/icons";
 import { loadIconsManifest } from "@/lib/icons-manifest";
 import { cn } from "@/lib/utils";
 
+const PLACEHOLDER_BRANDS = ["GitHub", "Stripe", "Figma", "Docker", "AWS Lambda", "Azure Functions", "BigQuery", "Vercel", "React", "Tailwind CSS"];
+
 /** Inline AWS logo - text inherits currentColor, arrow stays orange */
 function AwsLogo({ className }: { className?: string }) {
   return (
@@ -135,7 +137,6 @@ export function Header() {
     (pathname.startsWith("/collection/") ? pathname.split("/")[2] : null);
 
   // Typewriter placeholder effect
-  const PLACEHOLDER_BRANDS = ["GitHub", "Stripe", "Figma", "Docker", "AWS Lambda", "Azure Functions", "BigQuery", "Vercel", "React", "Tailwind CSS"];
   const [placeholderIdx, setPlaceholderIdx] = useState(0);
   const [charIdx, setCharIdx] = useState(0);
   const [isDeleting, setIsDeleting] = useState(false);

--- a/src/components/home-content.tsx
+++ b/src/components/home-content.tsx
@@ -193,30 +193,40 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
   const [filtered, setFiltered] = useState<IconEntry[]>([]);
   const filterKey = `${query}|${categoryParam ?? ""}|${sortParam ?? ""}|${favoritesParam}|${collectionParam ?? ""}`;
 
+  // Apply favorites + category filters here so the array identity only changes
+  // when those filters change (not on every keystroke). This lets the Fuse
+  // search index reuse its cached instance instead of re-indexing per keystroke.
+  const searchBase = useMemo(() => {
+    let r = collectionIcons ?? [];
+    if (favoritesParam) {
+      r = r.filter((icon) => favorites.includes(icon.slug));
+    }
+    if (categoryParam) {
+      r = r.filter((icon) =>
+        icon.categories.some((c) => c.toLowerCase() === categoryParam.toLowerCase())
+      );
+    }
+    return r;
+  }, [collectionIcons, favoritesParam, favorites, categoryParam]);
+
+  // Clear a prior manifest load failure when filters change so the load effect
+  // above can re-attempt the fetch (recovers from a transient network error
+  // without a full page reload). setState to the same value is a no-op.
+  useEffect(() => {
+    setManifestError(false);
+  }, [filterKey]);
+
   useEffect(() => {
     if (!collectionIcons) return;
 
     let active = true;
-    let result = collectionIcons;
+    let result = searchBase;
 
-    // Favorites filter
-    if (favoritesParam) {
-      result = result.filter((icon) => favorites.includes(icon.slug));
-    }
-
-    // Category filter
-    if (categoryParam) {
-      result = result.filter((icon) =>
-        icon.categories.some(
-          (c) => c.toLowerCase() === categoryParam.toLowerCase()
-        )
-      );
-    }
-
-    // Lazy-load Fuse.js only when there is a search query.
-    // Clear stale results immediately so the previous query's matches don't
-    // linger while Fuse downloads / runs.
-    if (query.trim()) {
+    // Lazy-load Fuse.js only when there is a real (>= 2 char) search query,
+    // matching Fuse's minMatchCharLength so a single character does not blank
+    // the grid. Clear stale results immediately so the previous query's matches
+    // don't linger while Fuse downloads / runs.
+    if (query.trim().length >= 2) {
       setFiltered([]);
       import("@/lib/search").then(({ searchIcons }) => {
         if (!active) return;
@@ -248,9 +258,10 @@ export function HomeContent({ categoryCounts, count, recentIcons, collections, d
 
     setFiltered(result);
     return () => { active = false; };
-  // filterKey captures all search/filter/sort deps; collectionIcons and favorites are the data deps
+  // filterKey captures all search/sort deps; searchBase carries the favorites +
+  // category filtering; collectionIcons is retained for the early-return guard.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collectionIcons, filterKey, favorites]);
+  }, [searchBase, collectionIcons, filterKey]);
 
   const activeCount = collectionParam && collectionIcons
     ? collectionIcons.length

--- a/src/components/landing/google-2026-landing.tsx
+++ b/src/components/landing/google-2026-landing.tsx
@@ -176,7 +176,7 @@ export function Google2026Landing({ icons }: Props) {
             className="g26-hero-mark"
             aria-label="Google Workspace mark · open detail page"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
+            { }
             <img
               src={hero.variants.default}
               alt=""

--- a/src/components/landing/google-2026-tile.tsx
+++ b/src/components/landing/google-2026-tile.tsx
@@ -120,7 +120,7 @@ export function Google2026Tile({ icon, delay, cleanTitle }: Props) {
       <span className="g26-tile-halo" aria-hidden />
 
       <span className="g26-tile-card">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
+        { }
         <img
           src={src}
           alt=""


### PR DESCRIPTION
## Summary
Findings from a multi-agent audit (4 read-only investigators + adversarial verification per finding). Only verified-safe fixes were applied; the verifiers caught and corrected several buggy auto-suggestions before they landed.

### Lint hygiene (2361 problems / 4 errors -> 13 / 0 errors)
- `eslint.config.mjs`: add generated extension dirs (`.output`, `.wxt`, `build`) to `globalIgnores` (all 4 errors + ~2320 warnings came from these gitignored artifacts). Add `^_` ignore pattern for intentional-unused vars.
- Remove 10 genuinely-dead imports/vars (`Link2`, `cdnImage`, `IconDetail`, `dirname`, `convertStyleStringToJsx`, `readdirSync`/`copyFile`/`stemFromRoute`, `cachedRecents`) and 10 redundant `eslint-disable` directives.
- Hoist `PLACEHOLDER_BRANDS` to module scope (fixes exhaustive-deps).
- The remaining 13 warnings are all the intentional, documented `set-state-in-effect` client-detection pattern — left as-is.

### Search UX + perf (home-content.tsx)
- **1-char query no longer blanks the grid** (aligned with Fuse `minMatchCharLength: 2`).
- **Fuse index no longer rebuilt on every keystroke** when a category/favorites filter is active — filtering moved into a memoized `searchBase` so the array identity is stable across keystrokes and the cached Fuse instance is reused.
- **Manifest load recovery**: a transient fetch failure now clears on filter change, so the grid recovers without a page reload (previously latched permanently).

### @thesvg/react validator + build (the 3185-error mystery)
- `validate-output.ts` compared the source SVG root fill against a `<svg>` tag that **does not exist** in the compiled `createElement` output, so every colored icon reported a false `fill -> none` error. It now reads the root paint from the serialized `_variants.default` and mirrors the build's default-fill logic (`currentColor`/`none`).
- The single *real* failure this surfaced was a stale orphan (`dist/huggingface.js`, a removed slug). The build now cleans `dist` before generating, so orphans no longer ship or trip the validator.
- **Validator result: 3185 errors -> PASS (6,415 components).**

## Verification
- `pnpm lint`: 0 errors (13 intentional warnings)
- `pnpm exec tsc --noEmit`: exit 0
- `pnpm build`: exit 0
- `packages/react`: rebuilt + `validate-output.ts` PASS on 6,415 files

## Type
- [x] Bug fix
- [x] Chore / quality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior for short queries and made filtering faster during active searches.
  * Made icon/manifest loading more resilient after temporary failures.
  * Fixed React output validation so generated icons match the source more reliably, including after component removals.

* **Chores**
  * Cleaned up linting rules and removed a few unused or redundant bits across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->