### PR TITLE
chore: add missing changeset for @thesvg/react-native

### DIFF
--- a/.changeset/add-react-native-package.md
+++ b/.changeset/add-react-native-package.md
@@ -1,0 +1,10 @@
+---
+"@thesvg/react-native": minor
+"@thesvg/icons": patch
+"thesvg": patch
+"@thesvg/react": patch
+"@thesvg/vue": patch
+"@thesvg/svelte": patch
+---
+
+Add @thesvg/react-native: typed, tree-shakeable icon components for React Native and Expo, backed by react-native-svg.


### PR DESCRIPTION
The `Version` workflow run after #887 merged reported "No changesets present" and `No publishable package changes detected`, so no version PR was ever opened and `@thesvg/react-native` never actually got published to npm despite being merged.

Added the changeset by hand (verified via `pnpm exec changeset status`: correctly bumps the whole linked group, including `@thesvg/react-native`, at minor). Should trigger a proper version PR on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed, tree-shakeable icon components for React Native and Expo.
  * Added support for rendering icons with `react-native-svg`.

* **Chores**
  * Prepared package releases for the React Native, icons, and framework integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->