### PR TITLE
feat: enrich per-icon ImageObject structured data

### DIFF
--- a/.changeset/icon-variant-structured-data.md
+++ b/.changeset/icon-variant-structured-data.md
@@ -1,0 +1,10 @@
+---
+"thesvg": patch
+---
+
+Enrich per-icon structured data for richer search results
+
+The icon detail page's ImageObject JSON-LD now marks the icon as free
+(`isAccessibleForFree`, `representativeOfPage`) and exposes each additional
+variant (mono, dark, color, wordmark, ...) as its own `associatedMedia`
+ImageObject, so search engines can surface a brand's variants individually.

--- a/src/app/icon/[slug]/page.tsx
+++ b/src/app/icon/[slug]/page.tsx
@@ -180,8 +180,29 @@ export default async function IconPage({ params }: PageProps) {
         creditText: icon.title,
         width: "512",
         height: "512",
+        isAccessibleForFree: true,
+        representativeOfPage: true,
         ...(icon.url ? { sameAs: [icon.url] } : {}),
         keywords: allKeywords.join(", "),
+        // Expose each additional variant (mono, dark, color, wordmark, ...) as
+        // its own ImageObject so search engines can surface them individually.
+        ...(() => {
+          const extraVariants = Object.keys(icon.variants).filter(
+            (v) => v !== "default",
+          );
+          return extraVariants.length > 0
+            ? {
+                associatedMedia: extraVariants.map((v) => ({
+                  "@type": "ImageObject",
+                  name: `${icon.title} ${v} SVG icon`,
+                  contentUrl: `${CDN_BASE}/${slug}/${v}.svg`,
+                  encodingFormat: "image/svg+xml",
+                  license: licenseUrl,
+                  isAccessibleForFree: true,
+                })),
+              }
+            : {};
+        })(),
         creator: {
           "@type": "Organization",
           name: "theSVG",


### PR DESCRIPTION
## Summary
Strengthens how search engines index individual icons (your 'Icon SEO' ask). The icon page already had a solid `ImageObject` + `WebPage` + `BreadcrumbList` graph; this enriches the `ImageObject`:

- `isAccessibleForFree: true` + `representativeOfPage: true` (free-content + primary-image signals)
- **`associatedMedia`**: each additional variant (mono, dark, color, wordmark, wordmarkDark, ...) is now its own `ImageObject` with its CDN `contentUrl`, so a brand's variants can surface individually in image/rich results.

Verified: build + `tsc` pass; rendered JSON-LD parses valid; e.g. Zoho emits 3 `associatedMedia` entries (mono, wordmark, wordmarkDark).

## ⚠️ Pre-existing delivery gap found (not fixed here)
While verifying, I found the site's JSON-LD (this ImageObject **and** the homepage `SearchAction`) is emitted **only into the Next RSC/hydration payload, not the raw static HTML** (`output: export`). JS-rendering crawlers like Googlebot still read it, but non-JS crawlers (and some scrapers) don't see a literal `<script type="application/ld+json">` in view-source. This affects all structured data, predates this PR, and is worth a focused follow-up.

## Type
- [x] SEO / structured data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved page metadata for icon pages so search engines can recognize free content and better index individual icon variants.
  * Added structured data for each icon style variant, helping variants like mono, dark, color, and wordmark appear separately in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->