### PR TITLE
docs: add jsDelivr badges to root and package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?style=flat-square&color=F97316&label=npm" alt="npm" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
+  <a href="https://www.jsdelivr.com/package/gh/glincker/thesvg"><img src="https://data.jsdelivr.com/v1/package/gh/glincker/thesvg/badge" alt="jsDelivr" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
   <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C500%2B-F97316?style=flat-square" alt="6,500+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/cli"><img src="https://img.shields.io/npm/v/@thesvg/cli?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/cli"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/cli/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/cli
 
 CLI tool to add SVG icons from [thesvg.org](https://thesvg.org) directly into your project - shadcn-style.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@thesvg/icons"><img src="https://img.shields.io/npm/v/@thesvg/icons?color=F97316&label=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/@thesvg/icons"><img src="https://img.shields.io/npm/dm/@thesvg/icons?color=F97316" alt="npm downloads" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/icons"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/icons/badge" alt="jsDelivr" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/packages/icons/LICENSE"><img src="https://img.shields.io/npm/l/@thesvg/icons?color=F97316" alt="license" /></a>
   <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=social" alt="GitHub stars" /></a>
 </p>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/mcp-server"><img src="https://img.shields.io/npm/v/@thesvg/mcp-server?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/mcp-server"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/mcp-server/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/mcp-server
 
 MCP (Model Context Protocol) server for [thesvg.org](https://thesvg.org). Gives AI agents in Claude Desktop, Cursor, Claude Code, and any MCP-aware client direct access to 6,500+ brand SVG icons -- no API key required.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/react-native"><img src="https://img.shields.io/npm/v/@thesvg/react-native?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/react-native"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/react-native/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/react-native
 
 Typed React Native SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/react"><img src="https://img.shields.io/npm/v/@thesvg/react?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/react"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/react/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/react
 
 Typed React SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/svelte"><img src="https://img.shields.io/npm/v/@thesvg/svelte?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/svelte"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/svelte/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/svelte
 
 Typed Svelte SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).

--- a/packages/thesvg/README.md
+++ b/packages/thesvg/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/v/thesvg?color=F97316&label=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?color=F97316" alt="npm downloads" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/thesvg"><img src="https://data.jsdelivr.com/v1/package/npm/thesvg/badge" alt="jsDelivr" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/packages/thesvg/LICENSE"><img src="https://img.shields.io/npm/l/thesvg?color=F97316" alt="license" /></a>
   <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=social" alt="GitHub stars" /></a>
 </p>

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -4,6 +4,11 @@
   </a>
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/@thesvg/vue"><img src="https://img.shields.io/npm/v/@thesvg/vue?color=F97316&label=npm" alt="npm version" /></a>
+  <a href="https://www.jsdelivr.com/package/npm/@thesvg/vue"><img src="https://data.jsdelivr.com/v1/package/npm/@thesvg/vue/badge" alt="jsDelivr" /></a>
+</p>
+
 # @thesvg/vue
 
 Typed Vue 3 SVG components for all 6,500+ brand icons from [thesvg.org](https://thesvg.org).


### PR DESCRIPTION
## Summary
- Adds a jsDelivr CDN badge to the root README's badge row (GitHub-package variant, linking to the repo's jsDelivr stats page)
- Adds a matching npm-package jsDelivr badge to each of the 8 packages under packages/ (thesvg, icons, react, vue, svelte, react-native, cli, mcp-server), alongside a new npm version badge for the packages that didn't already have a badge row

## Test plan
- [x] Docs-only change, no code/build logic touched
- [x] Verified each badge URL matches the exact package name from its package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added npm version and jsDelivr download badges to package README headers.
  * Updated badges across the CLI, icons, MCP, React Native, React, Svelte, core, and Vue packages.
  * Badge links provide direct access to package and CDN information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->