### PR TITLE
fix: bump Release - Version workflow to Node 22

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   version:


### PR DESCRIPTION
The Release - Version workflow has been failing on every push to main since #928 bumped `@changesets/cli` to 3.0.1:

```
TypeError: enableCompileCache is not a function
    at .../@changesets/cli/bin.js:6:3
```

That's `node:module`'s `enableCompileCache`, added in Node 22.1. `version.yml` was still pinned to Node 20; `release.yml` already runs Node 22 for the same dependency. Bumped to match.

Net effect: no Version Packages PR has gone out since Aug 31, so nothing from that point (including today's icon additions and CI fixes) has reached npm/GitHub releases yet. Once this merges, the next push to main should generate a fresh Version PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version release process to run with Node.js 22 for improved runtime support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->