### PR TITLE
fix: bump release workflow Node version to 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- release.yml's publish job pins Node 20 but force-upgrades npm via `npm install -g npm@latest`, which now requires Node 22.22+/24.15+/26+. Every run of the publish workflow fails at that step before installing deps, building, or publishing anything.
- Bumps `NODE_VERSION` to `22` so the npm upgrade step succeeds and the release can actually run.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger `Release - Publish` via `workflow_dispatch` (or merge the next Version Packages PR) and confirm the job proceeds past "Upgrade npm for OIDC"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use Node.js 22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->