### PR TITLE
fix: pin npm OIDC upgrade to stable 11.18.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   NODE_VERSION: "22"
+  NPM_VERSION: "11.18.0"
 
 jobs:
   publish:
@@ -41,7 +42,7 @@ jobs:
           cache: pnpm
 
       - name: Upgrade npm for OIDC
-        run: npm install -g npm@11.18.0
+        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
+      - name: Upgrade npm for OIDC
+        run: npm install -g npm@11.18.0
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary
- Root cause of the publish 404 (#722's fix): this repo publishes via npm's OIDC Trusted Publishing (visible in npm's registry maintainer field: "GitHub Actions <npm-oidc-no-reply@github.com>"), which requires npm CLI >=11.5.1. Node 22's bundled npm (~10.9) is too old to exchange the GitHub OIDC token for a registry auth token, so publish falls back to unauthenticated and gets a 404 on the scoped package.
- The original upgrade step used `npm install -g npm@latest`, which currently resolves to a freshly-released `12.0.0` with a broken self-install (missing `sigstore`, needed for `--provenance`).
- Fix: re-add the upgrade step, pinned to the last stable 11.x release (`11.18.0`) instead of `@latest`. Supports trusted publishing, avoids the 12.0.0 packaging bug.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger `Release - Publish` via `workflow_dispatch` and confirm npm publish actually succeeds end to end (tags + GitHub release created)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release process to use a newer npm version before publishing to improve secure package publishing compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->