### PR TITLE
fix: blog code blocks with internal blank lines render as raw HTML

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -70,10 +70,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 function processInline(text: string): string {
   return text
     .replace(/\*\*(.+?)\*\*/g, '<strong class="font-semibold text-foreground">$1</strong>')
-    .replace(
-      /`(.+?)`/g,
-      '<code class="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] dark:bg-white/[0.06]">$1</code>'
-    )
+    .replace(/`(.+?)`/g, (_match, code: string) => {
+      const escaped = code.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      return `<code class="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] dark:bg-white/[0.06]">${escaped}</code>`;
+    })
     .replace(
       /\[(.+?)\]\((.+?)\)/g,
       '<a href="$2" class="text-orange-500 underline underline-offset-2 hover:text-orange-400">$1</a>'
@@ -81,16 +81,30 @@ function processInline(text: string): string {
 }
 
 function renderMarkdown(body: string): string {
-  return body
+  // Fenced code blocks can contain blank lines (e.g. between a variable
+  // declaration and a function), which would otherwise get cut in half by
+  // the paragraph split below, before the fence is ever recognized. Pull
+  // every fenced block out up front (matched across the whole body, not
+  // per-paragraph) and swap in a placeholder that can't itself contain a
+  // blank line, so splitting the remainder into paragraphs can't slice
+  // through a fence. The extracted code is escaped and rendered here, then
+  // spliced back in after the paragraph pass.
+  const codeBlocks: string[] = [];
+  const withPlaceholders = body.replace(/```[a-z]*\n([\s\S]*?)\n```/g, (_match, code: string) => {
+    const html = `<pre class="my-4 overflow-x-auto rounded-xl border border-border/40 bg-muted/30 p-4 font-mono text-xs text-foreground dark:border-white/[0.06] dark:bg-white/[0.03]"><code>${code.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</code></pre>`;
+    codeBlocks.push(html);
+    return ` CODEBLOCK${codeBlocks.length - 1} `;
+  });
+
+  return withPlaceholders
     .split("\n\n")
     .map((block) => {
       if (block.startsWith("## ")) {
         return `<h2 class="mt-8 mb-3 text-xl font-bold tracking-tight text-foreground">${block.slice(3)}</h2>`;
       }
-      if (block.startsWith("```")) {
-        const lines = block.split("\n");
-        const code = lines.slice(1, -1).join("\n");
-        return `<pre class="my-4 overflow-x-auto rounded-xl border border-border/40 bg-muted/30 p-4 font-mono text-xs text-foreground dark:border-white/[0.06] dark:bg-white/[0.03]"><code>${code.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</code></pre>`;
+      const codeBlockMatch = block.match(/^ CODEBLOCK(\d+) $/);
+      if (codeBlockMatch) {
+        return codeBlocks[Number(codeBlockMatch[1])];
       }
       if (block.includes("\n- ")) {
         const items = block.split("\n").filter((l) => l.startsWith("- "));


### PR DESCRIPTION
Reported live on /blog/dark-mode-logo-wall-guide, the "Putting it together" section's code block was rendering as literal broken HTML/a broken image icon instead of code text.

## Root cause

The markdown renderer split the whole post body by blank lines (`\n\n`) before ever detecting fenced code blocks. A fence containing a blank line internally (e.g. between a variable declaration and a function, completely normal markdown) got cut in half by that split. The trailing half fell through to the plain-paragraph rendering branch, which intentionally passes raw HTML through unescaped (used elsewhere for inline image galleries, e.g. the Google 2026 post), so the leaked JSX rendered as literal tags.

Also found and fixed the same class of bug in inline single-backtick code spans (e.g. `` `<picture>` `` mentioned in prose), which didn't escape their contents either.

## Fix

Extract every fenced code block from the full body up front via a regex that spans newlines, before the paragraph split, swap in placeholders that can't themselves contain a blank line so the split can't slice through a fence, then splice the pre-rendered (properly escaped) code block HTML back in afterward.

## Verification

Tested the actual render logic (not a rewritten approximation) against all 13 existing posts:
- No unmatched fences in any post
- The previously-broken section now renders as an escaped `&lt;picture&gt;` block instead of a live element
- The intentional raw-HTML-in-prose posts (inline image galleries) still render unescaped as before, confirmed via the real built static output (`.next/server/app/blog/*.html`), not just the source logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown code block rendering.
  * Preserved fenced code blocks containing blank lines.
  * Escaped angle brackets in inline and fenced code to display code safely and accurately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->