### PR TITLE
ci: validate GitHub Actions workflows with actionlint on PRs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,23 @@
+name: Actionlint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+concurrency:
+  group: actionlint-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Validate workflow files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@49cb3ce06e5d81452e14b38ad34e4b12a8acfe2b # v1.73.3
         with:
           fail_level: error


### PR DESCRIPTION
Adds an actionlint check that runs on any PR touching `.github/workflows/**`. Catches invalid/renamed action inputs, bad expression syntax, and shellcheck issues in `run:` blocks before they land on main.

Direct motivation: #938 fixed `changesets/action@v2`'s renamed `commit`/`title` inputs, which had been silently breaking the Release - Version workflow on every push to main. This check would have caught it at PR time instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated validation for workflow configuration changes.
  * Pull requests modifying workflow files are now checked for errors, helping identify issues before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->