### PR TITLE
docs: market theSVG's inclusion in Iconify

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   <a href="https://www.figma.com/community/plugin/1612997159050367763"><img src="https://img.shields.io/badge/Figma-Plugin-F24E1E?style=flat-square&logo=figma&logoColor=white" alt="Figma" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/badge/VS%20Code-Extension-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white" alt="VS Code" /></a>
   <a href="https://www.raycast.com/thegdsks/thesvg"><img src="https://img.shields.io/badge/Raycast-Store-FF6363?style=flat-square&logo=raycast" alt="Raycast" /></a>
+  <a href="https://icon-sets.iconify.design/thesvg-color/"><img src="https://img.shields.io/badge/Iconify-2%20sets-026C9C?style=flat-square" alt="Iconify" /></a>
   <a href="https://github.com/glincker/thesvg/tree/main/extensions/neovim"><img src="https://img.shields.io/badge/Neovim-Plugin-019733?style=flat-square&logo=neovim&logoColor=white" alt="Neovim" /></a>
   <a href="https://github.com/glincker/thesvg/tree/main/extensions/alfred"><img src="https://img.shields.io/badge/Alfred-Workflow-5C1F87?style=flat-square&logo=alfred&logoColor=white" alt="Alfred" /></a>
   <a href="https://github.com/glincker/thesvg/tree/main/extensions/browser"><img src="https://img.shields.io/badge/Chrome-Coming%20Soon-4285F4?style=flat-square&logo=googlechrome&logoColor=white" alt="Chrome" /></a>
@@ -135,6 +136,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 | [`@thesvg/cli`](https://www.npmjs.com/package/@thesvg/cli) | Published | shadcn-style installer. `npx @thesvg/cli add github` drops the SVG into your project. |
 | [Homebrew](https://github.com/glincker/homebrew-thesvg) | Published | `brew tap glincker/thesvg && brew install thesvg` |
 | [CDN via jsDelivr](https://www.jsdelivr.com/package/gh/glincker/thesvg) | Published | Serve any icon via global CDN. Drop into HTML, CSS, Markdown, Notion, Webflow, Framer. |
+| [Iconify](https://icon-sets.iconify.design/thesvg-color/) | Published | Brand icons available as [`thesvg`](https://icon-sets.iconify.design/thesvg/) (mono) and [`thesvg-color`](https://icon-sets.iconify.design/thesvg-color/) sets. Works with any Iconify-consuming tool: Mermaid architecture diagrams, Iconify's VS Code and Figma plugins, `@iconify/react`, and more. |
 | [Browser Extension](https://github.com/glincker/thesvg/tree/main/extensions/browser) | Beta | Chrome, Firefox, Edge popup with 6,500+ brand SVGs. MV3, no telemetry. |
 | [JetBrains](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | IntelliJ, WebStorm, PyCharm, Rider tool window. Help wanted. |
 | [Neovim](https://github.com/glincker/thesvg/tree/main/extensions/neovim) | Published | Lua plugin with Telescope picker. Insert SVG URL or inline content at cursor. |

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -23,7 +23,7 @@ import { SidebarShell } from "@/components/layout/sidebar-shell";
 export const metadata: Metadata = {
   title: "Best SVG Icon Library 2026: theSVG vs Simple Icons, svgl, Lucide, Font Awesome, Iconify",
   description:
-    "Updated 2026 comparison of the largest brand SVG icon libraries. theSVG ships 6,500+ brand icons, cloud icons (AWS/Azure/GCP), the Google 2026 refresh, Figma, VS Code, Raycast, Alfred, MCP, and skills.sh agent skill. Compare features side by side.",
+    "Updated 2026 comparison of the largest brand SVG icon libraries. theSVG ships 6,500+ brand icons, cloud icons (AWS/Azure/GCP), the Google 2026 refresh, Figma, VS Code, Raycast, Alfred, MCP, Iconify, and skills.sh agent skill. Compare features side by side.",
   keywords: [
     "best SVG icon library 2026",
     "largest open SVG brand library",
@@ -89,7 +89,7 @@ const LIBRARIES: LibInfo[] = [
     name: "theSVG",
     icons: "6,500+",
     focus: "Brand logos + Cloud icons",
-    desc: "Largest open brand SVG library with multi-variant support (color, dark, light, wordmark, mono). Includes AWS, Azure, GCP cloud icons and the Google 2026 gradient refresh. Full toolchain: Figma, VS Code, Raycast, Alfred, npm, React/Vue/Svelte, CLI, REST API, MCP server, skills.sh agent skill.",
+    desc: "Largest open brand SVG library with multi-variant support (color, dark, light, wordmark, mono). Includes AWS, Azure, GCP cloud icons and the Google 2026 gradient refresh. Full toolchain: Figma, VS Code, Raycast, Alfred, npm, React/Vue/Svelte, CLI, REST API, MCP server, Iconify, skills.sh agent skill.",
     highlight: true,
   },
   {
@@ -368,7 +368,7 @@ export default function ComparePage() {
                   theSVG
                 </h3>
                 <p className="text-[11px] leading-relaxed text-muted-foreground">
-                  Need brand logos with color, dark, light, wordmark, and mono variants. Want Figma, VS Code, Raycast, Alfred, CLI, REST API, MCP server, or a skills.sh agent skill. Building with any framework.
+                  Need brand logos with color, dark, light, wordmark, and mono variants. Want Figma, VS Code, Raycast, Alfred, CLI, REST API, MCP server, Iconify, or a skills.sh agent skill. Building with any framework.
                 </p>
               </div>
               <div className="rounded-xl border border-border/40 p-4 dark:border-white/[0.06]">

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -209,6 +209,14 @@ const CATEGORIES: Category[] = [
         iconSlug: "jsdelivr",
       },
       {
+        name: "Iconify",
+        description: "Brand icons as thesvg (mono) and thesvg-color sets. Works in Mermaid diagrams, Iconify's Figma and VS Code plugins, and @iconify/react.",
+        status: "available",
+        cta: "Browse sets",
+        href: "https://icon-sets.iconify.design/thesvg-color/",
+        iconSlug: "iconify",
+      },
+      {
         name: "Homebrew",
         description: "Install the thesvg CLI via Homebrew. brew tap glincker/thesvg && brew install thesvg.",
         status: "available",


### PR DESCRIPTION
Both the mono (\`thesvg\`) and color (\`thesvg-color\`) brand icon sets were added to Iconify's collection registry this week (iconify/icon-sets#293). Adds:

- A README badge (top badge row) linking to https://icon-sets.iconify.design/thesvg-color/
- A row in the README extensions table and the site's /extensions page, explaining what it unlocks (Mermaid diagrams, Iconify's own Figma/VS Code plugins, `@iconify/react`, etc.)
- Mentions in the /compare page's integration lists (meta description, OG description, and the theSVG summary card)

Azure and Kubernetes sets are still pending on Iconify's side, will follow up with another mention once those land too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Iconify integration support for theSVG’s mono and color icon sets.
  - Added Iconify to the available developer tools and usage recommendations.
  - Documented supported Iconify integrations and usage contexts.

- **Documentation**
  - Updated comparison-page descriptions and metadata to highlight Iconify support.
  - Added README badges and an Extensions entry for Iconify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->