### PR TITLE
chore: add catch-up changeset for silently-failed release pipeline

### DIFF
--- a/.changeset/catch-up-2026-09-01.md
+++ b/.changeset/catch-up-2026-09-01.md
@@ -1,0 +1,24 @@
+---
+"@thesvg/icons": patch
+"@thesvg/react": patch
+"@thesvg/vue": patch
+"@thesvg/svelte": patch
+"thesvg": patch
+"@thesvg/cli": patch
+"@thesvg/mcp-server": patch
+---
+
+Catch up the release pipeline after the Release - Version workflow was
+silently failing on every push since 2026-08-20 (`@changesets/cli` 3.x
+requires Node 22, the workflow was still pinned to Node 20 - fixed in
+#942). Each failed run generated a changeset in its own ephemeral
+checkout that was never committed, so nothing accumulated for the last
+~11 merges. This changeset consolidates them:
+
+- Added Weavefox, Sive, Brevitas, Zero, Orildo, Prusa Research,
+  lifesight-light, decathlon-logo, Rilian, Zapal, MeetAndy, and
+  Farmsent icons
+- Fixed the outdated Zod logo
+- Fixed a duplicate `zero` icons.json entry introduced by a
+  squash-merge race
+- Fixed the iCloud icon's metadata URL


### PR DESCRIPTION
Discovered while checking why no GitHub release has gone out since Aug 16 (`thesvg v3.3.1`): the Release - Version workflow has been failing on every push touching packages since **2026-08-20**, not just since #928 as I first thought. `@changesets/cli` went 2.31.1 -> 3.0.0 in #901 (Aug 20), and that version already requires Node 22's `enableCompileCache`. #942 fixed the workflow's Node version, but each of the ~11 failed runs generated its changeset in an ephemeral checkout that was never committed - so nothing accumulated for the pipeline to version.

This adds one hand-written changeset consolidating everything unreleased since `518e90a5` (the #896 release commit): 11 icon/fix PRs across icons, react, vue, svelte, thesvg, cli, and mcp packages. Verified with `pnpm exec changeset status --verbose` - resolves to a clean patch bump on all 7 packages (3.3.1 -> 3.3.2 for the icon/framework packages, 0.7.1 -> 0.7.2 for cli, 0.8.1 -> 0.8.2 for mcp).

Once this merges, the next Release - Version run should open a real `chore(release): version packages` PR. Merging *that* PR is what actually triggers npm publish + the GitHub release (needs `npm-publish` environment approval, per usual).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icons for Weavefox, Sive, Brevitas, Zero, Orildo, Prusa Research, Lifesight, Decathlon, Rilian, Zapal, MeetAndy, and Farmsent.
  * Made the new icons available across supported SVG, React, Vue, Svelte, CLI, and MCP packages.

* **Bug Fixes**
  * Updated the outdated Zod logo.
  * Removed a duplicate Zero icon entry.
  * Corrected the iCloud icon metadata URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->