### PR TITLE
fix: remove broken npm self-upgrade step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
-      - name: Upgrade npm for OIDC
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Even after bumping to Node 22 (#721), the publish job failed one step later: `npm install -g npm@latest` reinstalls a global npm that's missing the `sigstore` optional dependency, which `libnpmpublish` needs for `--provenance` publishing. Every package after the first hit `Cannot find module 'sigstore'`.
- Node 22's bundled npm (~10.9) already supports provenance/OIDC natively, so the upgrade step is unnecessary and actively breaks the install. Removed it.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger `Release - Publish` via `workflow_dispatch` and confirm packages actually publish end to end (tags + GitHub release created)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release process by removing an unnecessary package manager upgrade step.
  * Dependency installation now proceeds directly after the environment is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->