### PR TITLE
fix: repair broken pnpm-lockfile (duplicate keys)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3298,10 +3298,6 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -6349,10 +6345,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
   fflate@0.4.8: {}
 
   figures@6.1.0:
@@ -7276,8 +7268,6 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
-
-  picomatch@4.0.5: {}
 
   picomatch@4.0.5: {}
 


### PR DESCRIPTION
## Problem

CI's `Lint & Build` job is failing on `main` and on every open PR at the **Install dependencies** step:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile is broken: duplicated mapping key (3301:3)
```

The shadcn bump (#681) landed a `pnpm-lock.yaml` containing three duplicated mapping keys (identical blocks):

- `picomatch@4.0.5` in `packages:`
- `picomatch@4.0.5` in `snapshots:`
- `fdir@6.5.0(picomatch@4.0.5)` in `snapshots:`

Duplicate YAML mapping keys make the lockfile unparseable, so `pnpm install --frozen-lockfile` aborts before anything builds.

## Fix

Removed the second (byte-identical) occurrence of each duplicated key. No dependency versions change. Verified there are zero remaining duplicate keys, and:

```
pnpm install --frozen-lockfile   # succeeds
pnpm run build                   # succeeds (full SSG build)
```

This needs to merge first; the other open PRs (#692, #693, #694, #695) will go green once rebased on it.

Co-Authored-By: Glinr <bot@glincker.com>