### PR TITLE
fix: rename changesets/action@v2 inputs to current names

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Create Version PR
         uses: changesets/action@v2
         with:
-          commit: "chore(release): version packages"
-          title: "chore(release): version packages"
+          commit-message: "chore(release): version packages"
+          pr-title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Release - Version workflow was failing on every push to main:

```
Warning: Unexpected input(s) 'commit', 'title', valid inputs are [...]
Error: The following inputs have been renamed:
- "commit" -> "commit-message"
- "title" -> "pr-title"
```

changesets/action@v2 renamed these inputs at some point; ours were still using the old names. Renamed to match, no behavior change intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release workflow settings to use the current commit message and pull request title configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->