### PR TITLE
feat: add Longbridge icon

### DIFF
--- a/public/icons/longbridge/default.svg
+++ b/public/icons/longbridge/default.svg
@@ -1,0 +1,16 @@
+<svg width="69px" height="69px" viewBox="0 0 69 69" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>light-logo</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="light-icon" transform="translate(-29.000000, -30.000000)" fill-rule="nonzero">
+            <g id="light-logo" transform="translate(29.000000, 30.000000)">
+                <rect id="Rectangle" fill="#000000" x="0" y="0" width="3" height="69"></rect>
+                <rect id="Rectangle" fill="#FFE000" x="21" y="60" width="9" height="9"></rect>
+                <rect id="Rectangle" fill="#000000" x="33" y="60" width="3" height="9"></rect>
+                <rect id="Rectangle" fill="#000000" x="53" y="43" width="9" height="26"></rect>
+                <rect id="Rectangle" fill="#FC5200" x="66" y="26" width="3" height="43"></rect>
+                <rect id="Rectangle" fill="#FC5200" x="40" y="52" width="10" height="17"></rect>
+                <rect id="Rectangle" fill="#00DBB6" x="7" y="0" width="10" height="69"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -51315,7 +51315,7 @@
     "dateAdded": "2026-06-29",
     "collection": "community"
   },
-	{
+  {
     "slug": "edison",
     "title": "Edison",
     "aliases": [],
@@ -78697,6 +78697,22 @@
     "url": "https://www.elastic.co/brand",
     "guidelines": "https://www.elastic.co/brand",
     "dateAdded": "2026-03-07",
+    "collection": "brands"
+  },
+  {
+    "slug": "longbridge",
+    "title": "Longbridge",
+    "aliases": [],
+    "hex": "00DBB6",
+    "categories": [
+      "Finance"
+    ],
+    "variants": {
+      "default": "/icons/longbridge/default.svg"
+    },
+    "license": "Longbridge Brand Guidelines - non-commercial use only",
+    "url": "https://longbridge.com",
+    "dateAdded": "2026-07-17",
     "collection": "brands"
   },
   {


### PR DESCRIPTION
## Summary
- Add the Longbridge brand icon, submitted via thesvg.org
- License is restrictive (non-commercial use only per Longbridge's brand guidelines) — kept as the explicit `license` string in icons.json so downstream consumers see the restriction rather than assuming MIT/CC0 like most of the catalog

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Longbridge brand icon to the available icon collection.
  * Included icon metadata, categorization, aliases, licensing, and attribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->