### PR TITLE
docs: add moderator application program

### DIFF
--- a/.github/ISSUE_TEMPLATE/moderator_application.yml
+++ b/.github/ISSUE_TEMPLATE/moderator_application.yml
@@ -1,0 +1,58 @@
+name: Moderator Application
+description: Apply to become a community moderator for thesvg
+labels: ["moderator-application"]
+title: "Moderator application: "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in helping run thesvg! Moderators get **triage access**
+        (labeling, closing/reopening issues, requesting changes on PRs) so they can help
+        keep icon requests and submissions moving. See the "Become a Moderator" section
+        of [CONTRIBUTING.md](../../CONTRIBUTING.md) for what the role involves.
+
+  - type: input
+    id: github_username
+    attributes:
+      label: GitHub Username
+      placeholder: e.g. octocat
+    validations:
+      required: true
+
+  - type: textarea
+    id: contributions
+    attributes:
+      label: Your contributions so far
+      description: Link to icon PRs, issue triage, or discussions you've participated in.
+      placeholder: |
+        - PR #123: added Acme Corp icon
+        - Helped triage issue #456
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why do you want to moderate?
+      description: What part of triage/review are you most interested in helping with?
+    validations:
+      required: true
+
+  - type: textarea
+    id: availability
+    attributes:
+      label: Availability
+      description: Roughly how much time per week can you spend on triage/review?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have read the Become a Moderator section of CONTRIBUTING.md
+          required: true
+        - label: I have at least one merged contribution or meaningful triage activity on this repo
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,30 @@ Web Services and all related marks are trademarks of Amazon.com, Inc.
 For trademark concerns, see [TRADEMARK.md](./TRADEMARK.md) or contact
 [support@glincker.com](mailto:support@glincker.com).
 
+## Become a Moderator
+
+thesvg runs on triage: labeling issues, checking SVG submissions against the
+requirements above, and reviewing incoming PRs. If you've been doing that
+informally, we'd like to make it official.
+
+**What moderators get**: triage access to the repo, so you can label issues,
+close/reopen, and request changes on PRs. Moderators do not get merge or push
+access; merges still go through a maintainer review.
+
+**What we look for**:
+
+- At least one merged icon or code contribution, or a track record of helpful
+  triage on issues/discussions
+- Familiarity with the [icon submission requirements](#submit-a-new-icon) so
+  you can sanity-check incoming requests (SVG validity, size, domain age,
+  category)
+- Enough time to check in on new issues/PRs at least weekly
+
+**How to apply**: open a
+[Moderator Application](https://github.com/glincker/thesvg/issues/new?template=moderator_application.yml)
+issue with links to your prior contributions. We review applications as they
+come in and follow up in the issue.
+
 ## Questions?
 
 - [Open a discussion](https://github.com/glincker/thesvg/discussions)


### PR DESCRIPTION
## Description

Adds a lightweight path for community members to apply for triage/moderator access, matching how other OSS projects (Kubernetes, CNCF, OpenFeature) document contributor ladders, scaled down to fit thesvg's no-gatekeeping culture.

## Changes

- `CONTRIBUTING.md`: new "Become a Moderator" section describing the role (triage access only, no merge/push), what we look for, and how to apply
- `.github/ISSUE_TEMPLATE/moderator_application.yml`: structured application form, same style as `icon_request.yml`
- New `moderator-application` label

## Type

- [x] Documentation
- [x] Maintenance/chore

## Next steps (not in this PR)

- Post a "We're looking for moderators" announcement in [Discussions → Announcements](https://github.com/glincker/thesvg/discussions/categories/announcements) once this merges, linking to the application template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured moderator application form to collect applicants’ contributions, motivation, availability, and eligibility confirmations.

* **Documentation**
  * Added guidance for the moderator role, including responsibilities, access levels, qualification criteria, availability expectations, and application instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->