### PR TITLE
fix: remove duplicate zero icon entry from icons.json

### DIFF
--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -123645,12 +123645,12 @@
     "variants": {
       "default": "/icons/zero/default.svg",
       "mono": "/icons/zero/mono.svg",
-      "wordmark-dark": "/icons/zero/wordmark-dark.svg",
-      "wordmark-light": "/icons/zero/wordmark-light.svg"
+      "wordmarkDark": "/icons/zero/wordmark-dark.svg",
+      "wordmarkLight": "/icons/zero/wordmark-light.svg"
     },
     "license": "MIT",
     "url": "https://zerolifestyle.co/",
-    "dateAdded": "2026-03-07",
+    "dateAdded": "2026-08-22",
     "collection": "brands"
   },
   {
@@ -124186,26 +124186,6 @@
     "license": "MIT",
     "url": "https://zyft.com",
     "dateAdded": "2026-03-07",
-    "collection": "brands"
-  },
-  {
-    "slug": "zero",
-    "title": "Zero",
-    "aliases": [],
-    "hex": "000000",
-    "categories": [
-      "Software",
-      "Platform"
-    ],
-    "variants": {
-      "default": "/icons/zero/default.svg",
-      "mono": "/icons/zero/mono.svg",
-      "wordmarkDark": "/icons/zero/wordmark-dark.svg",
-      "wordmarkLight": "/icons/zero/wordmark-light.svg"
-    },
-    "license": "MIT",
-    "url": "https://zerolifestyle.co/",
-    "dateAdded": "2026-08-22",
     "collection": "brands"
   },
   {


### PR DESCRIPTION
A squash-merge landed a stale duplicate `zero` entry out of alphabetical order (near `zyft`, with outdated kebab-case variant keys), tripping the Validate SVG workflow's icons.json structure check on unrelated PRs (surfaced on #934).

Kept the correctly-positioned entry with the current camelCase `wordmarkDark`/`wordmarkLight` keys and the more accurate `dateAdded`. Removed the misplaced duplicate.

Verified against the same validation logic CI runs: no duplicate slugs, alphabetical order intact, all 6519 entries valid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Zero icon’s variant names for consistent access.
  * Updated the Zero icon’s listing date.
  * Removed a duplicate Zero icon entry to prevent redundant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->