### PR TITLE
fix: emit variant prop in React demo snippet

### DIFF
--- a/src/lib/code-snippets.ts
+++ b/src/lib/code-snippets.ts
@@ -79,12 +79,15 @@ export function generateSnippet(
   const cssClass = `icon-${slugToClassName(slug)}`;
 
   switch (format) {
-    case "react":
+    case "react": {
+      const variantProp =
+        variant && variant !== "default" ? ` variant="${variant}"` : "";
       return `import { ${componentName} } from '@thesvg/react';
 
 export default function App() {
-  return <${componentName} className="h-6 w-6" />;
+  return <${componentName}${variantProp} className="h-6 w-6" />;
 }`;
+    }
 
     case "vue":
       return `<template>


### PR DESCRIPTION
Resolves #685.

When a non-default variant is selected in the icon detail demo builder, the React code snippet now includes the `variant` prop, matching the behavior already present for the Vue/HTML/CSS/Next.js snippets (which route through the variant-aware CDN/site URL helpers).

Before:
```jsx
return <Zoom className="h-6 w-6" />;
```

After (variant = mono):
```jsx
return <Zoom variant="mono" className="h-6 w-6" />;
```

The `default` variant is omitted since it is the component default. The `@thesvg/react` components already accept a typed `variant` prop.

Closes #685

Co-Authored-By: Glinr <bot@glincker.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * React icon snippets now include the selected variant when one is chosen, improving the accuracy of generated code examples.
  * Snippets continue to omit the variant setting when the default option is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->