### PR TITLE
feat: add Ivy Framework icon

### DIFF
--- a/public/icons/ivy-framework/default.svg
+++ b/public/icons/ivy-framework/default.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27.0513 0H0.0512695V27.0128C14.9434 27.0128 27.0513 14.9247 27.0513 0Z" fill="#00D18E"/>
+</svg>

--- a/src/data/icons.json
+++ b/src/data/icons.json
@@ -71420,6 +71420,22 @@
     "collection": "brands"
   },
   {
+    "slug": "ivy-framework",
+    "title": "Ivy Framework",
+    "aliases": [],
+    "hex": "00D18E",
+    "categories": [
+      "Framework"
+    ],
+    "variants": {
+      "default": "/icons/ivy-framework/default.svg"
+    },
+    "license": "Apache-2.0",
+    "url": "https://ivy.app",
+    "collection": "brands",
+    "dateAdded": "2026-09-07"
+  },
+  {
     "slug": "jabber",
     "title": "Jabber",
     "aliases": [],


### PR DESCRIPTION
## Summary

We noticed the Ivy Framework brand mark wasn't in the catalog yet, so this adds it.

- `ivy-framework` — Ivy Framework, an open-source C# framework for building internal tools. Logo sourced directly from the project's own repository assets (used as their site favicon/logo), license set to Apache-2.0 to match the project's own LICENSE since the mark isn't separately licensed.

## Test plan

- [x] SVG is valid XML with a `viewBox`, well under the 50KB limit, no scripts/event handlers/embedded raster images
- [x] Entry inserted into `src/data/icons.json` at the correct alphabetical position
- [x] `node -e "require('./src/data/icons.json')"` parses cleanly, no duplicate slugs
- [x] `pnpm build` succeeds and generates `/icon/ivy-framework`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Ivy Framework brand icon, including its standard branding details and SVG variant.
  - Included attribution, licensing, website, category, and collection metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->