### PR TITLE
feat: add @thesvg/react-native package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "fixed": [],
   "linked": [
-    ["@thesvg/icons", "thesvg", "@thesvg/react", "@thesvg/vue", "@thesvg/svelte"]
+    ["@thesvg/icons", "thesvg", "@thesvg/react", "@thesvg/vue", "@thesvg/svelte", "@thesvg/react-native"]
   ],
   "access": "public",
   "baseBranch": "main",

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,0 +1,190 @@
+<p align="center">
+  <a href="https://github.com/glincker/thesvg">
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ Brand SVG Icons" width="700" />
+  </a>
+</p>
+
+# @thesvg/react-native
+
+Typed React Native SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).
+
+- Renders via [`react-native-svg`](https://github.com/software-mansion/react-native-svg) (peer dependency)
+- Works in **Expo Go** with no config plugin and no native setup
+- Data-driven icons: each icon is a small render-tree, shared by one runtime component (not one generated component per icon), so bundle size scales with icon count, not with duplicated render logic
+- TypeScript strict mode with typed per-icon `variant` props
+- `forwardRef` on every component
+- Tree-shakeable ESM, plus individual per-icon subpath imports for bundlers that don't tree-shake
+
+## Installation
+
+```bash
+npm install @thesvg/react-native react-native-svg
+```
+
+```bash
+pnpm add @thesvg/react-native react-native-svg
+```
+
+```bash
+yarn add @thesvg/react-native react-native-svg
+```
+
+`react-native-svg` is required as a peer dependency. It works in Expo Go
+without a config plugin or any native/autolinking setup, and as a Turbo
+Module in bare React Native apps.
+
+## Usage
+
+### Named import from barrel (convenient, relies on tree-shaking)
+
+```tsx
+import { Github, VisualStudioCode, Figma } from '@thesvg/react-native';
+
+export function MyComponent() {
+  return (
+    <>
+      <Github size={24} />
+      <VisualStudioCode size={24} color="#3b82f6" />
+      <Figma size={32} />
+    </>
+  );
+}
+```
+
+### Individual icon import (best for bundle size)
+
+```tsx
+import Github from '@thesvg/react-native/icons/github';
+import VisualStudioCode from '@thesvg/react-native/icons/visual-studio-code';
+```
+
+Each icon is a separate module (pure render-tree data plus a reference to
+the shared runtime), so bundlers that don't support tree-shaking
+(e.g. CommonJS/Metro without tree-shaking) still only ship the icons you
+import.
+
+### Selecting a variant
+
+Many brands ship more than one mark (a monochrome version, a wordmark, a
+light/dark optimized variant). Pass the `variant` prop to choose one. It
+defaults to `"default"`, so existing usage is unchanged:
+
+```tsx
+import { Github } from '@thesvg/react-native';
+
+<Github />                    {/* default mark */}
+<Github variant="mono" />     {/* monochrome */}
+<Github variant="wordmark" /> {/* text logo */}
+```
+
+The accepted variant names are typed per icon, so your editor autocompletes
+only the variants that icon actually has, and an unknown variant is a type
+error. At runtime an unrecognized variant safely falls back to `"default"`.
+
+### With Expo
+
+No config plugin, no `expo prebuild` step, no native module linking. Works
+in Expo Go out of the box because `react-native-svg` ships a Turbo Module
+that Expo Go already includes:
+
+```tsx
+import { Github, Figma } from '@thesvg/react-native';
+
+export default function Screen() {
+  return (
+    <View style={{ flexDirection: 'row', gap: 16 }}>
+      <Github size={28} />
+      <Figma size={28} />
+    </View>
+  );
+}
+```
+
+## Props
+
+Every component accepts `react-native-svg`'s `SvgProps`, plus two shorthands:
+
+| Prop        | Type               | Default              | Description                                          |
+| ----------- | ------------------ | --------------------- | ----------------------------------------------------- |
+| `size`      | `number \| string` | `24`                   | Shorthand for both `width` and `height`                |
+| `color`     | `string`            | -                      | Shorthand that sets both `fill` and `stroke`           |
+| `width`     | `number \| string` | `size`, else `24`      | Overrides `size` for width only                        |
+| `height`    | `number \| string` | `size`, else `24`      | Overrides `size` for height only                       |
+| `fill`      | `string`            | from source SVG        | Overrides `color` for fill only                        |
+| `stroke`    | `string`            | from source SVG        | Overrides `color` for stroke only                      |
+| `variant`   | `string`            | `"default"`             | Which icon variant to render (per-icon typed union)    |
+| `ref`       | `Ref<Svg>`          | -                      | Forwarded ref to the underlying `react-native-svg` root |
+| ...         | ...                 | -                      | Any other `SvgProps` from `react-native-svg`            |
+
+```tsx
+// Fixed size
+<Github size={24} />
+
+// Explicit width/height
+<Github width={32} height={24} />
+
+// Recolor via the color shorthand
+<Github color="#3b82f6" />
+
+// Fine-grained control
+<Github fill="#3b82f6" stroke="#1d4ed8" strokeWidth={0.5} />
+```
+
+## Component names
+
+Slugs are converted to PascalCase component names:
+
+| Slug                  | Component name         |
+| ---------------------- | ----------------------- |
+| `github`                | `Github`                  |
+| `visual-studio-code`    | `VisualStudioCode`        |
+| `figma`                 | `Figma`                   |
+| `01dotai`               | `I01Dotai`                |
+| `dotnet`                | `Dotnet`                  |
+
+Slugs that start with a digit are prefixed with `I` to produce a valid
+JavaScript identifier.
+
+## Architecture
+
+Unlike [`@thesvg/react`](https://www.npmjs.com/package/@thesvg/react), which
+generates one self-contained inline component per icon, this package follows
+the same pattern as [`lucide-react-native`](https://github.com/lucide-icons/lucide):
+
+- Each icon compiles to a small data tree of `[tagName, props, children]`
+  tuples extracted from its SVG.
+- A single shared runtime (`createIcon`, exported from `@thesvg/react-native/createIcon`)
+  resolves each tag name against `react-native-svg`'s exports (`Path`,
+  `Circle`, `G`, `Defs`, `LinearGradient`, ...) and renders it.
+
+This keeps per-icon modules to just data, so bundle size scales with icon
+count instead of with duplicated render logic across 6,500+ files.
+
+Supported SVG elements: `path`, `circle`, `rect`, `ellipse`, `line`,
+`polygon`, `polyline`, `g`, `defs`, `linearGradient`, `radialGradient`,
+`stop`, `clipPath`, `mask`, `use`, `text`, `tspan`. Elements with no
+`react-native-svg` equivalent (`filter` and its primitives, `style`,
+`title`, `desc`, `script`) are stripped at build time; any other unsupported
+wrapper element has its children kept and only the wrapper itself dropped,
+so visual content is never silently lost.
+
+## Compatibility
+
+| Environment       | Version | Status    |
+| ------------------ | ------- | --------- |
+| React               | 18, 19  | Supported |
+| React Native        | 0.70+   | Supported |
+| Expo (Expo Go)      | SDK 49+ | Supported, no config plugin needed |
+| react-native-svg    | 13+     | Required peer dependency |
+| Node.js             | 18+     | Supported |
+
+## Available icons
+
+Over 6,500 brand icons are available. Browse the full list at
+[thesvg.org](https://thesvg.org).
+
+## License
+
+MIT - see [LICENSE](./LICENSE).
+
+Brand icons and logos are the property of their respective trademark holders. See [thesvg.org](https://thesvg.org) for details.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@thesvg/react-native",
+  "version": "0.1.0",
+  "description": "Typed React Native SVG components for all 6,500+ brand icons from thesvg.org",
+  "type": "module",
+  "sideEffects": false,
+  "license": "MIT",
+  "author": "thesvg.org",
+  "homepage": "https://thesvg.org",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/glincker/thesvg.git",
+    "directory": "packages/react-native"
+  },
+  "bugs": {
+    "url": "https://github.com/glincker/thesvg/issues"
+  },
+  "keywords": [
+    "svg",
+    "icons",
+    "brand",
+    "logos",
+    "react-native",
+    "expo",
+    "components",
+    "tree-shakeable",
+    "esm",
+    "typescript"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./createIcon": {
+      "import": "./dist/createIcon.js",
+      "require": "./dist/createIcon.cjs",
+      "types": "./dist/createIcon.d.ts"
+    },
+    "./icons/*": {
+      "import": "./dist/icons/*.js",
+      "require": "./dist/icons/*.cjs",
+      "types": "./dist/icons/*.d.ts"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsx scripts/build-components.ts",
+    "validate": "tsx scripts/validate-output.ts",
+    "test": "tsx scripts/validate-output.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-native": ">=0.70",
+    "react-native-svg": ">=13"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "react-native": "^0.87.0",
+    "react-native-svg": "^15.15.5",
+    "tsx": "^4.23.10",
+    "typescript": "^6.0.3"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  }
+}

--- a/packages/react-native/scripts/build-components.ts
+++ b/packages/react-native/scripts/build-components.ts
@@ -1,0 +1,916 @@
+/**
+ * build-components.ts
+ *
+ * Generates the @thesvg/react-native distribution from the monorepo source
+ * data. Unlike @thesvg/react (one self-contained inline-JSX component per
+ * icon), this package mirrors the lucide-react-native architecture:
+ *
+ *   - Each icon compiles down to lightweight *data*: a tree of
+ *     [tagName, props, children] tuples extracted from its SVG.
+ *   - A single shared runtime component (`createIcon`, emitted once as
+ *     dist/createIcon.{js,cjs,d.ts}) recursively resolves each tuple's tag
+ *     name against react-native-svg's exports and renders it.
+ *
+ * This keeps per-icon modules tiny (data only, no repeated render logic),
+ * which matters at 6,500+ icons — the React DOM package's one-component-per-
+ * file approach doesn't scale to React Native's bundle/startup constraints.
+ *
+ * Run with:
+ *   bun run scripts/build-components.ts
+ *   tsx  scripts/build-components.ts
+ *
+ * Output layout:
+ *   dist/
+ *     createIcon.js    ESM shared runtime (renders icon data via react-native-svg)
+ *     createIcon.cjs    CJS shared runtime
+ *     createIcon.d.ts   Shared runtime + data types
+ *     icons/
+ *       {slug}.js       ESM icon data module per icon
+ *       {slug}.cjs      CJS icon data module per icon
+ *       {slug}.d.ts     Type declarations per icon
+ *     index.js          ESM barrel (named exports)
+ *     index.cjs         CJS barrel (named exports)
+ *     index.d.ts        Type barrel
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/** Root of the packages/react-native package */
+const PKG_ROOT = resolve(__dirname, "..");
+/** Root of the thesvg monorepo */
+const REPO_ROOT = resolve(PKG_ROOT, "../..");
+const ICONS_JSON = join(REPO_ROOT, "src/data/icons.json");
+const DIST = join(PKG_ROOT, "dist");
+const DIST_ICONS = join(DIST, "icons");
+
+// ---------------------------------------------------------------------------
+// Types mirrored from icons.json shape
+// ---------------------------------------------------------------------------
+
+interface RawIconVariants {
+  default?: string;
+  mono?: string;
+  light?: string;
+  dark?: string;
+  wordmark?: string;
+  wordmarkLight?: string;
+  wordmarkDark?: string;
+  color?: string;
+  [key: string]: string | undefined;
+}
+
+interface RawIcon {
+  slug: string;
+  title: string;
+  aliases: string[];
+  hex: string;
+  categories: string[];
+  variants: RawIconVariants;
+  license: string;
+  url: string;
+  guidelines?: string;
+}
+
+// ---------------------------------------------------------------------------
+// SVG reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read an SVG file given its icons.json-relative public path (e.g.
+ * "/icons/apple-music/wordmark-light.svg"). Returns empty string on miss.
+ *
+ * Variant SVG filenames aren't always the camelCase variant key
+ * (e.g. "wordmarkLight" -> "wordmark-light.svg" on disk), so the path must
+ * come from icons.json rather than being reconstructed from slug + variant.
+ */
+function readSvg(publicPath: string): string {
+  const filePath = join(REPO_ROOT, "public", publicPath.replace(/^\//, ""));
+  if (!existsSync(filePath)) return "";
+  return readFileSync(filePath, "utf8").trim();
+}
+
+/**
+ * Resolve the "primary" SVG for an icon.
+ * Preference order: default -> color -> mono -> light -> dark -> wordmark -> first available.
+ */
+function primarySvg(variants: RawIconVariants): string {
+  const order = ["default", "color", "mono", "light", "dark", "wordmark"];
+  for (const v of order) {
+    const path = variants[v];
+    if (path) {
+      const content = readSvg(path);
+      if (content) return content;
+    }
+  }
+  for (const path of Object.values(variants)) {
+    if (!path) continue;
+    const content = readSvg(path);
+    if (content) return content;
+  }
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// SVG -> render-tree conversion
+// ---------------------------------------------------------------------------
+
+/** Extract the viewBox attribute from an SVG string. Falls back to "0 0 24 24". */
+function extractViewBox(svgContent: string): string {
+  const match = svgContent.match(/viewBox=["']([^"']+)["']/);
+  return match ? match[1] : "0 0 24 24";
+}
+
+interface RootSvgPaint {
+  fill: string;
+  stroke?: string;
+}
+
+/**
+ * Extract root paint attributes from the outer <svg> element. Same rules as
+ * @thesvg/react's extractRootSvgPaint (kept identical so the two packages
+ * render the same default color for the same source SVG):
+ * - Explicit fill (including "none") is preserved as-is.
+ * - No fill + has stroke: "none" (stroke-only icons; fill must not bleed).
+ * - No fill + no stroke: "currentColor" so paths inherit the icon's `color` prop.
+ */
+function extractRootSvgPaint(svgContent: string): RootSvgPaint {
+  const svgTag = svgContent.match(/<svg[^>]*>/s);
+  if (!svgTag) return { fill: "currentColor" };
+
+  const fillMatch = svgTag[0].match(/\bfill=["']([^"']+)["']/);
+  const strokeMatch = svgTag[0].match(/\bstroke=["']([^"']+)["']/);
+
+  return {
+    fill: fillMatch ? fillMatch[1] : (strokeMatch ? "none" : "currentColor"),
+    stroke: strokeMatch ? strokeMatch[1] : undefined,
+  };
+}
+
+/**
+ * Strip the outer <svg ...>...</svg> wrapper and any XML/HTML constructs that
+ * have no react-native-svg equivalent, returning just the inner markup plus
+ * the extracted viewBox/paint.
+ *
+ * Beyond what @thesvg/react strips, this also removes <title>, <desc>,
+ * <script>, and <filter> blocks: react-native-svg has no CSS engine (so
+ * <style> and class-based styling never applied here either) and no filter
+ * primitives, so shipping them would just be dead weight / dangling
+ * `filter="url(#id)"` references to nothing.
+ */
+function stripToInner(svgContent: string): { inner: string; viewBox: string; fill: string; stroke?: string } {
+  const viewBox = extractViewBox(svgContent);
+  const { fill, stroke } = extractRootSvgPaint(svgContent);
+
+  let inner = svgContent
+    .replace(/^<svg[^>]*>/s, "")
+    .replace(/<\/svg>\s*$/, "")
+    .trim();
+
+  inner = inner.replace(/<\?xml[^?]*\?>/g, ""); // XML prologs
+  inner = inner.replace(/<!DOCTYPE[^>]*>/gi, ""); // DOCTYPE declarations
+  inner = inner.replace(/<!--[\s\S]*?-->/g, ""); // HTML/XML comments
+  inner = inner.replace(/<sodipodi:[^>]*(?:\/>|>[\s\S]*?<\/sodipodi:[^>]+>)/g, "");
+  // Self-closing forms (<metadata/>, <style/>) first, so the block-form regexes
+  // below don't need to worry about matching across an unrelated self-closed tag.
+  inner = inner.replace(/<(metadata|style|title|desc|filter)[^>]*\/>/gi, "");
+  inner = inner.replace(/<metadata[\s\S]*?<\/metadata>/g, "");
+  inner = inner.replace(/<style[\s\S]*?<\/style>/g, ""); // no CSS engine in react-native-svg
+  inner = inner.replace(/<title[\s\S]*?<\/title>/gi, ""); // no visual/DOM equivalent
+  inner = inner.replace(/<desc[\s\S]*?<\/desc>/gi, "");
+  inner = inner.replace(/<script[\s\S]*?<\/script>/gi, "");
+  inner = inner.replace(/<filter[\s\S]*?<\/filter>/gi, ""); // no filter primitive support
+  inner = inner.replace(/<(rdf|dc|cc):[^>]*(?:\/>|>[\s\S]*?<\/\1:[^>]+>)/g, "");
+
+  // Unwrap nested <svg> wrappers from Inkscape exports (keep their children)
+  inner = inner.replace(/<svg[^>]*>/gs, "");
+  inner = inner.replace(/<\/svg>/g, "");
+
+  return { inner, viewBox, fill, stroke };
+}
+
+/** Convert kebab-case attribute names to camelCase (stroke-width -> strokeWidth). */
+function kebabToCamel(attr: string): string {
+  return attr.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+/**
+ * Parse a CSS declaration string ("fill:#fff;stroke-width:2") into an object
+ * of camelCased presentation-attribute props. react-native-svg components
+ * take these as direct props (fill=, strokeWidth=), not a nested style
+ * object the way DOM SVG can, so — unlike @thesvg/react, which converts
+ * style="..." into a React style object — this merges the declarations
+ * directly onto the element's props, matching inline style's normal
+ * override-everything-else precedence in the CSS cascade.
+ */
+function parseStyleToProps(styleValue: string): Record<string, string> {
+  const props: Record<string, string> = {};
+  for (const decl of styleValue.split(";")) {
+    const trimmed = decl.trim();
+    if (!trimmed) continue;
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+    const cssProp = trimmed.slice(0, colonIdx).trim();
+    const cssVal = trimmed.slice(colonIdx + 1).trim();
+    if (!cssProp || !cssVal) continue;
+    props[kebabToCamel(cssProp)] = cssVal;
+  }
+  return props;
+}
+
+/**
+ * Convert one SVG attribute to its react-native-svg prop equivalent.
+ * Returns null when the attribute should be dropped entirely.
+ *
+ * Reuses the same drop-list / rename rules as @thesvg/react's
+ * convertAttrToJsx (xmlns/inkscape/sodipodi/xml:/dc:/cc:/rdf: dropped,
+ * xlink:href -> href, data- and aria- prefixed attrs kept hyphenated,
+ * kebab-case -> camelCase)
+ * with two react-native-svg-specific additions: `class`/`className` has no
+ * meaning without a CSS engine so it's dropped, and `filter` is dropped
+ * since <filter> definitions never survive stripToInner().
+ */
+function convertAttrForRN(attr: string, value: string): [string, string] | null {
+  if (attr === "xmlns" || attr.startsWith("xmlns:")) return null;
+  if (attr.startsWith("inkscape:") || attr.startsWith("sodipodi:")) return null;
+  if (attr.startsWith("xml:")) return null;
+  if (attr.startsWith("dc:") || attr.startsWith("cc:") || attr.startsWith("rdf:")) return null;
+  if (attr === "class" || attr === "className") return null; // no CSS classes in react-native-svg
+  if (attr === "filter") return null; // <filter> defs are stripped; drop dangling refs too
+  if (attr === "xlink:href") return ["href", value];
+  if (attr.startsWith("data-") || attr.startsWith("aria-")) return [attr, value];
+  return [kebabToCamel(attr), value];
+}
+
+/**
+ * One parsed attribute string ("id" "d" ...) into a props record, style-aware.
+ *
+ * The value-matching group intentionally accepts a full quoted string rather
+ * than "everything up to the next quote character" — attribute values that
+ * embed the opposite quote style (e.g. a double-quoted font-family listing a
+ * single-quoted font name, font-family="...,'Inter',...") would otherwise
+ * get truncated at that inner quote.
+ */
+function attrsToProps(attrsRaw: string): Record<string, string> {
+  const props: Record<string, string> = {};
+  let styleProps: Record<string, string> = {};
+  const attrRe = /([a-zA-Z][a-zA-Z0-9:_-]*)=("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')/g;
+  let match: RegExpExecArray | null;
+  while ((match = attrRe.exec(attrsRaw)) !== null) {
+    const name = match[1];
+    const value = match[2].slice(1, -1);
+    if (name === "style") {
+      styleProps = parseStyleToProps(value);
+      continue;
+    }
+    const converted = convertAttrForRN(name, value);
+    if (converted) props[converted[0]] = converted[1];
+  }
+  // Inline style wins over presentation attributes of the same name, mirroring
+  // normal CSS/SVG cascade precedence. `filter` can arrive via a style
+  // declaration too (style="...;filter:url(#x)") — drop it the same as a
+  // direct attribute, since <filter> defs never survive stripToInner().
+  delete styleProps.filter;
+  Object.assign(props, styleProps);
+  return props;
+}
+
+/**
+ * A single element in an icon's render tree: [tagName, props, children].
+ * `children` is omitted for leaf/self-closing elements. Text nodes (only
+ * meaningful under <text>/<tspan>) are plain strings.
+ */
+type SvgNode = readonly [string, Record<string, string>] | readonly [string, Record<string, string>, readonly (SvgNode | string)[]];
+
+/**
+ * Parse SVG inner markup into a tree of [tagName, props, children] tuples.
+ * Same regex-based approach as @thesvg/react's convertJsxToCjs (no full
+ * DOM/XML parser, to stay zero-runtime-dep) — targeted tag/attr matching
+ * plus depth-aware close-tag search for nested same-type elements (e.g. <g>
+ * inside <g>).
+ */
+function parseNodes(markup: string): (SvgNode | string)[] {
+  const nodes: (SvgNode | string)[] = [];
+  const tagRe = /<([a-zA-Z][a-zA-Z0-9:.-]*)([^>]*?)(\/?)>/g;
+  let remaining = markup;
+
+  while (remaining.length > 0) {
+    const tagMatch = tagRe.exec(remaining);
+    if (!tagMatch) {
+      const text = remaining.trim();
+      if (text) nodes.push(text);
+      break;
+    }
+
+    const textBefore = remaining.slice(0, tagMatch.index).trim();
+    if (textBefore) nodes.push(textBefore);
+
+    const tagName = tagMatch[1];
+    const attrsRaw = tagMatch[2].trim();
+    const isSelfClosing = tagMatch[3] === "/";
+    const matchEnd = tagMatch.index + tagMatch[0].length;
+    const props = attrsToProps(attrsRaw);
+
+    if (isSelfClosing) {
+      nodes.push([tagName, props]);
+    } else {
+      const afterOpen = remaining.slice(matchEnd);
+      const closeIdx = findMatchingCloseTag(afterOpen, tagName);
+      if (closeIdx >= 0) {
+        const innerContent = afterOpen.slice(0, closeIdx);
+        const closeTagLen = `</${tagName}>`.length;
+        const children = parseNodes(innerContent);
+        nodes.push(children.length > 0 ? [tagName, props, children] : [tagName, props]);
+        remaining = afterOpen.slice(closeIdx + closeTagLen);
+        tagRe.lastIndex = 0;
+        continue;
+      }
+      // No matching close tag found — treat as self-closing.
+      nodes.push([tagName, props]);
+    }
+
+    remaining = remaining.slice(matchEnd);
+    tagRe.lastIndex = 0;
+  }
+
+  return nodes;
+}
+
+/**
+ * Find the index of the matching close tag in `html` for a given `tagName`,
+ * correctly handling nested elements of the same type. Returns -1 if none found.
+ */
+function findMatchingCloseTag(html: string, tagName: string): number {
+  const openRe = new RegExp(`<${tagName}(?:\\s[^>]*)?>`, "g");
+  const closeRe = new RegExp(`</${tagName}>`, "g");
+  let depth = 1;
+  let pos = 0;
+
+  while (depth > 0 && pos < html.length) {
+    openRe.lastIndex = pos;
+    closeRe.lastIndex = pos;
+
+    const openMatch = openRe.exec(html);
+    const closeMatch = closeRe.exec(html);
+
+    if (!closeMatch) return -1;
+
+    if (openMatch && openMatch.index < closeMatch.index) {
+      if (!openMatch[0].endsWith("/>")) depth++;
+      pos = openMatch.index + openMatch[0].length;
+    } else {
+      depth--;
+      if (depth === 0) return closeMatch.index;
+      pos = closeMatch.index + closeMatch[0].length;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Tags the shared runtime knows how to render, mapped to their
+ * react-native-svg export names. Kept as the single source of truth so the
+ * codegen (this file) and the runtime (generateRuntime* below) never drift.
+ */
+const TAG_COMPONENT_MAP: Record<string, string> = {
+  g: "G",
+  path: "Path",
+  circle: "Circle",
+  rect: "Rect",
+  ellipse: "Ellipse",
+  line: "Line",
+  polygon: "Polygon",
+  polyline: "Polyline",
+  defs: "Defs",
+  linearGradient: "LinearGradient",
+  radialGradient: "RadialGradient",
+  stop: "Stop",
+  clipPath: "ClipPath",
+  mask: "Mask",
+  use: "Use",
+  text: "Text",
+  tspan: "TSpan",
+};
+
+/**
+ * Drop any tag not in TAG_COMPONENT_MAP, flattening its children up into the
+ * parent so nested visual content (e.g. an unsupported wrapper like <a> or
+ * <symbol> around a <path>) isn't silently lost. Tracks every dropped tag
+ * name in `unsupported` for the build summary.
+ */
+function pruneUnsupported(nodes: readonly (SvgNode | string)[], unsupported: Set<string>): (SvgNode | string)[] {
+  const out: (SvgNode | string)[] = [];
+  for (const node of nodes) {
+    if (typeof node === "string") {
+      out.push(node);
+      continue;
+    }
+    const [tag, props, children] = node;
+    const prunedChildren = children ? pruneUnsupported(children, unsupported) : undefined;
+    if (Object.prototype.hasOwnProperty.call(TAG_COMPONENT_MAP, tag)) {
+      out.push(prunedChildren && prunedChildren.length > 0 ? [tag, props, prunedChildren] : [tag, props]);
+    } else {
+      unsupported.add(tag);
+      if (prunedChildren && prunedChildren.length > 0) out.push(...prunedChildren);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// PascalCase / identifier helpers (identical to @thesvg/react)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a slug to a PascalCase component name.
+ * Examples: github -> Github, visual-studio-code -> VisualStudioCode,
+ * 01dotai -> I01Dotai (numeric-leading names get an "I" prefix for validity).
+ */
+function toPascalCase(slug: string): string {
+  const pascal = slug
+    .split(/[-._]+/)
+    .map((segment) => {
+      if (segment.length === 0) return "";
+      return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+    })
+    .join("");
+
+  if (/^[0-9]/.test(pascal)) return `I${pascal}`;
+  return pascal;
+}
+
+/** Slug -> valid JS identifier for the CJS barrel's local require() bindings. */
+function toSafeIdentifier(slug: string): string {
+  let id = slug.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (/^[0-9]/.test(id)) id = `i_${id}`;
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Per-icon parsing
+// ---------------------------------------------------------------------------
+
+interface ParsedVariant {
+  viewBox: string;
+  fill: string;
+  stroke?: string;
+  children: (SvgNode | string)[];
+}
+
+interface ParsedIcon {
+  /** Ordered variant keys, always starting with "default". */
+  keys: string[];
+  variants: Record<string, ParsedVariant>;
+}
+
+function parseVariant(publicPath: string, unsupported: Set<string>): ParsedVariant | null {
+  const svgContent = readSvg(publicPath);
+  if (!svgContent) return null;
+  const { inner, viewBox, fill, stroke } = stripToInner(svgContent);
+  const children = pruneUnsupported(parseNodes(inner), unsupported);
+  return { viewBox, fill, stroke, children };
+}
+
+/**
+ * Parse every variant declared for an icon, once, for reuse by ESM/CJS/d.ts
+ * generation. "default" always maps to the icon's primary SVG (default ->
+ * color -> mono -> ... fallback), matching @thesvg/react's resolution order.
+ */
+function parseSvgForIcon(icon: RawIcon, unsupported: Set<string>): ParsedIcon | null {
+  const svgContent = primarySvg(icon.variants);
+  if (!svgContent) return null;
+
+  const { inner, viewBox, fill, stroke } = stripToInner(svgContent);
+  const variants: Record<string, ParsedVariant> = {
+    default: { viewBox, fill, stroke, children: pruneUnsupported(parseNodes(inner), unsupported) },
+  };
+
+  for (const [key, path] of Object.entries(icon.variants)) {
+    if (key === "default" || !path) continue;
+    const parsed = parseVariant(path, unsupported);
+    if (parsed) {
+      if (key === "mono" && parsed.fill === "none") {
+        parsed.fill = "currentColor";
+      }
+      variants[key] = parsed;
+    }
+  }
+
+  return { keys: Object.keys(variants), variants };
+}
+
+// ---------------------------------------------------------------------------
+// Shared runtime (createIcon) — emitted once, not per icon
+// ---------------------------------------------------------------------------
+
+function generateRuntimeEsm(): string {
+  return [
+    `// @thesvg/react-native — shared icon runtime`,
+    `// Auto-generated. Do not edit.`,
+    `//`,
+    `// Renders an icon's [tagName, props, children] data tree by resolving each`,
+    `// tag name against react-native-svg's exports. One copy of this logic is`,
+    `// shared by every generated icon module (see icons/*.js), which is why`,
+    `// icon modules can be pure data instead of one inline component each.`,
+    ``,
+    `import { createElement, forwardRef } from 'react';`,
+    `import {`,
+    `  Svg, G, Path, Circle, Rect, Ellipse, Line, Polygon, Polyline,`,
+    `  Defs, LinearGradient, RadialGradient, Stop, ClipPath, Mask, Use, Text, TSpan,`,
+    `} from 'react-native-svg';`,
+    ``,
+    `const TAG_COMPONENTS = {`,
+    `  g: G, path: Path, circle: Circle, rect: Rect, ellipse: Ellipse,`,
+    `  line: Line, polygon: Polygon, polyline: Polyline, defs: Defs,`,
+    `  linearGradient: LinearGradient, radialGradient: RadialGradient, stop: Stop,`,
+    `  clipPath: ClipPath, mask: Mask, use: Use, text: Text, tspan: TSpan,`,
+    `};`,
+    ``,
+    `const RESERVED_PROPS = { variant: 1, color: 1, size: 1, width: 1, height: 1, fill: 1, stroke: 1 };`,
+    ``,
+    `function renderNode(node, key) {`,
+    `  if (typeof node === 'string') return node;`,
+    `  const Component = TAG_COMPONENTS[node[0]];`,
+    `  if (!Component) return null;`,
+    `  const children = node[2] ? node[2].map(renderNode) : undefined;`,
+    `  return createElement(Component, Object.assign({ key: key }, node[1]), children);`,
+    `}`,
+    ``,
+    `export function createIcon(name, variants) {`,
+    `  const IconComponent = forwardRef(function (props, ref) {`,
+    `    const variant = props.variant || 'default';`,
+    `    const data = variants[variant] || variants.default;`,
+    `    const width = props.width !== undefined ? props.width : (props.size !== undefined ? props.size : 24);`,
+    `    const height = props.height !== undefined ? props.height : (props.size !== undefined ? props.size : 24);`,
+    `    const fill = props.fill !== undefined ? props.fill : (props.color !== undefined ? props.color : data.fill);`,
+    `    const stroke = props.stroke !== undefined`,
+    `      ? props.stroke`,
+    `      : (props.color !== undefined && data.stroke !== undefined ? props.color : data.stroke);`,
+    `    const rest = {};`,
+    `    for (const k in props) { if (!RESERVED_PROPS[k]) rest[k] = props[k]; }`,
+    `    const svgProps = Object.assign(`,
+    `      { ref: ref, viewBox: data.viewBox, width: width, height: height, fill: fill },`,
+    `      stroke !== undefined ? { stroke: stroke } : {},`,
+    `      rest,`,
+    `    );`,
+    `    return createElement(Svg, svgProps, data.children.map(renderNode));`,
+    `  });`,
+    `  IconComponent.displayName = name;`,
+    `  return IconComponent;`,
+    `}`,
+  ].join("\n");
+}
+
+function generateRuntimeCjs(): string {
+  return [
+    `"use strict";`,
+    `// @thesvg/react-native — shared icon runtime`,
+    `// Auto-generated. Do not edit.`,
+    ``,
+    `Object.defineProperty(exports, "__esModule", { value: true });`,
+    ``,
+    `const react_1 = require("react");`,
+    `const svg_1 = require("react-native-svg");`,
+    ``,
+    `const TAG_COMPONENTS = {`,
+    `  g: svg_1.G, path: svg_1.Path, circle: svg_1.Circle, rect: svg_1.Rect, ellipse: svg_1.Ellipse,`,
+    `  line: svg_1.Line, polygon: svg_1.Polygon, polyline: svg_1.Polyline, defs: svg_1.Defs,`,
+    `  linearGradient: svg_1.LinearGradient, radialGradient: svg_1.RadialGradient, stop: svg_1.Stop,`,
+    `  clipPath: svg_1.ClipPath, mask: svg_1.Mask, use: svg_1.Use, text: svg_1.Text, tspan: svg_1.TSpan,`,
+    `};`,
+    ``,
+    `const RESERVED_PROPS = { variant: 1, color: 1, size: 1, width: 1, height: 1, fill: 1, stroke: 1 };`,
+    ``,
+    `function renderNode(node, key) {`,
+    `  if (typeof node === 'string') return node;`,
+    `  const Component = TAG_COMPONENTS[node[0]];`,
+    `  if (!Component) return null;`,
+    `  const children = node[2] ? node[2].map(renderNode) : undefined;`,
+    `  return react_1.createElement(Component, Object.assign({ key: key }, node[1]), children);`,
+    `}`,
+    ``,
+    `function createIcon(name, variants) {`,
+    `  const IconComponent = react_1.forwardRef(function (props, ref) {`,
+    `    const variant = props.variant || 'default';`,
+    `    const data = variants[variant] || variants.default;`,
+    `    const width = props.width !== undefined ? props.width : (props.size !== undefined ? props.size : 24);`,
+    `    const height = props.height !== undefined ? props.height : (props.size !== undefined ? props.size : 24);`,
+    `    const fill = props.fill !== undefined ? props.fill : (props.color !== undefined ? props.color : data.fill);`,
+    `    const stroke = props.stroke !== undefined`,
+    `      ? props.stroke`,
+    `      : (props.color !== undefined && data.stroke !== undefined ? props.color : data.stroke);`,
+    `    const rest = {};`,
+    `    for (const k in props) { if (!RESERVED_PROPS[k]) rest[k] = props[k]; }`,
+    `    const svgProps = Object.assign(`,
+    `      { ref: ref, viewBox: data.viewBox, width: width, height: height, fill: fill },`,
+    `      stroke !== undefined ? { stroke: stroke } : {},`,
+    `      rest,`,
+    `    );`,
+    `    return react_1.createElement(svg_1.Svg, svgProps, data.children.map(renderNode));`,
+    `  });`,
+    `  IconComponent.displayName = name;`,
+    `  return IconComponent;`,
+    `}`,
+    `exports.createIcon = createIcon;`,
+  ].join("\n");
+}
+
+function generateRuntimeDts(): string {
+  return [
+    `// @thesvg/react-native — shared icon runtime types`,
+    `// Auto-generated. Do not edit.`,
+    ``,
+    `import type { ComponentRef, ForwardRefExoticComponent, RefAttributes } from 'react';`,
+    `import type { Svg, SvgProps } from 'react-native-svg';`,
+    ``,
+    `/** One element in an icon's render tree: [tagName, props, children]. */`,
+    `export type IconNode =`,
+    `  | readonly [tag: string, props: Record<string, unknown>]`,
+    `  | readonly [tag: string, props: Record<string, unknown>, children: readonly (IconNode | string)[]];`,
+    ``,
+    `export interface IconVariantData {`,
+    `  viewBox: string;`,
+    `  fill?: string;`,
+    `  stroke?: string;`,
+    `  children: readonly (IconNode | string)[];`,
+    `}`,
+    ``,
+    `export interface IconProps extends Omit<SvgProps, 'children'> {`,
+    `  /** Which icon variant to render. Defaults to "default". */`,
+    `  variant?: string;`,
+    `  /** Shorthand for both width and height. Ignored when width/height are set. Defaults to 24. */`,
+    `  size?: number | string;`,
+    `  /** Shorthand that sets both fill and stroke to a single color. */`,
+    `  color?: string;`,
+    `}`,
+    ``,
+    `export type IconComponent<V extends string = string> = ForwardRefExoticComponent<`,
+    `  Omit<IconProps, 'variant'> & { variant?: V } & RefAttributes<ComponentRef<typeof Svg>>`,
+    `>;`,
+    ``,
+    `export declare function createIcon<V extends string = string>(`,
+    `  name: string,`,
+    `  variants: Record<V, IconVariantData> & { default: IconVariantData },`,
+    `): IconComponent<V>;`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Per-icon module generators
+// ---------------------------------------------------------------------------
+
+function generateEsmIconModule(icon: RawIcon, parsed: ParsedIcon | null): string {
+  const componentName = toPascalCase(icon.slug);
+
+  if (!parsed) {
+    return [
+      `// @thesvg/react-native — ${icon.title}`,
+      `// Auto-generated. Do not edit.`,
+      `// WARNING: SVG source not found for slug "${icon.slug}"`,
+      ``,
+      `import { createIcon } from '../createIcon.js';`,
+      ``,
+      `const _variants = { default: { viewBox: '0 0 24 24', fill: 'currentColor', children: [] } };`,
+      ``,
+      `const ${componentName} = createIcon('${componentName}', _variants);`,
+      ``,
+      `export default ${componentName};`,
+    ].join("\n");
+  }
+
+  return [
+    `// @thesvg/react-native — ${icon.title}`,
+    `// Auto-generated. Do not edit.`,
+    `// Variants: ${parsed.keys.join(", ")}`,
+    ``,
+    `import { createIcon } from '../createIcon.js';`,
+    ``,
+    `const _variants = ${JSON.stringify(parsed.variants)};`,
+    ``,
+    `const ${componentName} = createIcon('${componentName}', _variants);`,
+    ``,
+    `export default ${componentName};`,
+  ].join("\n");
+}
+
+function generateCjsIconModule(icon: RawIcon, parsed: ParsedIcon | null): string {
+  const componentName = toPascalCase(icon.slug);
+
+  if (!parsed) {
+    return [
+      `"use strict";`,
+      `// @thesvg/react-native — ${icon.title}`,
+      `// Auto-generated. Do not edit.`,
+      `// WARNING: SVG source not found for slug "${icon.slug}"`,
+      ``,
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      ``,
+      `const { createIcon } = require('../createIcon.cjs');`,
+      ``,
+      `const _variants = { default: { viewBox: '0 0 24 24', fill: 'currentColor', children: [] } };`,
+      ``,
+      `const ${componentName} = createIcon('${componentName}', _variants);`,
+      ``,
+      `exports.default = ${componentName};`,
+    ].join("\n");
+  }
+
+  return [
+    `"use strict";`,
+    `// @thesvg/react-native — ${icon.title}`,
+    `// Auto-generated. Do not edit.`,
+    `// Variants: ${parsed.keys.join(", ")}`,
+    ``,
+    `Object.defineProperty(exports, "__esModule", { value: true });`,
+    ``,
+    `const { createIcon } = require('../createIcon.cjs');`,
+    ``,
+    `const _variants = ${JSON.stringify(parsed.variants)};`,
+    ``,
+    `const ${componentName} = createIcon('${componentName}', _variants);`,
+    ``,
+    `exports.default = ${componentName};`,
+  ].join("\n");
+}
+
+function generateDtsIconModule(icon: RawIcon, parsed: ParsedIcon | null): string {
+  const componentName = toPascalCase(icon.slug);
+  const variantKeys = parsed && parsed.keys.length > 0 ? parsed.keys : ["default"];
+  const variantUnion = variantKeys.map((k) => `'${k}'`).join(" | ");
+  return [
+    `// @thesvg/react-native — ${icon.title}`,
+    `// Auto-generated. Do not edit.`,
+    ``,
+    `import type { IconComponent } from '../createIcon.js';`,
+    ``,
+    `export type ${componentName}Variant = ${variantUnion};`,
+    ``,
+    `declare const ${componentName}: IconComponent<${componentName}Variant>;`,
+    `export default ${componentName};`,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Barrel generators
+// ---------------------------------------------------------------------------
+
+function generateEsmBarrel(entries: Array<{ slug: string; componentName: string }>): string {
+  const lines = [`// @thesvg/react-native`, `// Auto-generated barrel. Do not edit.`, ``];
+  for (const { slug, componentName } of entries) {
+    lines.push(`export { default as ${componentName} } from './icons/${slug}.js';`);
+  }
+  return lines.join("\n");
+}
+
+function generateCjsBarrel(entries: Array<{ slug: string; componentName: string }>): string {
+  const lines = [
+    `"use strict";`,
+    `// @thesvg/react-native`,
+    `// Auto-generated barrel. Do not edit.`,
+    ``,
+    `Object.defineProperty(exports, "__esModule", { value: true });`,
+    ``,
+  ];
+  for (const { slug, componentName } of entries) {
+    lines.push(
+      `const _${toSafeIdentifier(slug)} = require('./icons/${slug}.cjs');`,
+      `exports.${componentName} = _${toSafeIdentifier(slug)}.default;`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function generateDtsBarrel(entries: Array<{ slug: string; componentName: string }>): string {
+  const lines = [
+    `// @thesvg/react-native`,
+    `// Auto-generated type barrel. Do not edit.`,
+    ``,
+    `export type { IconProps, IconComponent, IconNode, IconVariantData } from './createIcon.js';`,
+    ``,
+  ];
+  for (const { componentName, slug } of entries) {
+    lines.push(`export { default as ${componentName} } from './icons/${slug}.js';`);
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Build validation (fast structural sanity check; scripts/validate-output.ts
+// does the deeper per-icon / variant-coverage pass)
+// ---------------------------------------------------------------------------
+
+function validateOutput(): boolean {
+  console.log("\nValidating output...");
+  let errors = 0;
+  let totalSampled = 0;
+
+  for (const ext of [".js", ".cjs"] as const) {
+    const files = readdirSync(DIST_ICONS).filter((f) => f.endsWith(ext));
+    const step = Math.max(1, Math.floor(files.length / 20));
+    const sampled = new Set<string>();
+    for (let i = 0; i < files.length && sampled.size < 20; i += step) {
+      sampled.add(files[i]);
+    }
+
+    for (const file of sampled) {
+      const content = readFileSync(join(DIST_ICONS, file), "utf8");
+
+      if (ext === ".js" && /\bimport\s+type\b/.test(content)) {
+        console.error(`  FAIL: icons/${file} contains "import type"`);
+        errors++;
+      }
+      if (/return\s*\(?\s*<[a-zA-Z]/.test(content)) {
+        console.error(`  FAIL: icons/${file} contains raw JSX syntax (should be data + createIcon)`);
+        errors++;
+      }
+      if (/<\?xml|<!DOCTYPE|<style[\s>]|<title[\s>]|<filter[\s>]/i.test(content)) {
+        console.error(`  FAIL: icons/${file} contains leftover XML/SVG-only markup`);
+        errors++;
+      }
+      if (/"class"\s*:|"className"\s*:|"style"\s*:\s*"/.test(content)) {
+        console.error(`  FAIL: icons/${file} contains a class/className/string-style prop react-native-svg can't use`);
+        errors++;
+      }
+    }
+
+    totalSampled += sampled.size;
+  }
+
+  if (errors === 0) {
+    console.log(`  PASS: Validated ${totalSampled} icon files (ESM + CJS), no issues found.`);
+    return true;
+  }
+  console.error(`  ${errors} validation error(s) found.`);
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  console.log("Reading icons.json…");
+  const rawIcons: RawIcon[] = JSON.parse(readFileSync(ICONS_JSON, "utf8")) as RawIcon[];
+  console.log(`Found ${rawIcons.length} icons.`);
+
+  // Clean stale output first so components for removed/renamed slugs (orphans)
+  // don't linger in dist and get shipped or flagged by the validator.
+  rmSync(DIST, { recursive: true, force: true });
+  mkdirSync(DIST_ICONS, { recursive: true });
+
+  // Shared runtime, emitted once.
+  writeFileSync(join(DIST, "createIcon.js"), generateRuntimeEsm() + "\n");
+  writeFileSync(join(DIST, "createIcon.cjs"), generateRuntimeCjs() + "\n");
+  writeFileSync(join(DIST, "createIcon.d.ts"), generateRuntimeDts() + "\n");
+
+  const entries: Array<{ slug: string; componentName: string }> = [];
+  const unsupportedTags = new Set<string>();
+  let skipped = 0;
+
+  for (const icon of rawIcons) {
+    const componentName = toPascalCase(icon.slug);
+    const parsed = parseSvgForIcon(icon, unsupportedTags);
+    if (!parsed) skipped++;
+
+    writeFileSync(join(DIST_ICONS, `${icon.slug}.js`), generateEsmIconModule(icon, parsed) + "\n");
+    writeFileSync(join(DIST_ICONS, `${icon.slug}.cjs`), generateCjsIconModule(icon, parsed) + "\n");
+    writeFileSync(join(DIST_ICONS, `${icon.slug}.d.ts`), generateDtsIconModule(icon, parsed) + "\n");
+
+    entries.push({ slug: icon.slug, componentName });
+
+    if (entries.length % 500 === 0) {
+      console.log(`  Processed ${entries.length} / ${rawIcons.length}…`);
+    }
+  }
+
+  writeFileSync(join(DIST, "index.js"), generateEsmBarrel(entries) + "\n");
+  writeFileSync(join(DIST, "index.cjs"), generateCjsBarrel(entries) + "\n");
+  writeFileSync(join(DIST, "index.d.ts"), generateDtsBarrel(entries) + "\n");
+
+  console.log(`\nDone. Built ${entries.length} icons (${skipped} had no SVG source).`);
+  if (skipped > 0) {
+    console.log(`  ${skipped} icons emitted an empty placeholder — check SVG paths.`);
+  }
+  if (unsupportedTags.size > 0) {
+    console.log(
+      `  ${unsupportedTags.size} unsupported SVG tag(s) encountered and flattened (children kept, wrapper dropped): ${[...unsupportedTags].sort().join(", ")}`,
+    );
+  }
+  console.log(`Output: ${DIST}`);
+
+  const valid = validateOutput();
+  if (!valid) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/react-native/scripts/validate-output.ts
+++ b/packages/react-native/scripts/validate-output.ts
@@ -1,0 +1,140 @@
+/**
+ * validate-output.ts
+ *
+ * Standalone validation script for @thesvg/react-native dist output.
+ * Scans dist/icons/*.js and fails if any contain:
+ * - TypeScript-only syntax (import type)
+ * - Raw JSX (the data + createIcon architecture should never emit JSX)
+ * - Leftover XML/SVG-only markup (xml prolog, DOCTYPE, <style>, <title>, <filter>)
+ * - class/className/string-style props react-native-svg can't consume
+ * - A variant declared in icons.json (with a real SVG on disk) missing from
+ *   the compiled output — regression test mirroring @thesvg/react's
+ *   coverage check (see its scripts/validate-output.ts, issue #740).
+ *
+ * Run with:
+ *   tsx scripts/validate-output.ts
+ *   bun run scripts/validate-output.ts
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DIST = resolve(__dirname, "../dist");
+const DIST_ICONS = join(DIST, "icons");
+const REPO_ROOT = resolve(__dirname, "../../..");
+const ICONS_JSON = resolve(REPO_ROOT, "src/data/icons.json");
+
+interface RawIcon {
+  slug: string;
+  variants: Record<string, string>;
+}
+
+let errors = 0;
+let checked = 0;
+
+if (!existsSync(DIST_ICONS)) {
+  console.error("No dist/icons directory found. Run `npm run build` first.");
+  process.exit(1);
+}
+
+const files = readdirSync(DIST_ICONS).filter((f) => f.endsWith(".js"));
+
+if (files.length === 0) {
+  console.error("No .js files found in dist/icons/. Run `npm run build` first.");
+  process.exit(1);
+}
+
+for (const file of files) {
+  const content = readFileSync(join(DIST_ICONS, file), "utf8");
+  checked++;
+
+  if (/\bimport\s+type\b/.test(content)) {
+    console.error(`FAIL: icons/${file} contains "import type"`);
+    errors++;
+  }
+
+  if (/return\s*\(?\s*<[a-zA-Z]/.test(content) || /createElement\s*\(\s*['"]?</.test(content)) {
+    console.error(`FAIL: icons/${file} contains raw JSX/markup (should be pure data)`);
+    errors++;
+  }
+
+  if (/<\?xml/.test(content)) {
+    console.error(`FAIL: icons/${file} contains XML prolog`);
+    errors++;
+  }
+  if (/<!DOCTYPE/i.test(content)) {
+    console.error(`FAIL: icons/${file} contains DOCTYPE declaration`);
+    errors++;
+  }
+  if (/<style[\s>]/i.test(content)) {
+    console.error(`FAIL: icons/${file} contains <style> element`);
+    errors++;
+  }
+  if (/<title[\s>]/i.test(content)) {
+    console.error(`FAIL: icons/${file} contains <title> element`);
+    errors++;
+  }
+  if (/<filter[\s>]/i.test(content)) {
+    console.error(`FAIL: icons/${file} contains <filter> element (unsupported by react-native-svg)`);
+    errors++;
+  }
+  if (/"class"\s*:|"className"\s*:/.test(content)) {
+    console.error(`FAIL: icons/${file} contains a class/className prop (no CSS engine in react-native-svg)`);
+    errors++;
+  }
+  if (/"style"\s*:\s*"/.test(content)) {
+    console.error(`FAIL: icons/${file} contains a string-form style prop (should be flattened onto element props)`);
+    errors++;
+  }
+  if (/import\s*\{\s*createIcon\s*\}\s*from\s*'\.\.\/createIcon\.js'/.test(content) === false) {
+    console.error(`FAIL: icons/${file} does not import the shared createIcon runtime`);
+    errors++;
+  }
+}
+
+// Every variant declared in icons.json with a real SVG on disk must survive
+// into the compiled output, mirroring @thesvg/react's coverage check.
+const icons: RawIcon[] = JSON.parse(readFileSync(ICONS_JSON, "utf8"));
+let iconsChecked = 0;
+
+for (const icon of icons) {
+  const dtsPath = join(DIST_ICONS, `${icon.slug}.d.ts`);
+  if (!existsSync(dtsPath)) continue;
+
+  const dts = readFileSync(dtsPath, "utf8");
+  const unionMatch = dts.match(/Variant = ([^;]+);/);
+  const compiledVariants = new Set(
+    unionMatch ? unionMatch[1].split("|").map((v) => v.trim().replace(/'/g, "")) : [],
+  );
+
+  for (const [variantKey, variantPath] of Object.entries(icon.variants)) {
+    const svgFile = join(REPO_ROOT, "public", variantPath.replace(/^\//, ""));
+    if (!existsSync(svgFile)) continue;
+
+    if (!compiledVariants.has(variantKey)) {
+      console.error(
+        `FAIL: ${icon.slug} declares variant "${variantKey}" (${variantPath}) but it is missing from the compiled output`,
+      );
+      errors++;
+    }
+  }
+  iconsChecked++;
+}
+
+// Shared runtime files must exist alongside the icons.
+for (const f of ["createIcon.js", "createIcon.cjs", "createIcon.d.ts", "index.js", "index.cjs", "index.d.ts"]) {
+  if (!existsSync(join(DIST, f))) {
+    console.error(`FAIL: dist/${f} is missing`);
+    errors++;
+  }
+}
+
+if (errors > 0) {
+  console.error(`\n${errors} error(s) in ${checked} files. Fix build-components.ts and rebuild.`);
+  process.exit(1);
+} else {
+  console.log(`PASS: ${checked} icon files validated, ${iconsChecked} icons' variant coverage checked, no issues found.`);
+}

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-native",
+    "declaration": false,
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["react", "react-native", "react-native-svg"]
+  },
+  "include": ["dist/**/*.d.ts"],
+  "exclude": ["node_modules", "scripts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,28 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/react-native:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.8
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      react-native:
+        specifier: ^0.87.0
+        version: 0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+      react-native-svg:
+        specifier: ^15.15.5
+        version: 15.15.5(react-native@0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+      tsx:
+        specifier: ^4.23.10
+        version: 4.23.10
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   packages/svelte:
     dependencies:
       svelte:
@@ -849,6 +871,18 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/ttlcache@1.4.1':
+    resolution: {integrity: sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==}
+    engines: {node: '>=12'}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -858,6 +892,9 @@ packages:
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1168,6 +1205,58 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-native/asset-utils@0.87.0':
+    resolution: {integrity: sha512-XUSXMnBmQuBMuMWNWaXMGt4tLzb2yraCVO4b7TFCvEqiCg3ByhbQA0QNmPp+cdWgvmPmptCJwOrBWjPxppXgOA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  '@react-native/codegen@0.87.0':
+    resolution: {integrity: sha512-odcBGR0A9Ee83A/XvzOp9juGRkSQOQcI4ZYs+3H20MySMxvZJ34/2nVHoxdmj0YY0Mn6gF8BjLzYkL0axbHuCA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    peerDependencies:
+      '@babel/core': '*'
+
+  '@react-native/community-cli-plugin@0.87.0':
+    resolution: {integrity: sha512-Voaq6e6aSjLsFmOVofP1RHM0wD0Wo51AlIheIDAzXqgBKwEHEz2na4swNZ6sjWLZH/4Wm2ydy+8A/6RCyfht6w==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    peerDependencies:
+      '@react-native-community/cli': '*'
+      '@react-native/metro-config': 0.87.0
+    peerDependenciesMeta:
+      '@react-native-community/cli':
+        optional: true
+      '@react-native/metro-config':
+        optional: true
+
+  '@react-native/debugger-frontend@0.87.0':
+    resolution: {integrity: sha512-TSUVjiX1cYganE6DcWVblDxs67x96u8/KqwhiHHViR6hGGjSIfIdNQcRLOEdXRpucuHB0awIFepBlw+34nTSUg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  '@react-native/debugger-shell@0.87.0':
+    resolution: {integrity: sha512-8Om5Qm8Ln9zGZ93DJj7gZtlfT0y1wAFc/iWr3GFkIXSa6zwmC3DGzm4sm5eBTtdMl27EXmKACIOGsqztPH3Cvg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  '@react-native/dev-middleware@0.87.0':
+    resolution: {integrity: sha512-Fy4RMTCcAn402KGgxQZ4CwoURJdVkoPVxUbN7OTf9xy9xCOmBsOQQ+Xs1n6ULkNMUGcL3ptajpb39ual6r5ixg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  '@react-native/gradle-plugin@0.87.0':
+    resolution: {integrity: sha512-CFOhPsxN4yS6vYjShSGKQiJHDPQFKmbiJG17zZfJuHTvJiaWz7JkpznE/P1RRKXdgvCmACrj31vxJiCHLlI7Gg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  '@react-native/normalize-colors@0.87.0':
+    resolution: {integrity: sha512-7aEGyrrquUqpbp+aEgOCp2xr0cTLYhJFCMfUqI4IoJddfwosra9Y5qtbrJU5Z/vBLndCmSIzABrWnHK0lxpwcA==}
+
+  '@react-native/virtualized-lists@0.87.0':
+    resolution: {integrity: sha512-rYQCtZupN7Iczm8fdGg3uKZUXhrxdZPRkg4BZK3RaQJ2HJ7n5tJNR2QPR3vSgpp5CATQggiGCuom1fNEC3T/8g==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    peerDependencies:
+      '@types/react': ^19.2.0
+      react: '*'
+      react-native: 0.87.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1204,6 +1293,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@sinclair/typebox@0.27.12':
+    resolution: {integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -1324,6 +1416,15 @@ packages:
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1355,6 +1456,12 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@typescript-eslint/eslint-plugin@8.66.0':
     resolution: {integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==}
@@ -1641,6 +1748,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -1663,6 +1774,9 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  anser@1.4.10:
+    resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1678,6 +1792,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1733,6 +1851,9 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1760,12 +1881,18 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  babel-plugin-syntax-hermes-parser@0.36.1:
+    resolution: {integrity: sha512-ycduwJbvdvIMmVvlAZqGggS+pm5Eu4Bk9pcV9Sm2Z4PJNRVsKkv0g7vHj+LeuC1gHTeF67sJXFOq61IlqCa2hA==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.11.13:
     resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
@@ -1779,6 +1906,9 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1795,6 +1925,12 @@ packages:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bser@2.1.1:
+    resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1820,6 +1956,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
@@ -1843,6 +1983,21 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  chrome-launcher@0.15.2:
+    resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
+  chromium-edge-launcher@0.3.0:
+    resolution: {integrity: sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==}
+
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -1856,6 +2011,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1884,9 +2043,16 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1894,6 +2060,10 @@ packages:
   conf@10.2.0:
     resolution: {integrity: sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==}
     engines: {node: '>=12'}
+
+  connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1938,6 +2108,17 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@1.1.3:
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
+    engines: {node: '>=8.0.0'}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1967,6 +2148,14 @@ packages:
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
     engines: {node: '>=10'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2032,6 +2221,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2061,8 +2254,21 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -2089,8 +2295,15 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2104,6 +2317,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -2114,6 +2331,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -2326,6 +2546,9 @@ packages:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   express-rate-limit@8.6.2:
     resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
     engines: {node: '>= 16'}
@@ -2362,6 +2585,14 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fb-dotslash@0.5.8:
+    resolution: {integrity: sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  fb-watchman@2.0.2:
+    resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2386,6 +2617,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -2409,12 +2644,19 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  flow-enums-runtime@0.0.6:
+    resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -2467,6 +2709,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -2567,11 +2813,20 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hermes-compiler@250829098.0.16:
+    resolution: {integrity: sha512-xsgzk+mUyvt9t1nUbF8USBlYxajTUtPJhVZ86q85s/SEoMKCF+52YZcudb0ENSnV3T3lV9mgB3s6R7+pH90zgw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
+  hermes-estree@0.36.1:
+    resolution: {integrity: sha512-guv1nQ6IJ7S83NRFPWc3SA7IBZrdNC9kapwOq6uXvF4wP+sDCgjzQbKPCoyYmoyZRzztF/n/c36l/rccCZSiCw==}
+
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  hermes-parser@0.36.1:
+    resolution: {integrity: sha512-GApNk4zLHi2UWoWZZkx7LNCOSzLSc5lB55pZ/PhK7ycFeg7u5LcF88p/WbpIi1XUDtE0MpHE3uRR3u3KB7TjSQ==}
 
   hono@4.13.0:
     resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
@@ -2586,6 +2841,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -2611,6 +2870,11 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2625,6 +2889,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
   ip-address@10.4.0:
     resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
@@ -2693,6 +2960,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -2835,6 +3106,22 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@29.7.0:
+    resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-validate@29.7.0:
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-worker@29.7.0:
+    resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -2856,6 +3143,9 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
+
+  jsc-safe-url@0.2.4:
+    resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2920,9 +3210,16 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lighthouse-logger@1.4.2:
+    resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3022,6 +3319,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
@@ -3041,6 +3341,12 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  makeerror@1.0.12:
+    resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  marky@1.3.0:
+    resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3048,9 +3354,15 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
+  mdn-data@2.0.14:
+    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
+
+  memoize-one@5.2.1:
+    resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -3062,6 +3374,64 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  metro-babel-transformer@0.87.0:
+    resolution: {integrity: sha512-IEn1K1FyY4J1sA5y6zqDjf2OkfmpTEqhZOeP6MJX8HepSW0cuHGw1m8bYOdv2adkG3XUE9dtM0csUs0gP/Xa5w==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-cache-key@0.87.0:
+    resolution: {integrity: sha512-Q+MPt6jl0zQogr4Q02WaJK6HY+GtE5A0nzj8kIV1Owgrx6OMNvm6scPTr1SM/R4LpCE8EH/Y5qfbXQ84GHTr0Q==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-cache@0.87.0:
+    resolution: {integrity: sha512-146vS1BMSKcp99jddOhFBfHwzUEWN35NrsnSJDF2sQQ0ZT5OsBcOjd574PM233TWEZISRJ5DOK+vokD+1ubx+w==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-config@0.87.0:
+    resolution: {integrity: sha512-yZ9QAIzWH9MxwrzwRlX/CBGRWOT14l7klSDYg8hdtSdnoUs5A7MQRdHE2KB9iHVzGQW5wgWM5aXJswNeWbSQPA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-core@0.87.0:
+    resolution: {integrity: sha512-yW57+pCOHRC/CJZ99GA2PTd+30dORwDAjUPRCokj91IWW5In9Jwtt2FB5wACrGO8P0GHTyVHdTwDNyZsNndUbA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-file-map@0.87.0:
+    resolution: {integrity: sha512-Dc57t8jsINwA90bbVlqaeDlxf1rVGgj5SmOEnOMbaHNUM/HCYYTJxPV8SRdOBwh7qTz/biO9vaQvBTjRBgbbsg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-minify-terser@0.87.0:
+    resolution: {integrity: sha512-tPa0O983PDutFu3LXbArRH5NduogcKrvW6fs9VHhksTKUA1iqDyoD1ZSj/Me52xJ6T9/9pOwIVyj9ulKc/zMkg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-resolver@0.87.0:
+    resolution: {integrity: sha512-Xl3M9R3KToaHJvXlI2lSOxtYHitzxite+195DSi00HL9PcS7Xik5+3xlRjfkKb3FA86SZxYPj+WJwlcfgaZoxg==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-runtime@0.87.0:
+    resolution: {integrity: sha512-XsXZkgEwI0ZMYSBfvOMAbenzwa60XlObXJ27g6/Khgrz9ESbiBbAsd7hR62G2jRBYOhGAzG61Gk22dpRJj/mdw==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-source-map@0.87.0:
+    resolution: {integrity: sha512-31BrYqu1c2co93rF1LN9Pw+7g+BrfDyxJkNQWrYm+pfA/+eVYVumF7tFMHbXLePLmHfhvSgVvbK6su1Oyiw1ng==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-symbolicate@0.87.0:
+    resolution: {integrity: sha512-uOpTxAXu74N+RSujUZ78L6gjI6bDdnz6XuW+AIUNuubZDEQPIpaX0StzIb0GMeQWP6zfHOHwFrWPP5Iquu1GXw==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    hasBin: true
+
+  metro-transform-plugins@0.87.0:
+    resolution: {integrity: sha512-i8keUe9+BaSwMuQM26DGheElCpTtflAKIrSwJAm8ZsgDb50RAUQus+e6zt2suaJXJ1OxZa7vqgtqoZxdniM6Fw==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro-transform-worker@0.87.0:
+    resolution: {integrity: sha512-YftLzNJxCTYxEN5k4AzR8KYwiENTEuz30L+4QeoMrtDd+U8mDThZg/ArR3JVRd8LaikwPOjVAS5SP3xPJN0AaA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+
+  metro@0.87.0:
+    resolution: {integrity: sha512-fRqFhSzQhLNQSCvJFeuRzBRXAOOKXf1O8d2cvmMtG6yFR0jCllQ7vBsXoLP18yuqtf+N1XwWXTPF11eWy9q6dQ==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    hasBin: true
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -3090,6 +3460,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -3112,9 +3487,17 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3181,6 +3564,9 @@ packages:
       encoding:
         optional: true
 
+  node-int64@0.4.0:
+    resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
@@ -3192,6 +3578,16 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nullthrows@1.1.1:
+    resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  ob1@0.87.0:
+    resolution: {integrity: sha512-8Q8sKCiUwsxgSmjDtVWyRgmxsgeJXXam3oQH6Id8ADfNaJMV6GZKyeAl8+pGVVdgwAZabfk5+aExle7AP/nZiA==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3229,6 +3625,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3253,6 +3653,10 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -3426,9 +3830,16 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  promise@8.3.0:
+    resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -3461,6 +3872,13 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
@@ -3469,6 +3887,9 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-devtools-core@6.1.5:
+    resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
+
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -3476,6 +3897,30 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-native-svg@15.15.5:
+    resolution: {integrity: sha512-L4go5jA+GWutdJ/JucuN20cjAbMg1HmMtAP+wZ+3JLCf6Jd0bhXQHxciRP/AQm/FlrIEZwkMcHNZP+FXAiic0w==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native@0.87.0:
+    resolution: {integrity: sha512-e7CeZOm1wBksIISI5oLNmH4/GJCqWrfNphF7PuBsLY2qUM6mtzqL23N7iLTW6U7LF45qYi+a4iAp5Y1kSk1vVw==}
+    engines: {node: ^22.13.0 || ^24.3.0 || >= 26.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^19.1.1
+      react: ^19.2.3
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-refresh@0.14.2:
+    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3527,6 +3972,9 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -3539,6 +3987,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3609,9 +4061,21 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@2.1.0:
+    resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
+    engines: {node: '>=0.10.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -3654,6 +4118,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
+
   shiki@4.4.2:
     resolution: {integrity: sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA==}
     engines: {node: '>=20'}
@@ -3692,6 +4160,13 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3708,6 +4183,17 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3719,6 +4205,10 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -3795,6 +4285,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3823,12 +4317,23 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  terser@5.50.0:
+    resolution: {integrity: sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  throat@5.0.0:
+    resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tmpl@1.0.5:
+    resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3874,6 +4379,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -3989,6 +4498,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -4003,6 +4516,9 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vlq@1.0.1:
+    resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
+
   vue@3.5.30:
     resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
     peerDependencies:
@@ -4011,11 +4527,17 @@ packages:
       typescript:
         optional: true
 
+  walker@1.0.8:
+    resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4050,15 +4572,43 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4803,6 +5353,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.2
 
+  '@isaacs/ttlcache@1.4.1': {}
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.12
+
+  '@jest/types@29.6.3':
+    dependencies:
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 26.1.2
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4814,6 +5379,11 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -5109,6 +5679,73 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
+  '@react-native/asset-utils@0.87.0': {}
+
+  '@react-native/codegen@0.87.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.8
+      hermes-parser: 0.36.1
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      tinyglobby: 0.2.17
+      yargs: 17.7.3
+
+  '@react-native/community-cli-plugin@0.87.0':
+    dependencies:
+      '@react-native/asset-utils': 0.87.0
+      '@react-native/dev-middleware': 0.87.0
+      debug: 4.4.3
+      invariant: 2.2.4
+      metro: 0.87.0
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/debugger-frontend@0.87.0': {}
+
+  '@react-native/debugger-shell@0.87.0':
+    dependencies:
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      fb-dotslash: 0.5.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/dev-middleware@0.87.0':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.87.0
+      '@react-native/debugger-shell': 0.87.0
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.3.0
+      connect: 3.7.0
+      debug: 4.4.3
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      open: 7.4.2
+      serve-static: 1.16.3
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/gradle-plugin@0.87.0': {}
+
+  '@react-native/normalize-colors@0.87.0': {}
+
+  '@react-native/virtualized-lists@0.87.0(@types/react@19.2.18)(react-native@0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 19.2.8
+      react-native: 0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -5152,6 +5789,8 @@ snapshots:
       '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@sinclair/typebox@0.27.12': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -5251,6 +5890,16 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -5278,6 +5927,12 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -5523,6 +6178,8 @@ snapshots:
 
   acorn@8.18.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -5545,6 +6202,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  anser@1.4.10: {}
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -5554,6 +6213,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -5638,6 +6299,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  asap@2.0.6: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -5656,9 +6319,15 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  babel-plugin-syntax-hermes-parser@0.36.1:
+    dependencies:
+      hermes-parser: 0.36.1
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.13: {}
 
@@ -5680,6 +6349,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -5700,6 +6371,12 @@ snapshots:
       electron-to-chromium: 1.5.403
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  bser@2.1.1:
+    dependencies:
+      node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
 
   bundle-name@4.1.0:
     dependencies:
@@ -5726,6 +6403,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@6.3.0: {}
+
   caniuse-lite@1.0.30001809: {}
 
   ccount@2.0.1: {}
@@ -5743,6 +6422,29 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  chrome-launcher@0.15.2:
+    dependencies:
+      '@types/node': 26.1.2
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  chromium-edge-launcher@0.3.0:
+    dependencies:
+      '@types/node': 26.1.2
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.4.2
+      mkdirp: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  ci-info@2.0.0: {}
+
+  ci-info@3.9.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -5754,6 +6456,12 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -5781,7 +6489,11 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@12.1.0: {}
+
   commander@14.0.3: {}
+
+  commander@2.20.3: {}
 
   concat-map@0.0.1: {}
 
@@ -5797,6 +6509,15 @@ snapshots:
       onetime: 5.1.2
       pkg-up: 3.1.0
       semver: 7.8.5
+
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   content-disposition@1.1.0: {}
 
@@ -5832,6 +6553,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@1.1.3:
+    dependencies:
+      mdn-data: 2.0.14
+      source-map: 0.6.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -5861,6 +6597,10 @@ snapshots:
   debounce-fn@4.0.0:
     dependencies:
       mimic-fn: 3.1.0
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@3.2.7:
     dependencies:
@@ -5903,6 +6643,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  destroy@1.2.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -5925,9 +6667,27 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-prop@6.0.1:
     dependencies:
@@ -5949,7 +6709,11 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  emoji-regex@8.0.0: {}
+
   emoji-regex@9.2.2: {}
+
+  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5963,6 +6727,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@4.5.0: {}
+
   entities@7.0.1: {}
 
   env-paths@2.2.1: {}
@@ -5970,6 +6736,10 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-abstract-get@1.0.0:
     dependencies:
@@ -6369,6 +7139,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
 
+  exponential-backoff@3.1.3: {}
+
   express-rate-limit@8.6.2(express@5.2.1):
     dependencies:
       debug: 4.4.3
@@ -6440,6 +7212,12 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fb-dotslash@0.5.8: {}
+
+  fb-watchman@2.0.2:
+    dependencies:
+      bser: 2.1.1
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -6457,6 +7235,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@2.1.1:
     dependencies:
@@ -6490,11 +7280,15 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  flow-enums-runtime@0.0.6: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -6545,6 +7339,8 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -6657,11 +7453,19 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
 
+  hermes-compiler@250829098.0.16: {}
+
   hermes-estree@0.25.1: {}
+
+  hermes-estree@0.36.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hermes-parser@0.36.1:
+    dependencies:
+      hermes-estree: 0.36.1
 
   hono@4.13.0: {}
 
@@ -6677,6 +7481,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.2.0: {}
 
   human-signals@2.1.0: {}
@@ -6690,6 +7501,10 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
 
   import-fresh@3.3.1:
     dependencies:
@@ -6705,6 +7520,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  invariant@2.2.4:
+    dependencies:
+      loose-envify: 1.4.0
 
   ip-address@10.4.0: {}
 
@@ -6769,6 +7588,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.2:
     dependencies:
@@ -6891,6 +7712,33 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jest-get-type@29.6.3: {}
+
+  jest-util@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 26.1.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      graceful-fs: 4.2.11
+      picomatch: 2.3.2
+
+  jest-validate@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      camelcase: 6.3.0
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      leven: 3.1.0
+      pretty-format: 29.7.0
+
+  jest-worker@29.7.0:
+    dependencies:
+      '@types/node': 26.1.2
+      jest-util: 29.7.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jiti@2.7.0: {}
 
   jose@6.2.8: {}
@@ -6909,6 +7757,8 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsc-safe-url@0.2.4: {}
 
   jsesc@3.1.0: {}
 
@@ -6963,10 +7813,19 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  leven@3.1.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lighthouse-logger@1.4.2:
+    dependencies:
+      debug: 2.6.9
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7038,6 +7897,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash.throttle@4.1.1: {}
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
@@ -7059,6 +7920,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  makeerror@1.0.12:
+    dependencies:
+      tmpl: 1.0.5
+
+  marky@1.3.0: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.1:
@@ -7073,13 +7940,190 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
+  mdn-data@2.0.14: {}
+
   media-typer@1.1.1: {}
+
+  memoize-one@5.2.1: {}
 
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  metro-babel-transformer@0.87.0:
+    dependencies:
+      '@babel/core': 7.29.7
+      flow-enums-runtime: 0.0.6
+      hermes-parser: 0.36.1
+      metro-cache-key: 0.87.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-cache-key@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-cache@0.87.0:
+    dependencies:
+      exponential-backoff: 3.1.3
+      flow-enums-runtime: 0.0.6
+      https-proxy-agent: 7.0.6
+      metro-core: 0.87.0
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-config@0.87.0:
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.87.0
+      metro-cache: 0.87.0
+      metro-core: 0.87.0
+      metro-runtime: 0.87.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro-core@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      lodash.throttle: 4.1.1
+      metro-resolver: 0.87.0
+
+  metro-file-map@0.87.0:
+    dependencies:
+      debug: 4.4.3
+      fb-watchman: 2.0.2
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      micromatch: 4.0.8
+      nullthrows: 1.1.1
+      walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-minify-terser@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      terser: 5.50.0
+
+  metro-resolver@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+
+  metro-runtime@0.87.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      flow-enums-runtime: 0.0.6
+
+  metro-source-map@0.87.0:
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-symbolicate: 0.87.0
+      nullthrows: 1.1.1
+      ob1: 0.87.0
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-symbolicate@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      metro-source-map: 0.87.0
+      nullthrows: 1.1.1
+      source-map: 0.5.7
+      vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-plugins@0.87.0:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      flow-enums-runtime: 0.0.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  metro-transform-worker@0.87.0:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      flow-enums-runtime: 0.0.6
+      metro: 0.87.0
+      metro-babel-transformer: 0.87.0
+      metro-cache: 0.87.0
+      metro-cache-key: 0.87.0
+      metro-minify-terser: 0.87.0
+      metro-source-map: 0.87.0
+      metro-transform-plugins: 0.87.0
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.87.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.36.1
+      image-size: 1.2.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.87.0
+      metro-cache: 0.87.0
+      metro-cache-key: 0.87.0
+      metro-config: 0.87.0
+      metro-core: 0.87.0
+      metro-file-map: 0.87.0
+      metro-resolver: 0.87.0
+      metro-runtime: 0.87.0
+      metro-source-map: 0.87.0
+      metro-symbolicate: 0.87.0
+      metro-transform-plugins: 0.87.0
+      metro-transform-worker: 0.87.0
+      mime-types: 3.0.2
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.13
+      yargs: 17.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -7109,6 +8153,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-fn@3.1.0: {}
@@ -7125,7 +8171,11 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mkdirp@1.0.4: {}
+
   mri@1.2.0: {}
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -7181,6 +8231,8 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-int64@0.4.0: {}
+
   node-releases@2.0.53: {}
 
   npm-run-path@4.0.1:
@@ -7191,6 +8243,16 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  nullthrows@1.1.1: {}
+
+  ob1@0.87.0:
+    dependencies:
+      flow-enums-runtime: 0.0.6
 
   object-assign@4.1.1: {}
 
@@ -7236,6 +8298,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7268,6 +8334,11 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   open@8.4.2:
     dependencies:
@@ -7431,9 +8502,19 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  promise@8.3.0:
+    dependencies:
+      asap: 2.0.6
 
   prompts@2.4.2:
     dependencies:
@@ -7466,6 +8547,12 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
+
+  range-parser@1.2.1: {}
+
   range-parser@1.3.0: {}
 
   raw-body@3.0.2:
@@ -7475,12 +8562,74 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
+  react-devtools-core@6.1.5:
+    dependencies:
+      shell-quote: 1.10.0
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
+
+  react-native-svg@15.15.5(react-native@0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
+    dependencies:
+      css-select: 5.2.2
+      css-tree: 1.1.3
+      react: 19.2.8
+      react-native: 0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+
+  react-native@0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8):
+    dependencies:
+      '@react-native/asset-utils': 0.87.0
+      '@react-native/codegen': 0.87.0(@babel/core@7.29.7)
+      '@react-native/community-cli-plugin': 0.87.0
+      '@react-native/gradle-plugin': 0.87.0
+      '@react-native/normalize-colors': 0.87.0
+      '@react-native/virtualized-lists': 0.87.0(@types/react@19.2.18)(react-native@0.87.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-plugin-syntax-hermes-parser: 0.36.1
+      base64-js: 1.5.1
+      commander: 12.1.0
+      flow-enums-runtime: 0.0.6
+      hermes-compiler: 250829098.0.16
+      invariant: 2.2.4
+      memoize-one: 5.2.1
+      metro-runtime: 0.87.0
+      metro-source-map: 0.87.0
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 19.2.8
+      react-devtools-core: 6.1.5
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.27.0
+      semver: 7.8.5
+      stacktrace-parser: 0.1.11
+      tinyglobby: 0.2.17
+      whatwg-fetch: 3.6.20
+      ws: 7.5.13
+      yargs: 17.7.3
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - '@react-native/metro-config'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.18)(react@19.2.8):
     dependencies:
@@ -7539,6 +8688,8 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regenerator-runtime@0.13.11: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -7557,6 +8708,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -7627,6 +8780,24 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -7640,6 +8811,17 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.3.0
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serialize-error@2.1.0: {}
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7756,6 +8938,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.10.0: {}
+
   shiki@4.4.2:
     dependencies:
       '@shikijs/core': 4.4.2
@@ -7805,6 +8989,13 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.5.7: {}
+
   source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -7818,6 +9009,14 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackframe@1.3.4: {}
+
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
+  statuses@1.5.0: {}
+
   statuses@2.0.2: {}
 
   stdin-discarder@0.2.2: {}
@@ -7826,6 +9025,12 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string-width@7.2.0:
     dependencies:
@@ -7922,6 +9127,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svelte@5.55.9(@typescript-eslint/types@8.66.0):
@@ -7955,12 +9164,23 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser@5.50.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.18.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  throat@5.0.0: {}
+
   tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8007,6 +9227,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.7.1: {}
 
   type-is@2.1.0:
     dependencies:
@@ -8160,6 +9382,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utils-merge@1.0.1: {}
+
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
@@ -8174,6 +9398,8 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vlq@1.0.1: {}
+
   vue@3.5.30(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.30
@@ -8184,9 +9410,15 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  walker@1.0.8:
+    dependencies:
+      makeerror: 1.0.12
+
   web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
+
+  whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
     dependencies:
@@ -8244,14 +9476,36 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
+
+  ws@7.5.13: {}
 
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
New package: `@thesvg/react-native`, a React Native / Expo compatible icon component library for all 6,509 icons.

## Architecture

Deliberately does NOT follow `@thesvg/react`'s inline-JSX-per-icon pattern (React DOM's native lowercase SVG tag support doesn't exist in React Native). Instead mirrors `lucide-react-native`'s approach, which is the current standard for large RN icon sets:

- Each icon is lightweight **data**: a `[tagName, props, children]` tuple tree, not a hand-written component
- ONE shared runtime (`createIcon.ts`) resolves tag names against `react-native-svg`'s exports (`Svg, Path, Circle, G, Defs, LinearGradient, ClipPath, Mask, Text, ...`) and renders
- `react-native-svg >=13` as the sole peer dependency (still the standard in 2026, Turbo Module native, works in Expo Go with no config plugin)
- Ships both a barrel (`index`) and per-icon subpaths (`@thesvg/react-native/icons/github`) since barrel-only tree-shaking isn't reliable at this icon count

## Verification

- Generator ran for real: 6,509 icons built, 0 missing SVG source
- `tsc --noEmit` passes with zero errors across all 6,509 generated `.d.ts` files
- Structural + variant-coverage validator passes on all 6,509 icons
- Built a runtime smoke test (stubbed `react-native-svg` since it needs Metro/Flow-stripping to run standalone) covering variant switching, color/size shorthand props, ref forwarding, and deep `defs`/gradient/clipPath trees
- Spot-checked 10+ icons across complexity levels by reading raw generated output (simple mono, multi-color/gradient, `clipPath`/`mask` usage, `<style>`-block, `<text>`/`<tspan>` wordmark)

Fixed 3 real bugs found during verification (not simulated): a JSDoc comment that broke the script's own syntax, a quote-handling regex bug that truncated attribute values containing an embedded single quote, and a `filter:url(#x)` leak via inline `style="..."` strings.

## Known limitation (pre-existing, shared with @thesvg/react)

SVGs using CSS class-based coloring (`<style>.st0{fill:#231F20}</style>` + `class="st0"`) lose their per-path colors, since both packages strip `<style>` blocks and drop `class`. Confirmed this already affects `@thesvg/react` too (~350 of 6,509 source files), not something newly introduced here. Flagging as a possible follow-up, not blocking this PR.

## Boundaries respected

Did not touch `packages/react`, `packages/vue`, `packages/svelte`, or `src/app`. Registered the new package via `.changeset/config.json`'s linked release group; root `package.json`/`pnpm-workspace.yaml` needed no changes since `packages/*` already globs new packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `@thesvg/react-native` package for using icons in React Native and Expo applications.
  * Supports barrel and per-icon imports, typed variants, forwarded refs, and standard icon properties.
  * Generates ESM, CommonJS, and TypeScript declaration outputs for available icons.

* **Documentation**
  * Added comprehensive setup, usage, compatibility, naming, and licensing documentation.

* **Validation**
  * Added checks to ensure generated distributions are valid and compatible with React Native.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->