### PR TITLE
fix: remove deprecated experimental.viewTransition next.config option

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,9 +5,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  experimental: {
-    viewTransition: true,
-  },
   skipTrailingSlashRedirect: true,
 };
 


### PR DESCRIPTION
The last \"Deploy to GitHub Pages\" run failed after the Next.js 16.3.0 dependabot bump (#876):

\`\`\`
⚠ Unrecognized key(s) in object: 'viewTransition' at "experimental"
next.config.ts(9,5): error TS2353: Object literal may only specify known properties, and 'viewTransition' does not exist in type 'ExperimentalConfig'.
Failed to type check.
\`\`\`

Next 16.3.0 removed `experimental.viewTransition` from `ExperimentalConfig`. This is why it slipped through the regular PR CI: the main "Lint & Build" check doesn't run a strict `tsc` pass the way the Pages deploy build step does, so PR #876 showed all green while this was actually broken.

Grepped the codebase, nothing references `ViewTransition`/`viewTransition` anywhere, it was an unused flag. Removed it outright. Verified locally: `pnpm run build` and `pnpm run lint` both pass clean against the actual installed Next 16.3.0 (my previous local checks were stale against a cached 16.2.12 install, hence not catching this at the time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the experimental view transition setting to improve application stability.
  * All other Next.js configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->