### PR TITLE
fix: include wordmark variant SVGs in @thesvg/react build

### DIFF
--- a/.changeset/react-wordmark-variants.md
+++ b/.changeset/react-wordmark-variants.md
@@ -1,0 +1,14 @@
+---
+"@thesvg/react": patch
+---
+
+Include wordmarkMono, wordmarkLight, and wordmarkDark variants in generated React components
+
+The codegen reconstructed each variant's SVG filename from its camelCase
+key (`wordmarkLight` -> `wordmarkLight.svg`), but those files are stored
+kebab-case on disk (`wordmark-light.svg`), so the variant silently failed
+to load and was dropped from the component's variant union entirely.
+icons.json already records the correct path for every variant; the codegen
+now reads that path directly instead of reconstructing it. Fixes 221
+missing variants across 70+ icons, including Apple Music, Zoom, TikTok,
+Vercel, and YouTube. Fixes #740.

--- a/packages/react/scripts/build-components.ts
+++ b/packages/react/scripts/build-components.ts
@@ -35,7 +35,6 @@ const PKG_ROOT = resolve(__dirname, "..");
 /** Root of the thesvg monorepo */
 const REPO_ROOT = resolve(PKG_ROOT, "../..");
 const ICONS_JSON = join(REPO_ROOT, "src/data/icons.json");
-const ICONS_PUBLIC = join(REPO_ROOT, "public/icons");
 const DIST = join(PKG_ROOT, "dist");
 
 // ---------------------------------------------------------------------------
@@ -70,9 +69,16 @@ interface RawIcon {
 // SVG reading & parsing
 // ---------------------------------------------------------------------------
 
-/** Read an SVG file from the public directory. Returns empty string on miss. */
-function readSvg(slug: string, variant: string): string {
-  const filePath = join(ICONS_PUBLIC, slug, `${variant}.svg`);
+/**
+ * Read an SVG file given its icons.json-relative public path (e.g.
+ * "/icons/apple-music/wordmark-light.svg"). Returns empty string on miss.
+ *
+ * Variant SVG filenames aren't always the camelCase variant key
+ * (e.g. "wordmarkLight" -> "wordmark-light.svg" on disk), so the path must
+ * come from icons.json rather than being reconstructed from slug + variant.
+ */
+function readSvg(publicPath: string): string {
+  const filePath = join(REPO_ROOT, "public", publicPath.replace(/^\//, ""));
   if (!existsSync(filePath)) return "";
   return readFileSync(filePath, "utf8").trim();
 }
@@ -81,16 +87,18 @@ function readSvg(slug: string, variant: string): string {
  * Resolve the "primary" SVG for an icon.
  * Preference order: default -> color -> mono -> light -> dark -> wordmark -> first available.
  */
-function primarySvg(slug: string, variants: RawIconVariants): string {
+function primarySvg(variants: RawIconVariants): string {
   const order = ["default", "color", "mono", "light", "dark", "wordmark"];
   for (const v of order) {
-    if (v in variants) {
-      const content = readSvg(slug, v);
+    const path = variants[v];
+    if (path) {
+      const content = readSvg(path);
       if (content) return content;
     }
   }
-  for (const v of Object.keys(variants)) {
-    const content = readSvg(slug, v);
+  for (const path of Object.values(variants)) {
+    if (!path) continue;
+    const content = readSvg(path);
     if (content) return content;
   }
   return "";
@@ -300,8 +308,8 @@ interface ParsedIcon {
 }
 
 /** Parse one variant SVG file. Returns null when the file is missing/empty. */
-function parseVariant(slug: string, variant: string): ParsedSvg | null {
-  const svgContent = readSvg(slug, variant);
+function parseVariant(publicPath: string): ParsedSvg | null {
+  const svgContent = readSvg(publicPath);
   if (!svgContent) return null;
   const { inner, viewBox, fill, stroke } = svgToJsxInner(svgContent);
   return { viewBox, fill, stroke, childNodes: convertJsxToCjs(inner) };
@@ -315,7 +323,7 @@ function parseVariant(slug: string, variant: string): ParsedSvg | null {
  * when their SVG file exists and parses. Returns null when no SVG is found.
  */
 function parseSvgForIcon(icon: RawIcon): ParsedIcon | null {
-  const svgContent = primarySvg(icon.slug, icon.variants);
+  const svgContent = primarySvg(icon.variants);
   if (!svgContent) return null;
 
   const { inner, viewBox, fill, stroke } = svgToJsxInner(svgContent);
@@ -323,9 +331,9 @@ function parseSvgForIcon(icon: RawIcon): ParsedIcon | null {
     default: { viewBox, fill, stroke, childNodes: convertJsxToCjs(inner) },
   };
 
-  for (const key of Object.keys(icon.variants)) {
-    if (key === "default") continue;
-    const parsed = parseVariant(icon.slug, key);
+  for (const [key, path] of Object.entries(icon.variants)) {
+    if (key === "default" || !path) continue;
+    const parsed = parseVariant(path);
     if (parsed) {
       // If a mono SVG explicitly declares fill="none" on its root (uncommon
       // but valid), override to currentColor. The general case (no fill attr)

--- a/packages/react/scripts/validate-output.ts
+++ b/packages/react/scripts/validate-output.ts
@@ -20,6 +20,7 @@ const __dirname = dirname(__filename);
 const DIST = resolve(__dirname, "../dist");
 const REPO_ROOT = resolve(__dirname, "../../..");
 const ICONS_PUBLIC = resolve(REPO_ROOT, "public/icons");
+const ICONS_JSON = resolve(REPO_ROOT, "src/data/icons.json");
 
 const PRIMARY_VARIANTS = ["default", "color", "mono", "light", "dark", "wordmark"];
 
@@ -151,9 +152,47 @@ for (const file of files) {
   }
 }
 
+// Every variant declared in icons.json with a real SVG on disk must survive
+// into the compiled output. Regression test for issue #740: build-components.ts
+// used to reconstruct SVG filenames from the variant key (e.g. "wordmarkLight"
+// -> "wordmarkLight.svg"), silently dropping variants whose files are
+// kebab-case on disk ("wordmark-light.svg"), which icons.json's own path
+// already records correctly.
+interface RawIcon {
+  slug: string;
+  variants: Record<string, string>;
+}
+
+const icons: RawIcon[] = JSON.parse(readFileSync(ICONS_JSON, "utf8"));
+let iconsChecked = 0;
+
+for (const icon of icons) {
+  const dtsPath = join(DIST, `${icon.slug}.d.ts`);
+  if (!existsSync(dtsPath)) continue;
+
+  const dts = readFileSync(dtsPath, "utf8");
+  const unionMatch = dts.match(/Variant = ([^;]+);/);
+  const compiledVariants = new Set(
+    unionMatch ? unionMatch[1].split("|").map((v) => v.trim().replace(/'/g, "")) : [],
+  );
+
+  for (const [variantKey, variantPath] of Object.entries(icon.variants)) {
+    const svgFile = join(REPO_ROOT, "public", variantPath.replace(/^\//, ""));
+    if (!existsSync(svgFile)) continue;
+
+    if (!compiledVariants.has(variantKey)) {
+      console.error(
+        `FAIL: ${icon.slug} declares variant "${variantKey}" (${variantPath}) but it is missing from the compiled output`,
+      );
+      errors++;
+    }
+  }
+  iconsChecked++;
+}
+
 if (errors > 0) {
   console.error(`\n${errors} error(s) in ${checked} files. Fix build-components.ts and rebuild.`);
   process.exit(1);
 } else {
-  console.log(`PASS: ${checked} .js files validated, no issues found.`);
+  console.log(`PASS: ${checked} .js files validated, ${iconsChecked} icons' variant coverage checked, no issues found.`);
 }


### PR DESCRIPTION
## Summary

- \`readSvg()\` in \`packages/react/scripts/build-components.ts\` reconstructed each variant's SVG filename from its camelCase variant key (e.g. \`wordmarkLight\` -> \`wordmarkLight.svg\`), but those files are kebab-case on disk (\`wordmark-light.svg\`). The lookup silently missed, and the variant was dropped from the generated component's variant union entirely.
- icons.json already records the correct path for every variant (e.g. \`/icons/apple-music/wordmark-light.svg\`), so the codegen now reads that path directly instead of reconstructing it from the key.
- Fixes 221 missing variants across 70+ icons (Apple Music, Zoom, TikTok, Vercel, YouTube, Webflow, and others).
- Extended \`validate-output.ts\` (the package's test/validation script) to assert every variant declared in icons.json with a real SVG on disk survives into the compiled output, so this regresses loudly next time instead of silently.

Fixes #740

## Test plan

- [x] \`npm run build\` in \`packages/react\` (regenerates dist from the fixed codegen)
- [x] \`npm run test\` in \`packages/react\` — new regression check fails against the old codegen (confirmed 221 errors before the fix) and passes after
- [x] Spot-checked \`dist/apple-music.d.ts\` and \`dist/zoom-2025.d.ts\` now include \`wordmarkLight\`/\`wordmarkDark\`/\`wordmarkMono\`
- [x] \`eslint\` clean on both changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading of light, dark, and monochrome wordmark variants.
  * Restored hundreds of previously missing icon variants across the React package.
  * Improved variant handling for SVG filenames with different naming conventions.

* **Tests**
  * Added validation to ensure available icon variants are included in compiled component output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->