### PR TITLE
docs: update icon counts to 6,500+ across README, packages, and site copy

### DIFF
--- a/LEGAL.md
+++ b/LEGAL.md
@@ -33,7 +33,7 @@ Icons marked `Fair Use` or `Proprietary` should be used with extra care. Review 
 
 ### Brand guidelines
 
-Where available, we link to official brand guidelines on each icon's detail page. Currently 869 of 4,000+ icons have verified guideline links. We are actively expanding this coverage.
+Where available, we link to official brand guidelines on each icon's detail page. Currently 1,103 of 6,500+ icons have verified guideline links. We are actively expanding this coverage.
 
 ## Takedown and Removal
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <strong>6,400+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
+  <strong>6,500+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C400%2B-F97316?style=flat-square" alt="6,400+ icons" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C500%2B-F97316?style=flat-square" alt="6,500+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
   <a href="https://www.figma.com/community/plugin/1612997159050367763"><img src="https://img.shields.io/badge/Figma-Plugin-F24E1E?style=flat-square&logo=figma&logoColor=white" alt="Figma" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/badge/VS%20Code-Extension-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white" alt="VS Code" /></a>
@@ -43,7 +43,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ SVG icons for developers" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ SVG icons for developers" width="720" />
   </a>
 </p>
 
@@ -53,12 +53,12 @@
 
 Most icon libraries focus on UI icons. Brand logos are scattered across press kits, Figma files, and random GitHub repos. **theSVG** is the single source for SVG icons - brand logos, cloud architecture diagrams, and more. Searchable, versioned, and available as npm packages, CDN, CLI, API, and MCP server.
 
-- **6,400+ icons** across multiple collections
-- **4,400+ brand icons** across 55+ categories
+- **6,500+ icons** across multiple collections
+- **4,600+ brand icons** across 140+ categories
 - **739 AWS Architecture icons** (2026-Q1)
 - **626 Azure Service icons** (2026-Q1)
 - **214 Google Cloud icons** (2026-Q1)
-- **8,400+ SVG variants** - color, mono, light, dark, wordmark
+- **12,300+ SVG variants** - color, mono, light, dark, wordmark
 - **Tree-shakeable** - import one icon, ship only that icon
 - **TypeScript-first** - fully typed, dual ESM/CJS
 - **Framework-agnostic** - React, Vue, Svelte, plain HTML, or CDN
@@ -70,7 +70,7 @@ theSVG organizes icons into collections:
 
 | Collection | Icons | Description |
 |------------|-------|-------------|
-| **Brand Icons** | 4,487 | Brand logos from 55+ categories |
+| **Brand Icons** | 4,629 | Brand logos from 140+ categories |
 | **AWS Architecture** | 739 | Official AWS service, resource, category, and group icons (2026-Q1) |
 | **Azure Services** | 626 | Microsoft Azure service icons (2026-Q1) |
 | **Google Cloud** | 214 | Google Cloud Platform icons (2026-Q1) |
@@ -127,15 +127,15 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 
 | Extension | Status | Description |
 |-----------|--------|-------------|
-| [Figma Plugin](https://www.figma.com/community/plugin/1612997159050367763) | Published | Browse 6,400+ brand SVGs, variant picker, recents row, keyboard shortcuts. Insert as editable vectors. |
-| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,400+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
+| [Figma Plugin](https://www.figma.com/community/plugin/1612997159050367763) | Published | Browse 6,500+ brand SVGs, variant picker, recents row, keyboard shortcuts. Insert as editable vectors. |
+| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,500+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [Agent Skill](https://skills.sh/glincker/thesvg) | Published | Drop-in skill for AI agents. Install via `npx skills add glincker/thesvg`. Teaches the icon CDN and registry. |
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |
 | [Homebrew](https://github.com/glincker/homebrew-thesvg) | Published | `brew tap glincker/thesvg && brew install thesvg` |
 | [CDN via jsDelivr](https://www.jsdelivr.com/package/gh/glincker/thesvg) | Published | Serve any icon via global CDN. Drop into HTML, CSS, Markdown, Notion, Webflow, Framer. |
-| [Browser Extension](https://github.com/glincker/thesvg/tree/main/extensions/browser) | Beta | Chrome, Firefox, Edge popup with 6,400+ brand SVGs. MV3, no telemetry. |
+| [Browser Extension](https://github.com/glincker/thesvg/tree/main/extensions/browser) | Beta | Chrome, Firefox, Edge popup with 6,500+ brand SVGs. MV3, no telemetry. |
 | [JetBrains](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | IntelliJ, WebStorm, PyCharm, Rider tool window. Help wanted. |
 | [Neovim](https://github.com/glincker/thesvg/tree/main/extensions/neovim) | Published | Lua plugin with Telescope picker. Insert SVG URL or inline content at cursor. |
 | [Alfred Workflow](https://github.com/glincker/thesvg/tree/main/extensions/alfred) | Published | macOS quick access. Search anywhere, copy SVG, CDN URL, or markdown. |
@@ -257,7 +257,7 @@ You can also clone the repo (~30 MB) and self-host. The codebase is MIT-licensed
 
 ## Categories
 
-Icons are organized into 55+ categories:
+Icons are organized into 140+ categories:
 
 `AI` `Analytics` `Authentication` `Automotive` `Aviation` `Browser` `Cloud` `CMS` `Community` `Crypto` `Database` `Design` `Devtool` `Education` `Entertainment` `Finance` `Food` `Framework` `Gaming` `Hardware` `Hosting` `IoT` `Language` `Library` `Linux` `Media` `Music` `Payment` `Platform` `Privacy` `Security` `Self-Hosted` `Shopping` `Social` `Software` and more...
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -44,7 +44,7 @@ _Be the first._
 
 ## What the money funds
 
-- Vercel hosting and bandwidth for thesvg.org (6,100+ icons served via CDN)
+- Vercel hosting and bandwidth for thesvg.org (6,500+ icons served via CDN)
 - Domain renewals and the occasional legal letter when a brand owner asks for a takedown
 - Quarterly architecture-icon refreshes (AWS, GCP, Azure import scripts and validation)
 - Maintainer time on triage, PR review, and the submit flow

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "thesvg/thesvg",
-	"description": "4,000+ brand SVG icons for developers and designers",
+	"description": "6,500+ brand SVG icons for developers and designers",
 	"homepage": "https://thesvg.org/",
 	"keywords": [
 		"svg",

--- a/extensions/alfred/info.plist
+++ b/extensions/alfred/info.plist
@@ -68,13 +68,13 @@
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>
-				<string>Search 6,030+ brand SVGs</string>
+				<string>Search 6,500+ brand SVGs</string>
 				<key>title</key>
 				<string>theSVG - Search brand icons</string>
 				<key>type</key>
 				<integer>0</integer>
 				<key>waitingsubtext</key>
-				<string>Search 6,030+ brand SVGs</string>
+				<string>Search 6,500+ brand SVGs</string>
 				<key>withspace</key>
 				<true/>
 			</dict>

--- a/extensions/alfred/thesvg_search.py
+++ b/extensions/alfred/thesvg_search.py
@@ -225,7 +225,7 @@ def main() -> None:
                     "title": "No icons found",
                     "subtitle": (
                         f'No results for "{query}"' if query
-                        else "Type to search 6,030+ brand icons"
+                        else "Type to search 6,500+ brand icons"
                     ),
                     "arg": "",
                     "valid": False,

--- a/extensions/browser/README.md
+++ b/extensions/browser/README.md
@@ -1,6 +1,6 @@
 # theSVG browser extension
 
-Search 6,030+ brand SVGs from a popup in Chrome, Firefox, or Edge. Copy raw SVG, the jsDelivr CDN URL, or markdown image syntax.
+Search 6,500+ brand SVGs from a popup in Chrome, Firefox, or Edge. Copy raw SVG, the jsDelivr CDN URL, or markdown image syntax.
 
 Manifest V3. No telemetry. Only `cdn.jsdelivr.net` host permission.
 

--- a/extensions/browser/SCREENSHOTS.md
+++ b/extensions/browser/SCREENSHOTS.md
@@ -59,7 +59,7 @@
 **Filename:** `screenshot-04-browse.png`
 **Dimensions:** 1280x800
 **Capture:** Open the popup with no search query typed. Show the default browse/recent view or the full icon grid scrolled to show multiple brands.
-**Purpose:** Establishes scope (6,030+ icons visible as a grid) and initial UX.
+**Purpose:** Establishes scope (6,500+ icons visible as a grid) and initial UX.
 
 ---
 

--- a/extensions/browser/STORE_LISTING.md
+++ b/extensions/browser/STORE_LISTING.md
@@ -4,13 +4,13 @@
 
 ### Chrome Web Store (132 chars max)
 ```
-Search and copy 6,030+ brand SVGs instantly. Get SVG code, CDN URL, or markdown — no account needed.
+Search and copy 6,500+ brand SVGs instantly. Get SVG code, CDN URL, or markdown — no account needed.
 ```
 (101 chars)
 
 ### Firefox AMO (250 chars max)
 ```
-thesvg puts 6,030+ open brand SVGs one click away. Search any brand, preview variants, and copy the SVG code, jsDelivr CDN URL, or ready-to-paste markdown — all offline-capable, no account required.
+thesvg puts 6,500+ open brand SVGs one click away. Search any brand, preview variants, and copy the SVG code, jsDelivr CDN URL, or ready-to-paste markdown — all offline-capable, no account required.
 ```
 (199 chars)
 
@@ -20,7 +20,7 @@ thesvg puts 6,030+ open brand SVGs one click away. Search any brand, preview var
 
 ### Version for Chrome Web Store and Edge Add-ons
 
-thesvg is the open SVG brand library. Over 6,030 brand icons, all MIT-licensed, all one click away from wherever you are on the web.
+thesvg is the open SVG brand library. Over 6,500 brand icons, all MIT-licensed, all one click away from wherever you are on the web.
 
 **Search as you type.** Open the popup, start typing a brand name, and results appear instantly using a local Fuse.js index. No server round trips, no rate limits, no sign-in.
 
@@ -39,7 +39,7 @@ Built on the same open dataset powering thesvg.org. The full library is MIT-lice
 
 ### Version for Firefox AMO
 
-thesvg is the open SVG brand library. Over 6,030 brand icons, all MIT-licensed, all one click away from wherever you are on the web.
+thesvg is the open SVG brand library. Over 6,500 brand icons, all MIT-licensed, all one click away from wherever you are on the web.
 
 **Search as you type.** Open the popup, start typing a brand name, and results appear instantly using a local Fuse.js index. No server round trips, no rate limits, no sign-in.
 
@@ -119,4 +119,4 @@ Chrome requires a single-sentence justification for each requested permission wh
 > The extension's core feature is letting users copy SVG code, CDN URLs, and markdown snippets to their clipboard with a single click. Without this permission the copy buttons cannot function.
 
 ### `host_permissions: https://cdn.jsdelivr.net/*`
-> SVG files are fetched on demand from the jsDelivr public CDN when a user previews or copies an icon. The full icon registry (6,030+ icons) is not bundled in the extension to keep the download size small. Only the specific icon the user selects is fetched, using the standard public jsDelivr URL format.
+> SVG files are fetched on demand from the jsDelivr public CDN when a user previews or copies an icon. The full icon registry (6,500+ icons) is not bundled in the extension to keep the download size small. Only the specific icon the user selects is fetched, using the standard public jsDelivr URL format.

--- a/extensions/browser/entrypoints/popup/App.tsx
+++ b/extensions/browser/entrypoints/popup/App.tsx
@@ -168,7 +168,7 @@ export default function App() {
           autoFocus
           type="text"
           className="search-input"
-          placeholder="Search 6,030+ brand SVGs"
+          placeholder="Search 6,500+ brand SVGs"
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thesvg-browser-extension",
   "version": "0.1.0",
-  "description": "Search 6,030+ brand SVGs. Copy SVG, CDN URL, or markdown.",
+  "description": "Search 6,500+ brand SVGs. Copy SVG, CDN URL, or markdown.",
   "private": true,
   "scripts": {
     "dev": "wxt",

--- a/extensions/browser/wxt.config.ts
+++ b/extensions/browser/wxt.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   browser: "chrome",
   manifest: {
     name: "theSVG",
-    description: "Search 6,030+ brand SVGs. Copy SVG, CDN URL, or markdown.",
+    description: "Search 6,500+ brand SVGs. Copy SVG, CDN URL, or markdown.",
     version: "0.1.0",
     permissions: ["storage", "clipboardWrite"],
     host_permissions: ["https://cdn.jsdelivr.net/*"],

--- a/extensions/figma/README.md
+++ b/extensions/figma/README.md
@@ -1,10 +1,10 @@
 # theSVG for Figma
 
-Browse and insert 6,000+ brand SVG logos directly into your Figma designs.
+Browse and insert 6,500+ brand SVG logos directly into your Figma designs.
 
 ## Features
 
-- Search across 6,000+ brand icons
+- Search across 6,500+ brand icons
 - Filter by category (AI, Analytics, Browser, CMS, etc.)
 - One-click insert as editable vector nodes
 - Variant picker for icons with light, dark, mono, or color versions (hover an icon, click the number badge in the corner)

--- a/extensions/figma/STORE_LISTING.md
+++ b/extensions/figma/STORE_LISTING.md
@@ -8,11 +8,11 @@ Keep this file in sync when the catalog grows or features change.
 ## Description
 
 ```
-Browse and insert 6,000+ brand SVG logos directly into your Figma designs.
+Browse and insert 6,500+ brand SVG logos directly into your Figma designs.
 One click and the mark drops in as an editable vector node.
 
 What's in the catalog:
-- 6,000+ brand icons across finance, gaming, entertainment, dev tools,
+- 6,500+ brand icons across finance, gaming, entertainment, dev tools,
   consumer goods, telecom, auto, pharma, and more
 - Multiple variants per brand where available: color, monochrome, light,
   dark, wordmark
@@ -40,7 +40,7 @@ Website: https://thesvg.org
 ## Tagline (one-liner)
 
 ```
-Search, preview, and insert from 6,000+ brand SVG logos.
+Search, preview, and insert from 6,500+ brand SVG logos.
 ```
 
 ---

--- a/extensions/figma/package.json
+++ b/extensions/figma/package.json
@@ -2,7 +2,7 @@
   "name": "thesvg-figma",
   "version": "1.2.0",
   "private": true,
-  "description": "Browse and insert 6,000+ brand SVG logos from theSVG into your Figma designs",
+  "description": "Browse and insert 6,500+ brand SVG logos from theSVG into your Figma designs",
   "scripts": {
     "build": "node esbuild.config.mjs",
     "dev": "node esbuild.config.mjs --watch"

--- a/extensions/figma/src/ui.html
+++ b/extensions/figma/src/ui.html
@@ -383,7 +383,7 @@
           id="search"
           class="search-input"
           type="text"
-          placeholder="Search 6,000+ brand icons..."
+          placeholder="Search 6,500+ brand icons..."
           autofocus
         />
         <select id="category" class="category-select">

--- a/extensions/neovim/README.md
+++ b/extensions/neovim/README.md
@@ -2,7 +2,7 @@
 
 Neovim plugin for [theSVG](https://thesvg.org) -- The Open SVG Brand Library.
 
-Search 6,030+ brand SVGs from a Telescope picker (or `vim.ui.select` fallback) and either
+Search 6,500+ brand SVGs from a Telescope picker (or `vim.ui.select` fallback) and either
 insert the CDN URL or inline SVG content at the cursor.
 
 ## Requirements

--- a/extensions/raycast/README.md
+++ b/extensions/raycast/README.md
@@ -1,6 +1,6 @@
 # theSVG for Raycast
 
-Search, preview, and copy 6,030+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
+Search, preview, and copy 6,500+ brand SVG icons from [thesvg.org](https://thesvg.org) directly in Raycast.
 
 ## Commands
 
@@ -34,7 +34,7 @@ Example: `Copy Brand Icon` > `github` copies the GitHub SVG to your clipboard.
 
 ## Features
 
-- Search 6,030+ brand icons with alias matching
+- Search 6,500+ brand icons with alias matching
 - Filter by 100+ categories (AI, Design, DevTool, Cloud, etc.)
 - Preview icon thumbnails in the list
 - View all available variants (up to 7 per icon)

--- a/extensions/raycast/package.json
+++ b/extensions/raycast/package.json
@@ -2,7 +2,7 @@
   "$schema": "https://www.raycast.com/schemas/extension.json",
   "name": "thesvg",
   "title": "TheSVG",
-  "description": "Search, preview, and copy 6,030+ brand SVG icons from thesvg.org",
+  "description": "Search, preview, and copy 6,500+ brand SVG icons from thesvg.org",
   "icon": "extension-icon.png",
   "author": "thegdsks",
   "categories": ["Design Tools", "Developer Tools"],
@@ -12,7 +12,7 @@
       "name": "search-icons",
       "title": "Search Brand Icons",
       "subtitle": "theSVG",
-      "description": "Search 6,030+ brand SVG icons. Copy SVG, download, or open in browser.",
+      "description": "Search 6,500+ brand SVG icons. Copy SVG, download, or open in browser.",
       "mode": "view"
     },
     {

--- a/extensions/raycast/src/search-icons.tsx
+++ b/extensions/raycast/src/search-icons.tsx
@@ -46,7 +46,7 @@ export default function SearchIcons() {
       isLoading={isLoading}
       searchText={searchText}
       onSearchTextChange={setSearchText}
-      searchBarPlaceholder="Search 6,030+ brand icons..."
+      searchBarPlaceholder="Search 6,500+ brand icons..."
       filtering={false}
       searchBarAccessory={
         <List.Dropdown

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,10 +1,10 @@
 # theSVG for VS Code
 
-Search and copy 6,030+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
+Search and copy 6,500+ SVG icons directly from VS Code. Brand logos, AWS, Azure, GCP, and Kubernetes architecture icons.
 
 ## Features
 
-- **Search** across 6,030+ icons from the command palette
+- **Search** across 6,500+ icons from the command palette
 - **Copy SVG** to clipboard with one keystroke
 - **Copy as JSX** for React projects
 - **Copy CDN link** (jsDelivr) for HTML/CSS
@@ -35,7 +35,7 @@ Search and copy 6,030+ SVG icons directly from VS Code. Brand logos, AWS, Azure,
 
 | Collection | Icons |
 |-----------|-------|
-| Brand Icons | 4,037 |
+| Brand Icons | 4,629 |
 | AWS Architecture | 739 |
 | Azure Services | 626 |
 | Google Cloud | 214 |

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thesvg",
   "displayName": "theSVG - SVG Icon Search",
-  "description": "Search and copy 6,030+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
+  "description": "Search and copy 6,500+ SVG icons (brands, AWS, Azure, GCP, Kubernetes) directly from VS Code",
   "version": "0.1.4",
   "publisher": "glincker",
   "license": "MIT",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,13 +1,13 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 <h3 align="center">@thesvg/icons</h3>
 
 <p align="center">
-  4,400+ brand SVG icons for developers. Tree-shakeable, typed, open source.
+  6,500+ brand SVG icons for developers. Tree-shakeable, typed, open source.
   <br />
   <a href="https://thesvg.org"><strong>Browse all icons &rarr;</strong></a>
 </p>
@@ -106,7 +106,7 @@ interface IconModule {
 The package is marked `"sideEffects": false`. Bundlers (webpack, Vite, Rollup, esbuild) will only include icons you import.
 
 ```ts
-// Your bundle only includes the GitHub icon (~3KB), not all 4,400+
+// Your bundle only includes the GitHub icon (~3KB), not all 6,500+
 import github from "@thesvg/icons/github";
 ```
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thesvg/icons",
   "version": "3.2.16",
-  "description": "Tree-shakeable SVG icon components and raw SVG strings from thesvg.org - 4,400+ brand icons",
+  "description": "Tree-shakeable SVG icon components and raw SVG strings from thesvg.org - 6,500+ brand icons",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,12 +1,12 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 # @thesvg/mcp-server
 
-MCP (Model Context Protocol) server for [thesvg.org](https://thesvg.org). Gives AI agents in Claude Desktop, Cursor, Claude Code, and any MCP-aware client direct access to 6,400+ brand SVG icons -- no API key required.
+MCP (Model Context Protocol) server for [thesvg.org](https://thesvg.org). Gives AI agents in Claude Desktop, Cursor, Claude Code, and any MCP-aware client direct access to 6,500+ brand SVG icons -- no API key required.
 
 ## What it does
 
@@ -22,7 +22,7 @@ The server exposes five tools that AI agents can call:
 
 ## Data source
 
-Icons are bundled at build time from the thesvg.org open registry (6,400+ entries). SVG content is fetched on demand from the jsDelivr CDN at `https://cdn.jsdelivr.net/gh/glincker/thesvg@v0.6.0/public/icons/{slug}/{variant}.svg`.
+Icons are bundled at build time from the thesvg.org open registry (6,500+ entries). SVG content is fetched on demand from the jsDelivr CDN at `https://cdn.jsdelivr.net/gh/glincker/thesvg@v0.6.0/public/icons/{slug}/{variant}.svg`.
 
 **Tradeoff**: bundling the registry (~2.8 MB) means the server starts instantly with no network dependency and works offline for search/URL queries. Only `get_icon` requires a network request (to fetch the SVG from jsDelivr). To refresh to a newer registry, rebuild the package.
 
@@ -217,7 +217,7 @@ Discover all icon categories with counts.
 
 **Output** (example):
 ```text
-128 categories across 6115 icons:
+142 categories across 6,502 icons:
 
 - Software - 4,200 icons
 - Platform - 2,100 icons

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thesvg/mcp-server",
   "version": "0.8.0",
-  "description": "MCP server for searching and fetching 6,030+ brand SVGs from thesvg.org",
+  "description": "MCP server for searching and fetching 6,500+ brand SVGs from thesvg.org",
   "type": "module",
   "license": "MIT",
   "author": "thesvg.org",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,12 +1,12 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 # @thesvg/react
 
-Typed React SVG components for all 6,400+ brand icons from [thesvg.org](https://thesvg.org).
+Typed React SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).
 
 - Zero runtime dependencies (React is a peer dep)
 - TypeScript strict mode with full `SVGProps<SVGSVGElement>` support
@@ -214,7 +214,7 @@ Breaking changes:
 
 ## Available icons
 
-Over 6,400 brand icons are available. Browse the full list at
+Over 6,500 brand icons are available. Browse the full list at
 [thesvg.org](https://thesvg.org).
 
 ## License

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thesvg/react",
   "version": "3.2.16",
-  "description": "Typed React SVG components for all 3,800+ brand icons from thesvg.org",
+  "description": "Typed React SVG components for all 6,500+ brand icons from thesvg.org",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,12 +1,12 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 # @thesvg/svelte
 
-Typed Svelte SVG components for all 6,400+ brand icons from [thesvg.org](https://thesvg.org).
+Typed Svelte SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).
 
 - Zero runtime dependencies (Svelte is a peer dep)
 - TypeScript support with full `SVGAttributes` types
@@ -125,7 +125,7 @@ For maximum control, use individual icon imports:
 
 ## Available icons
 
-Over 6,400 brand icons are available. Browse the full list at
+Over 6,500 brand icons are available. Browse the full list at
 [thesvg.org](https://thesvg.org).
 
 ## License

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -1,13 +1,13 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 <h3 align="center">theSVG</h3>
 
 <p align="center">
-  6,400+ brand SVG icons for developers. Tree-shakeable, typed, open source.
+  6,500+ brand SVG icons for developers. Tree-shakeable, typed, open source.
   <br />
   <a href="https://thesvg.org"><strong>Browse all icons &rarr;</strong></a>
 </p>
@@ -21,7 +21,7 @@
 
 ---
 
-This is the convenience package for [`@thesvg/icons`](https://www.npmjs.com/package/@thesvg/icons). Both packages contain the same 6,400+ icons.
+This is the convenience package for [`@thesvg/icons`](https://www.npmjs.com/package/@thesvg/icons). Both packages contain the same 6,500+ icons.
 
 ## Install
 

--- a/packages/thesvg/package.json
+++ b/packages/thesvg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thesvg",
   "version": "3.2.16",
-  "description": "3,800+ brand SVG icons - tree-shakeable, typed, dual ESM/CJS. The one-stop brand icon library.",
+  "description": "6,500+ brand SVG icons - tree-shakeable, typed, dual ESM/CJS. The one-stop brand icon library.",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,12 +1,12 @@
 <p align="center">
   <a href="https://github.com/glincker/thesvg">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,400+ Brand SVG Icons" width="700" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
   </a>
 </p>
 
 # @thesvg/vue
 
-Typed Vue 3 SVG components for all 6,400+ brand icons from [thesvg.org](https://thesvg.org).
+Typed Vue 3 SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).
 
 - Zero runtime dependencies (Vue is a peer dep)
 - TypeScript strict mode - full `SVGAttributes` support
@@ -128,7 +128,7 @@ import Github from "@thesvg/vue/github";
 
 ## Available icons
 
-Over 6,400 brand icons are available. Browse the full list at
+Over 6,500 brand icons are available. Browse the full list at
 [thesvg.org](https://thesvg.org).
 
 ## License

--- a/skills/thesvg/SKILL.md
+++ b/skills/thesvg/SKILL.md
@@ -6,7 +6,7 @@ license: MIT
 
 # theSVG agent skill
 
-Use this skill whenever the user asks for a brand logo, service icon, framework mark, or cloud service icon. theSVG hosts 6,030+ brand SVGs and cloud architecture icons under one consistent URL pattern, so you do not need to scrape the web or guess at file paths.
+Use this skill whenever the user asks for a brand logo, service icon, framework mark, or cloud service icon. theSVG hosts 6,500+ brand SVGs and cloud architecture icons under one consistent URL pattern, so you do not need to scrape the web or guess at file paths.
 
 ## When to use this skill
 

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -13,7 +13,7 @@ import { categoryUrl } from "@/lib/categories";
 export const metadata: Metadata = {
   title: "Browse All Categories",
   description:
-    "Explore all icon categories on theSVG. Browse 6,400+ brand, AWS, Azure, and GCP SVG icons organized by category.",
+    "Explore all icon categories on theSVG. Browse 6,500+ brand, AWS, Azure, and GCP SVG icons organized by category.",
   keywords: [
     "SVG icon categories",
     "brand icon categories",

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -23,7 +23,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Best SVG Icon Library 2026: theSVG vs Simple Icons, svgl, Lucide, Font Awesome, Iconify",
   description:
-    "Updated 2026 comparison of the largest brand SVG icon libraries. theSVG ships 6,400+ brand icons, cloud icons (AWS/Azure/GCP), the Google 2026 refresh, Figma, VS Code, Raycast, Alfred, MCP, and skills.sh agent skill. Compare features side by side.",
+    "Updated 2026 comparison of the largest brand SVG icon libraries. theSVG ships 6,500+ brand icons, cloud icons (AWS/Azure/GCP), the Google 2026 refresh, Figma, VS Code, Raycast, Alfred, MCP, and skills.sh agent skill. Compare features side by side.",
   keywords: [
     "best SVG icon library 2026",
     "largest open SVG brand library",
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Best SVG Icon Library 2026 - theSVG vs Simple Icons, svgl, Lucide, Font Awesome, Iconify",
     description:
-      "Updated 2026 comparison of brand SVG icon libraries. theSVG ships 6,400+ icons with Figma, VS Code, Raycast, Alfred, MCP, and skills.sh agent skill.",
+      "Updated 2026 comparison of brand SVG icon libraries. theSVG ships 6,500+ icons with Figma, VS Code, Raycast, Alfred, MCP, and skills.sh agent skill.",
     siteName: "theSVG",
   },
   alternates: {
@@ -87,7 +87,7 @@ interface LibInfo {
 const LIBRARIES: LibInfo[] = [
   {
     name: "theSVG",
-    icons: "6,400+",
+    icons: "6,500+",
     focus: "Brand logos + Cloud icons",
     desc: "Largest open brand SVG library with multi-variant support (color, dark, light, wordmark, mono). Includes AWS, Azure, GCP cloud icons and the Google 2026 gradient refresh. Full toolchain: Figma, VS Code, Raycast, Alfred, npm, React/Vue/Svelte, CLI, REST API, MCP server, skills.sh agent skill.",
     highlight: true,
@@ -250,7 +250,7 @@ export default function ComparePage() {
                   {iconCount.toLocaleString()} brand icons in three months
                 </h2>
                 <p className="mt-1.5 max-w-2xl text-xs leading-relaxed text-muted-foreground sm:text-sm">
-                  thesvg launched March 2026 and crossed 6,400 curated brand SVGs by June. The largest open brand SVG library available today, by count and by feature coverage.
+                  thesvg launched March 2026 and crossed 6,500 curated brand SVGs by August. The largest open brand SVG library available today, by count and by feature coverage.
                 </p>
               </div>
               <Link

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -21,7 +21,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Extensions & Integrations - Figma, VS Code, React, CLI",
   description:
-    "Use 6,400+ free SVG icons in Figma, VS Code, Raycast, React, Vue, CLI, and more. Official Figma plugin, npm packages, MCP server, and CDN.",
+    "Use 6,500+ free SVG icons in Figma, VS Code, Raycast, React, Vue, CLI, and more. Official Figma plugin, npm packages, MCP server, and CDN.",
   keywords: [
     "Figma brand icons plugin",
     "SVG icon Figma plugin",
@@ -274,7 +274,7 @@ const CATEGORIES: Category[] = [
     items: [
       {
         name: "Browser Extension",
-        description: "Chrome, Firefox, Edge popup. Search 6,400+ brand SVGs, copy SVG, CDN URL, or markdown. MV3, no telemetry.",
+        description: "Chrome, Firefox, Edge popup. Search 6,500+ brand SVGs, copy SVG, CDN URL, or markdown. MV3, no telemetry.",
         status: "coming-soon",
         cta: "View source",
         href: "https://github.com/glincker/thesvg/tree/main/extensions/browser",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -7,7 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "thesvg - Open SVG Brand Library",
     short_name: "thesvg",
-    description: "Search, copy, and ship 6,400+ brand SVG icons.",
+    description: "Search, copy, and ship 6,500+ brand SVG icons.",
     start_url: "/",
     scope: "/",
     display: "standalone",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
         This icon might have been moved, renamed, or doesn&apos;t exist yet.
       </p>
       <p className="mb-8 max-w-md text-xs text-muted-foreground/60">
-        We have 6,400+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
+        We have 6,500+ icons across brands, AWS, Azure, and GCP. Try searching for what you need.
       </p>
 
       {/* Actions */}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,7 +14,7 @@ const CDN_BASE =
 // output: "export" on GitHub Pages (the sharded files end up at
 // /sitemap/N.xml and the index is missing), so robots.txt-discovery breaks.
 // One sitemap fits comfortably under the 50,000-URL and 50MB Google limits
-// for our ~6,100 icons + the static pages.
+// for our ~6,500 icons + the static pages.
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const icons = getAllIcons();

--- a/src/components/help-fab.tsx
+++ b/src/components/help-fab.tsx
@@ -28,7 +28,7 @@ const TIPS = [
   {
     icon: Search,
     title: "Search everything",
-    description: "Press Cmd+K to search across 6,400+ icons",
+    description: "Press Cmd+K to search across 6,500+ icons",
     gradient: "from-orange-500 to-amber-500",
     glow: "shadow-orange-500/25",
   },

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -91,7 +91,7 @@ const ALL_SLIDES = [
   {
     badge: "Open Source",
     badgeIcon: Sparkles,
-    title: "6,400+ SVG Icons. Search. Copy. Ship.",
+    title: "6,500+ SVG Icons. Search. Copy. Ship.",
     description: "Search, copy, and ship brand icons in seconds. Free, open-source, and community-driven.",
     cta: { label: "Get Started", href: "/extensions" },
     ctaSecondary: { label: "Submit an Icon", href: "/submit" },


### PR DESCRIPTION
We just crossed 6,500 icons (6,502 exact as of this PR). Sweeps every stale count reference repo-wide:

| Metric | Old (stale) | New |
|---|---|---|
| Total icons | 6,400+ / 6,030+ / 6,000+ | 6,500+ |
| Brand-only icons | 4,400+ / 4,487 / 4,037 | 4,629 (4,600+) |
| SVG variants | 8,400+ | 12,300+ |
| Categories | 55+ | 140+ (computed the same way `/categories` does: distinct brand + AWS category strings) |

Updated: README.md, LEGAL.md, SPONSORS.md, composer.json, `skills/thesvg/SKILL.md`, all `packages/*/README.md` and `package.json` descriptions, all `extensions/*` READMEs/store listings/manifests, and site copy in `src/app` and `src/components`.

Not touched: `CHANGELOG.md` files and `src/data/posts.json` blog post bodies, both are historical records of counts at the time they were written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated catalog messaging across the website, packages, integrations, and extensions to reflect 6,500+ brand SVG icons.
  * Refreshed related category, variant, collection, and brand coverage figures.
  * Updated search prompts, descriptions, metadata, badges, and promotional copy for consistency.
  * Revised milestone information, including the anticipated milestone timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->