### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,11 +300,11 @@ If you are a brand owner and would like an icon updated or removed, please [open
 
 ## Star History
 
-<a href="https://star-history.com/#glincker/thesvg&Date">
+<a href="https://star-history.dera.page/#glincker/thesvg&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=glincker/thesvg&type=Date" width="600" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=glincker/thesvg&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=glincker/thesvg&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=glincker/thesvg&type=Date" width="600" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This updates the chart links to use the working mirror hosted at star-history.dera.page so the chart renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links and image sources to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->