### PR TITLE
fix: correct iCloud icon url to point to icloud.com

### DIFF
--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -69204,7 +69204,7 @@
       "mono": "/icons/icloud/mono.svg"
     },
     "license": "CC0-1.0",
-    "url": "https://commons.wikimedia.org/wiki/File:ICloud_logo.svg",
+    "url": "https://www.icloud.com",
     "dateAdded": "2026-03-07",
     "collection": "brands"
   },


### PR DESCRIPTION
Closes #924

The iCloud icon metadata url pointed to the Wikimedia Commons source page instead of the brand's own site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the iCloud icon link to direct users to the official iCloud website.
  * Corrected Zero icon metadata and removed a duplicate entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->