### PR TITLE
feat: add draw.io shape libraries for brand and dev-tool icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ CLAUDE.md
 # generated API files (built from icons.json at build time)
 public/api/
 
+# generated draw.io shape libraries (built from icons.json at build time)
+public/integrations/drawio/
+
 # marketing assets (exported PNGs - too large for OSS repo)
 public/banners/
 posthog-setup-report.md

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "lsof -ti:3333 | xargs kill -9 2>/dev/null; next dev --port 3333",
-    "build": "tsx src/scripts/generate-api.ts && next build",
+    "build": "tsx src/scripts/generate-api.ts && tsx src/scripts/generate-drawio-libraries.ts && next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -188,6 +188,15 @@ const CATEGORIES: Category[] = [
         href: "https://www.jsdelivr.com/package/gh/glincker/thesvg",
         iconSlug: "framer",
       },
+      {
+        name: "draw.io / diagrams.net",
+        description:
+          "Category-based shape libraries of brand and dev-tool icons for architecture diagrams. Complements draw.io's built-in AWS, Azure, GCP, and Kubernetes libraries.",
+        status: "available",
+        cta: "Browse libraries",
+        href: "/integrations/drawio",
+        iconSlug: "diagramsdotnet",
+      },
     ],
   },
   {

--- a/src/app/integrations/drawio/page.tsx
+++ b/src/app/integrations/drawio/page.tsx
@@ -1,0 +1,143 @@
+import { Suspense } from "react";
+import { Download, FolderTree, ListChecks } from "lucide-react";
+import type { Metadata } from "next";
+import { getAllIcons, getCategoryCounts } from "@/lib/icons";
+import { DRAWIO_LIBRARIES, getIconsForDrawioLibrary, type DrawioLibraryDef } from "@/lib/drawio-libraries";
+import { SidebarShell } from "@/components/layout/sidebar-shell";
+
+export const metadata: Metadata = {
+  title: "draw.io / diagrams.net Shape Libraries - Free Brand Icons",
+  description:
+    "Download free custom shape libraries of brand and dev-tool logos for draw.io / diagrams.net, grouped by category. Drop them into architecture and software diagrams alongside the built-in AWS, Azure, GCP, and Kubernetes libraries.",
+  keywords: [
+    "draw.io shape library",
+    "diagrams.net custom shapes",
+    "draw.io brand icons",
+    "draw.io stencils",
+    "architecture diagram icons",
+    "draw.io logo library",
+    "diagrams.net icon library",
+  ],
+  openGraph: {
+    title: "draw.io / diagrams.net Shape Libraries | theSVG",
+    description: `${DRAWIO_LIBRARIES.length} category-based shape libraries of brand and dev-tool icons for draw.io / diagrams.net architecture diagrams.`,
+    siteName: "theSVG",
+  },
+  alternates: { canonical: "https://thesvg.org/integrations/drawio" },
+};
+
+const IMPORT_STEPS = [
+  "Open draw.io (or diagrams.net) with a diagram you're working on.",
+  "At the bottom of the left-hand Shapes panel, click the grid icon labeled \"More Shapes\".",
+  "In the dialog that opens, scroll down and choose \"Open Library from Device...\".",
+  "Pick the downloaded .xml file for the category you want.",
+  "The icons appear as a new panel in the left sidebar, ready to drag onto the canvas.",
+];
+
+function DrawioLibraryCard({ lib, count }: { lib: DrawioLibraryDef; count: number }) {
+  return (
+    <div className="group relative flex flex-col rounded-xl border border-border/40 bg-card/30 p-5 transition-all duration-200 hover:border-border/70 hover:bg-card/60 hover:shadow-xl hover:shadow-black/5 dark:border-white/[0.06] dark:bg-white/[0.02] dark:hover:border-white/[0.1] dark:hover:bg-white/[0.04] dark:hover:shadow-black/40">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted/80 text-foreground/80">
+          <FolderTree className="h-5 w-5" />
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          {count} {count === 1 ? "icon" : "icons"}
+        </span>
+      </div>
+
+      <h3 className="mb-1.5 text-sm font-semibold">{lib.label}</h3>
+      <p className="mb-5 flex-1 text-[13px] leading-relaxed text-muted-foreground">
+        {lib.label} brand and tool logos, ready to drag onto your diagram.
+      </p>
+
+      <a
+        href={`/integrations/drawio/${lib.slug}.xml`}
+        download
+        className="group/link inline-flex w-fit items-center gap-1.5 text-xs font-medium text-foreground/70 transition-colors hover:text-foreground"
+      >
+        <Download className="h-3.5 w-3.5 opacity-50 transition-opacity group-hover/link:opacity-100" />
+        Download .xml
+      </a>
+    </div>
+  );
+}
+
+export default function DrawioIntegrationPage() {
+  const categoryCounts = getCategoryCounts();
+  const allIcons = getAllIcons();
+
+  return (
+    <Suspense>
+      <SidebarShell categoryCounts={categoryCounts}>
+        <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+          {/* Header */}
+          <div className="mb-8 flex items-center gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-muted/80">
+              <img
+                src="/icons/diagramsdotnet/default.svg"
+                alt=""
+                width={28}
+                height={28}
+                className="h-7 w-7"
+              />
+            </div>
+            <div>
+              <h1 className="mb-1 text-2xl font-bold sm:text-3xl">
+                draw.io / diagrams.net Shape Libraries
+              </h1>
+              <p className="text-muted-foreground">
+                Brand and dev-tool icons, ready to drop into your diagrams.
+              </p>
+            </div>
+          </div>
+
+          {/* Intro */}
+          <p className="mb-10 max-w-3xl text-sm leading-relaxed text-muted-foreground">
+            These are downloadable custom shape libraries built from theSVG&apos;s brand icon
+            catalog, grouped by category, for use in draw.io / diagrams.net architecture and
+            software diagrams. draw.io already ships built-in libraries for AWS, Azure, GCP, and
+            Kubernetes, so these libraries cover the brand and developer-tool logos those
+            don&apos;t include: languages, frameworks, databases, CI/CD tools, and more.
+          </p>
+
+          {/* How to import */}
+          <div className="mb-12 overflow-hidden rounded-xl border border-border/40 bg-card/30 dark:border-white/[0.06] dark:bg-white/[0.02]">
+            <div className="p-6 sm:p-8">
+              <div className="mb-4 flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted/80 text-foreground/80">
+                  <ListChecks className="h-5 w-5" />
+                </div>
+                <h2 className="text-lg font-semibold">How to import a library</h2>
+              </div>
+              <ol className="ml-[38px] space-y-2 text-sm text-muted-foreground">
+                {IMPORT_STEPS.map((step, i) => (
+                  <li key={step} className="flex gap-3">
+                    <span className="shrink-0 font-mono text-xs text-foreground/50">
+                      {i + 1}.
+                    </span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          </div>
+
+          {/* Libraries grid */}
+          <section>
+            <h2 className="mb-5 text-base font-semibold">{DRAWIO_LIBRARIES.length} category libraries</h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {DRAWIO_LIBRARIES.map((lib) => (
+                <DrawioLibraryCard
+                  key={lib.slug}
+                  lib={lib}
+                  count={getIconsForDrawioLibrary(allIcons, lib).length}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+      </SidebarShell>
+    </Suspense>
+  );
+}

--- a/src/app/integrations/drawio/page.tsx
+++ b/src/app/integrations/drawio/page.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from "react";
 import { Download, FolderTree, ListChecks } from "lucide-react";
 import type { Metadata } from "next";
-import { getAllIcons, getCategoryCounts } from "@/lib/icons";
-import { DRAWIO_LIBRARIES, getIconsForDrawioLibrary, type DrawioLibraryDef } from "@/lib/drawio-libraries";
+import { getCategoryCounts } from "@/lib/icons";
+import { DRAWIO_LIBRARIES, type DrawioLibraryDef } from "@/lib/drawio-libraries";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
+import libraryCounts from "@/data/drawio-library-counts.json";
 
 export const metadata: Metadata = {
   title: "draw.io / diagrams.net Shape Libraries - Free Brand Icons",
@@ -65,7 +66,7 @@ function DrawioLibraryCard({ lib, count }: { lib: DrawioLibraryDef; count: numbe
 
 export default function DrawioIntegrationPage() {
   const categoryCounts = getCategoryCounts();
-  const allIcons = getAllIcons();
+  const counts = libraryCounts as Record<string, number>;
 
   return (
     <Suspense>
@@ -131,7 +132,7 @@ export default function DrawioIntegrationPage() {
                 <DrawioLibraryCard
                   key={lib.slug}
                   lib={lib}
-                  count={getIconsForDrawioLibrary(allIcons, lib).length}
+                  count={counts[lib.slug] ?? 0}
                 />
               ))}
             </div>

--- a/src/data/drawio-library-counts.json
+++ b/src/data/drawio-library-counts.json
@@ -1,0 +1,14 @@
+{
+  "developer-tools": 769,
+  "ai": 291,
+  "finance": 131,
+  "database": 86,
+  "networking": 6,
+  "security": 37,
+  "analytics": 43,
+  "iot": 9,
+  "framework": 120,
+  "storage": 2,
+  "design": 115,
+  "language": 96
+}

--- a/src/lib/drawio-libraries.ts
+++ b/src/lib/drawio-libraries.ts
@@ -1,0 +1,42 @@
+import { ARCHITECTURE_COLLECTIONS, type IconEntry } from "@/lib/icons";
+
+/**
+ * Category groupings for the draw.io / diagrams.net shape libraries.
+ * Shared by the build-time generator (src/scripts/generate-drawio-libraries.ts)
+ * and the /integrations/drawio listing page so counts never drift from the
+ * actual generated files.
+ *
+ * Cloud architecture collections (aws/azure/gcp/k8s) are excluded: draw.io
+ * already ships those as built-in shape libraries, so duplicating them here
+ * adds no value. `categories` is matched case-insensitively against each
+ * icon's `categories` array to merge the "Devtool"/"DevTool" casing split
+ * in the source data.
+ */
+export interface DrawioLibraryDef {
+  slug: string;
+  label: string;
+  categories: string[];
+}
+
+export const DRAWIO_LIBRARIES: DrawioLibraryDef[] = [
+  { slug: "developer-tools", label: "Developer Tools", categories: ["devtool"] },
+  { slug: "ai", label: "AI", categories: ["ai"] },
+  { slug: "finance", label: "Finance", categories: ["finance"] },
+  { slug: "database", label: "Database", categories: ["database"] },
+  { slug: "networking", label: "Networking", categories: ["networking"] },
+  { slug: "security", label: "Security", categories: ["security"] },
+  { slug: "analytics", label: "Analytics", categories: ["analytics"] },
+  { slug: "iot", label: "IoT", categories: ["iot"] },
+  { slug: "framework", label: "Framework", categories: ["framework"] },
+  { slug: "storage", label: "Storage", categories: ["storage"] },
+  { slug: "design", label: "Design", categories: ["design"] },
+  { slug: "language", label: "Language", categories: ["language"] },
+];
+
+export function getIconsForDrawioLibrary(icons: IconEntry[], lib: DrawioLibraryDef): IconEntry[] {
+  const wanted = new Set(lib.categories.map((c) => c.toLowerCase()));
+  return icons.filter((icon) => {
+    if (ARCHITECTURE_COLLECTIONS.has(icon.collection)) return false;
+    return icon.categories.some((c) => wanted.has(c.toLowerCase()));
+  });
+}

--- a/src/scripts/generate-drawio-libraries.ts
+++ b/src/scripts/generate-drawio-libraries.ts
@@ -20,7 +20,7 @@
  * values nested inside a JSON string) from colliding.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync, realpathSync } from "fs";
 import { join, resolve, sep } from "path";
 import { DRAWIO_LIBRARIES, getIconsForDrawioLibrary } from "@/lib/drawio-libraries";
 import type { IconEntry } from "@/lib/icons";
@@ -65,7 +65,15 @@ function buildShapeEntry(icon: IconEntry): DrawioShapeEntry | null {
   if (!absPath.startsWith(ICONS_DIR)) {
     throw new Error(`variant path "${svgPath}" resolves outside public/icons/, refusing to read`);
   }
-  const svg = readFileSync(absPath, "utf-8");
+  // realpathSync (not just resolve) so a symlink under public/icons/ pointing
+  // outside it can't be used to smuggle an arbitrary file into the generated
+  // public XML - resolve() only normalizes the path string, it doesn't
+  // follow symlinks.
+  const realPath = realpathSync(absPath);
+  if (!realPath.startsWith(ICONS_DIR)) {
+    throw new Error(`variant path "${svgPath}" resolves (via symlink) outside public/icons/, refusing to read`);
+  }
+  const svg = readFileSync(realPath, "utf-8");
 
   const { w, h } = getAspectDims(svg);
   const base64 = Buffer.from(svg, "utf-8").toString("base64");

--- a/src/scripts/generate-drawio-libraries.ts
+++ b/src/scripts/generate-drawio-libraries.ts
@@ -21,14 +21,16 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "fs";
-import { join } from "path";
+import { join, resolve, sep } from "path";
 import { DRAWIO_LIBRARIES, getIconsForDrawioLibrary } from "@/lib/drawio-libraries";
 import type { IconEntry } from "@/lib/icons";
 
 const ROOT = join(__dirname, "../..");
 const ICONS_JSON = join(ROOT, "src/data/icons.json");
 const PUBLIC_DIR = join(ROOT, "public");
+const ICONS_DIR = resolve(PUBLIC_DIR, "icons") + sep;
 const OUTPUT_DIR = join(ROOT, "public/integrations/drawio");
+const COUNTS_PATH = join(ROOT, "src/data/drawio-library-counts.json");
 
 interface DrawioShapeEntry {
   xml: string;
@@ -59,7 +61,10 @@ function buildShapeEntry(icon: IconEntry): DrawioShapeEntry | null {
   const svgPath = icon.variants.default;
   if (!svgPath) return null;
 
-  const absPath = join(PUBLIC_DIR, svgPath);
+  const absPath = resolve(PUBLIC_DIR, `.${svgPath}`);
+  if (!absPath.startsWith(ICONS_DIR)) {
+    throw new Error(`variant path "${svgPath}" resolves outside public/icons/, refusing to read`);
+  }
   const svg = readFileSync(absPath, "utf-8");
 
   const { w, h } = getAspectDims(svg);
@@ -80,6 +85,7 @@ function main() {
   mkdirSync(OUTPUT_DIR, { recursive: true });
 
   let totalSkipped = 0;
+  const counts: Record<string, number> = {};
 
   for (const lib of DRAWIO_LIBRARIES) {
     const matched = getIconsForDrawioLibrary(icons, lib);
@@ -111,8 +117,15 @@ function main() {
     const sizeKb = (Buffer.byteLength(contents, "utf-8") / 1024).toFixed(1);
     console.log(`  ${lib.label} (${lib.slug}.xml): ${entries.length} icons, ${sizeKb} KB${skipped ? `, ${skipped} skipped` : ""}`);
 
+    counts[lib.slug] = entries.length;
     totalSkipped += skipped;
   }
+
+  // Committed (not gitignored) so the page can show the actual generated
+  // count without re-running this script, and so the count can never
+  // silently diverge from what a downloaded library file really contains
+  // if a future icon fails conversion.
+  writeFileSync(COUNTS_PATH, JSON.stringify(counts, null, 2) + "\n", "utf-8");
 
   console.log(`draw.io library generation complete.${totalSkipped ? ` ${totalSkipped} icons skipped total.` : ""}`);
 }

--- a/src/scripts/generate-drawio-libraries.ts
+++ b/src/scripts/generate-drawio-libraries.ts
@@ -1,0 +1,120 @@
+/**
+ * Generates draw.io / diagrams.net custom shape library XML files in
+ * public/integrations/drawio/, one per curated category defined in
+ * src/lib/drawio-libraries.ts.
+ *
+ * Run: npx tsx src/scripts/generate-drawio-libraries.ts
+ *
+ * Outputs:
+ *   public/integrations/drawio/{slug}.xml - one draw.io shape library per
+ *   entry in DRAWIO_LIBRARIES, each wrapping a JSON array of shape defs in
+ *   an <mxlibrary> tag (the format draw.io's "Edit Diagram > Edit Library"
+ *   / custom library import expects).
+ *
+ * Each shape's `xml` field embeds the icon's default-variant SVG as a
+ * base64 data URI inside an mxCell image shape. Base64 output never
+ * contains characters that need XML or JSON escaping (its alphabet is
+ * limited to A-Z, a-z, 0-9, +, /, =), so the only escaping JSON.stringify
+ * has to do is around the surrounding XML's literal double quotes - which
+ * it handles automatically. That keeps the two encodings (XML attribute
+ * values nested inside a JSON string) from colliding.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "fs";
+import { join } from "path";
+import { DRAWIO_LIBRARIES, getIconsForDrawioLibrary } from "@/lib/drawio-libraries";
+import type { IconEntry } from "@/lib/icons";
+
+const ROOT = join(__dirname, "../..");
+const ICONS_JSON = join(ROOT, "src/data/icons.json");
+const PUBLIC_DIR = join(ROOT, "public");
+const OUTPUT_DIR = join(ROOT, "public/integrations/drawio");
+
+interface DrawioShapeEntry {
+  xml: string;
+  w: number;
+  h: number;
+  title: string;
+  aspect: "fixed";
+}
+
+/** Extracts width/height from an SVG's viewBox attribute; falls back to 1:1. */
+function getAspectDims(svg: string): { w: number; h: number } {
+  const match = svg.match(/viewBox=["']([^"']+)["']/);
+  const FALLBACK = { w: 48, h: 48 };
+  if (!match) return FALLBACK;
+
+  const parts = match[1].trim().split(/\s+/).map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return FALLBACK;
+
+  const [, , vbWidth, vbHeight] = parts;
+  if (!vbWidth || !vbHeight) return FALLBACK;
+
+  const h = 48;
+  const w = Math.round(48 * (vbWidth / vbHeight));
+  return { w, h };
+}
+
+function buildShapeEntry(icon: IconEntry): DrawioShapeEntry | null {
+  const svgPath = icon.variants.default;
+  if (!svgPath) return null;
+
+  const absPath = join(PUBLIC_DIR, svgPath);
+  const svg = readFileSync(absPath, "utf-8");
+
+  const { w, h } = getAspectDims(svg);
+  const base64 = Buffer.from(svg, "utf-8").toString("base64");
+
+  const xml = `<mxGraphModel><root><mxCell style="shape=image;html=1;image=data:image/svg+xml;base64,${base64};" vertex="1"><mxGeometry width="${w}" height="${h}" as="geometry"/></mxCell></root></mxGraphModel>`;
+
+  return { xml, w, h, title: icon.title, aspect: "fixed" };
+}
+
+function main() {
+  const icons: IconEntry[] = JSON.parse(readFileSync(ICONS_JSON, "utf-8"));
+
+  // Clean previous output and ensure directory
+  if (existsSync(OUTPUT_DIR)) {
+    rmSync(OUTPUT_DIR, { recursive: true });
+  }
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  let totalSkipped = 0;
+
+  for (const lib of DRAWIO_LIBRARIES) {
+    const matched = getIconsForDrawioLibrary(icons, lib);
+    const entries: DrawioShapeEntry[] = [];
+    let skipped = 0;
+
+    for (const icon of matched) {
+      try {
+        const entry = buildShapeEntry(icon);
+        if (!entry) {
+          skipped++;
+          continue;
+        }
+        // Round-trip through JSON.stringify per-entry to guarantee the icon's
+        // title/slug can't produce a malformed library file (e.g. unpaired
+        // surrogate code points).
+        JSON.stringify(entry);
+        entries.push(entry);
+      } catch (error) {
+        console.error(`[generate-drawio-libraries] Failed to process icon "${icon.slug}" for library "${lib.slug}":`, error);
+        skipped++;
+      }
+    }
+
+    const outputPath = join(OUTPUT_DIR, `${lib.slug}.xml`);
+    const contents = `<mxlibrary>${JSON.stringify(entries)}</mxlibrary>`;
+    writeFileSync(outputPath, contents, "utf-8");
+
+    const sizeKb = (Buffer.byteLength(contents, "utf-8") / 1024).toFixed(1);
+    console.log(`  ${lib.label} (${lib.slug}.xml): ${entries.length} icons, ${sizeKb} KB${skipped ? `, ${skipped} skipped` : ""}`);
+
+    totalSkipped += skipped;
+  }
+
+  console.log(`draw.io library generation complete.${totalSkipped ? ` ${totalSkipped} icons skipped total.` : ""}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds 12 downloadable draw.io / diagrams.net custom shape libraries, grouped by category (Developer Tools, AI, Finance, Database, Networking, Security, Analytics, IoT, Framework, Storage, Design, Language), covering brand and dev-tool logos not in draw.io's built-in AWS/Azure/GCP/Kubernetes libraries.
- Generated at build time (`src/scripts/generate-drawio-libraries.ts`) from `src/data/icons.json` into `public/integrations/drawio/*.xml` (gitignored, same pattern as `public/api/`).
- New `/integrations/drawio` page listing all libraries with download links and import instructions, plus a linked entry on `/extensions`.

## Test plan
- [x] `pnpm build` passes end to end, `/integrations/drawio` and all 12 `.xml` files generate correctly
- [x] Generated XML validated: `<mxlibrary>` wrapper parses, inner JSON parses, and every one of the 1,705 icon entries' embedded `mxGraphModel` XML structurally validated via regex (base64 payload guarantees no XML/JSON-breaking characters)
- [x] `tsc --noEmit` and `eslint` clean on all changed/new files
- [ ] Manual visual check in draw.io's UI (browser automation against app.diagrams.net was flaky/unreliable in this environment; the file format has been mechanically validated instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added draw.io / diagrams.net integration support.
  - Browse categorized icon libraries from the Extensions page.
  - View library availability, icon counts, import instructions, and download links for custom shape libraries.
  - Library files are generated automatically during builds.

- **Documentation**
  - Added guidance explaining how to import custom shape libraries into draw.io / diagrams.net.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->