### PR TITLE
fix: correct Xbox brand hex color

### DIFF
--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -120131,7 +120131,7 @@
     "slug": "xbox",
     "title": "Xbox",
     "aliases": [],
-    "hex": "000000",
+    "hex": "107c10",
     "categories": [
       "Software",
       "Platform"


### PR DESCRIPTION
Closes #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Xbox icon color to its official green shade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->