### PR TITLE
fix: consolidate collection metadata, fix community collection 404

### DIFF
--- a/src/app/collection/[name]/page.tsx
+++ b/src/app/collection/[name]/page.tsx
@@ -10,98 +10,16 @@ import {
   getCollectionCount,
   type Collection,
 } from "@/lib/icons";
+import { COLLECTION_IDS, COLLECTIONS_META, isValidCollectionId } from "@/lib/collections-meta";
 import { HomeContent } from "@/components/home-content";
 
-const COLLECTION_META: Record<
-  string,
-  { title: string; description: string; keywords: string[] }
-> = {
-  aws: {
-    title: "AWS Architecture Icons - Free SVG Download",
-    description:
-      "Browse and download 739 official AWS Architecture SVG icons. Lambda, EC2, S3, RDS, DynamoDB, and all AWS services. Free for developers. Copy as SVG, JSX, React component, or CDN link.",
-    keywords: [
-      "AWS icons",
-      "AWS architecture icons",
-      "AWS SVG",
-      "AWS Lambda icon",
-      "Amazon EC2 icon",
-      "AWS service icons",
-      "cloud architecture icons",
-      "AWS diagram icons",
-    ],
-  },
-  azure: {
-    title: "Microsoft Azure Icons - Free SVG Download",
-    description:
-      "Browse and download 626 official Microsoft Azure service SVG icons. Virtual Machines, App Services, Azure SQL, Cosmos DB, and all Azure services. Free for developers.",
-    keywords: [
-      "Azure icons",
-      "Microsoft Azure icons",
-      "Azure SVG",
-      "Azure service icons",
-      "Azure architecture icons",
-      "cloud icons",
-      "Azure VM icon",
-      "Azure Functions icon",
-    ],
-  },
-  gcp: {
-    title: "Google Cloud Platform Icons - Free SVG Download",
-    description:
-      "Browse and download 214 Google Cloud Platform SVG icons. Compute Engine, BigQuery, Cloud Run, GKE, and all GCP services. Free for developers.",
-    keywords: [
-      "GCP icons",
-      "Google Cloud icons",
-      "GCP SVG",
-      "Google Cloud Platform icons",
-      "BigQuery icon",
-      "Cloud Run icon",
-      "GKE icon",
-      "cloud architecture icons",
-    ],
-  },
-  brands: {
-    title: "Brand SVG Icons - Free Logo Download",
-    description:
-      "Browse and download 4,019 brand SVG icons. GitHub, Stripe, Vercel, Docker, React, and thousands more. Multiple variants: color, mono, dark, light, wordmark.",
-    keywords: [
-      "brand icons",
-      "brand SVG",
-      "logo SVG",
-      "brand logos",
-      "free logo download",
-      "SVG icons",
-      "developer icons",
-    ],
-  },
-  k8s: {
-    title: "Kubernetes Icons - Free SVG Download",
-    description:
-      "Browse and download 38 official Kubernetes architecture SVG icons. Pods, Deployments, Services, Ingress, ConfigMaps, Secrets, and the full CNCF Kubernetes icon set. Apache 2.0.",
-    keywords: [
-      "Kubernetes icons",
-      "K8s icons",
-      "Kubernetes SVG",
-      "Pod icon",
-      "Deployment icon",
-      "Service icon",
-      "Ingress icon",
-      "CNCF icons",
-      "cloud native icons",
-    ],
-  },
-};
-
-const VALID_COLLECTIONS = ["aws", "azure", "gcp", "brands", "k8s"] as const;
-type ValidCollection = (typeof VALID_COLLECTIONS)[number];
-
-function isValidCollection(name: string): name is ValidCollection {
-  return (VALID_COLLECTIONS as readonly string[]).includes(name);
-}
-
+// The set of collections with a static page is derived from the shared
+// collections-meta config, so adding a collection there is enough to get
+// it a working `/collection/[name]` page - no allowlist to remember to
+// update separately (that drift is what caused /collection/community to
+// 404 in production).
 export function generateStaticParams() {
-  return VALID_COLLECTIONS.map((name) => ({ name }));
+  return COLLECTION_IDS.map((name) => ({ name }));
 }
 
 export const dynamicParams = false;
@@ -112,16 +30,16 @@ interface PageProps {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { name } = await params;
-  const meta = COLLECTION_META[name];
+  const meta = COLLECTIONS_META[name as Collection];
   if (!meta) return {};
 
   return {
-    title: meta.title,
-    description: meta.description,
-    keywords: meta.keywords,
+    title: meta.pageTitle,
+    description: meta.pageDescription,
+    keywords: meta.pageKeywords,
     openGraph: {
-      title: `${meta.title} | theSVG`,
-      description: meta.description,
+      title: `${meta.pageTitle} | theSVG`,
+      description: meta.pageDescription,
       url: `https://thesvg.org/collection/${name}`,
       type: "website",
       siteName: "theSVG",
@@ -130,14 +48,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
           url: "/og-image.png",
           width: 1200,
           height: 630,
-          alt: meta.title,
+          alt: meta.pageTitle,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title: meta.title,
-      description: meta.description,
+      title: meta.pageTitle,
+      description: meta.pageDescription,
     },
     alternates: {
       canonical: `https://thesvg.org/collection/${name}`,
@@ -148,7 +66,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function CollectionPage({ params }: PageProps) {
   const { name } = await params;
 
-  if (!isValidCollection(name)) {
+  if (!isValidCollectionId(name)) {
     notFound();
   }
 
@@ -158,14 +76,14 @@ export default async function CollectionPage({ params }: PageProps) {
   const collections = getCollections();
 
   const collectionName = name as Collection;
-  const meta = COLLECTION_META[name];
+  const meta = COLLECTIONS_META[collectionName];
   const collectionItemCount = getCollectionCount(collectionName);
 
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    name: meta?.title,
-    description: meta?.description,
+    name: meta?.pageTitle,
+    description: meta?.pageDescription,
     url: `https://thesvg.org/collection/${name}`,
     isPartOf: {
       "@type": "WebSite",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import posthog from "posthog-js";
 import { usePathname, useRouter } from "next/navigation";
-import { ArrowRight, Cloud, FileText, Menu, Moon, Package, Plus, Search, Shapes, Sparkles, Sun, X } from "lucide-react";
+import { ArrowRight, FileText, Menu, Moon, Package, Plus, Search, Sparkles, Sun, X } from "lucide-react";
 import { Github } from "@/components/icons/shared/brand-icons";
 import { TheSVGMark } from "@/components/icons/the-svg-mark";
 import { useTheme } from "next-themes";
@@ -13,52 +13,12 @@ import { Button } from "@/components/ui/button";
 import { useSidebarStore } from "@/lib/stores/sidebar-store";
 import { useSearchStore } from "@/lib/stores/search-store";
 import { useRecentsStore } from "@/lib/stores/recents-store";
-import type { IconEntry } from "@/lib/icons";
+import { getCollections, type IconEntry } from "@/lib/icons";
+import { COLLECTIONS_LIST } from "@/lib/collections-meta";
 import { loadIconsManifest } from "@/lib/icons-manifest";
 import { cn } from "@/lib/utils";
 
 const PLACEHOLDER_BRANDS = ["GitHub", "Stripe", "Figma", "Docker", "AWS Lambda", "Azure Functions", "BigQuery", "Vercel", "React", "Tailwind CSS"];
-
-/** Inline AWS logo - text inherits currentColor, arrow stays orange */
-function AwsLogo({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" className={className}>
-      <path d="M6.763 11.212c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 01-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 01-.287-.375 6.18 6.18 0 01-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.39-.384-.59-.894-.59-1.533 0-.678.24-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.4 2.4 0 01-.28.104.488.488 0 01-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 01.224-.167 4.577 4.577 0 011.005-.36 4.84 4.84 0 011.246-.151c.95 0 1.644.216 2.091.647.44.43.662 1.085.662 1.963v2.586h.016zm-3.24 1.214c.263 0 .534-.048.822-.144a1.78 1.78 0 00.758-.51 1.27 1.27 0 00.272-.512c.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 00-.735-.136 6.02 6.02 0 00-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296zm6.41.862c-.144 0-.24-.024-.304-.08-.064-.048-.12-.16-.168-.311L7.586 6.726a1.398 1.398 0 01-.072-.32c0-.128.064-.2.191-.2h.783c.151 0 .255.025.31.08.065.048.113.16.16.312l1.342 5.284 1.245-5.284c.04-.16.088-.264.151-.312a.549.549 0 01.32-.08h.638c.152 0 .256.025.32.08.063.048.12.16.151.312l1.261 5.348 1.381-5.348c.048-.16.104-.264.16-.312a.52.52 0 01.311-.08h.743c.127 0 .2.065.2.2 0 .04-.009.08-.017.128a1.137 1.137 0 01-.056.2l-1.923 6.17c-.048.16-.104.263-.168.311a.51.51 0 01-.303.08h-.687c-.15 0-.255-.024-.32-.08-.063-.056-.119-.16-.15-.32L12.32 7.747l-1.23 5.14c-.04.16-.087.264-.15.32-.065.056-.177.08-.32.08l-.686.001zm10.256.215c-.415 0-.83-.048-1.229-.143-.399-.096-.71-.2-.918-.32-.128-.071-.215-.151-.247-.223a.563.563 0 01-.048-.224v-.407c0-.167.064-.247.183-.247.048 0 .096.008.144.024.048.016.12.048.2.08.271.12.566.215.878.279.32.064.63.096.95.096.502 0 .894-.088 1.165-.264a.86.86 0 00.415-.758.777.777 0 00-.215-.559c-.144-.151-.416-.287-.807-.415l-1.157-.36c-.583-.183-1.014-.454-1.277-.813a1.902 1.902 0 01-.4-1.158c0-.335.073-.63.216-.886.144-.255.335-.479.575-.654.24-.184.51-.32.83-.415.32-.096.655-.136 1.006-.136.175 0 .36.008.535.032.183.024.35.056.518.088.16.04.312.08.455.127.144.048.256.096.336.144a.69.69 0 01.24.2.43.43 0 01.071.263v.375c0 .168-.064.256-.184.256a.83.83 0 01-.303-.096 3.652 3.652 0 00-1.532-.311c-.455 0-.815.071-1.062.223-.248.152-.375.383-.375.71 0 .224.08.416.24.567.16.152.454.304.877.44l1.134.358c.574.184.99.44 1.237.767.247.327.367.702.367 1.117 0 .343-.072.655-.207.926a2.157 2.157 0 01-.583.703c-.248.2-.543.343-.886.447-.36.111-.734.167-1.142.167z" />
-      <path d="M.378 15.475c3.384 1.963 7.56 3.153 11.877 3.153 2.914 0 6.114-.607 9.06-1.852.44-.2.814.287.383.607-2.626 1.94-6.442 2.969-9.722 2.969-4.598 0-8.74-1.7-11.87-4.526-.247-.223-.024-.527.272-.351zm23.531-.2c.287.36-.08 2.826-1.485 4.007-.215.184-.423.088-.327-.151l.175-.439c.343-.88.802-2.198.52-2.555-.336-.43-2.22-.207-3.074-.103-.255.032-.295-.192-.063-.36 1.5-1.053 3.967-.75 4.254-.399z" fill="#F90" />
-    </svg>
-  );
-}
-
-function AzureLogo({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" className={className}>
-      <defs>
-        <linearGradient id="az-a" x1="42.83" x2="15.79" y1="12.69" y2="92.57" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stopColor="#114a8b" />
-          <stop offset="1" stopColor="#0669bc" />
-        </linearGradient>
-        <linearGradient id="az-c" x1="47.84" x2="77.52" y1="10.36" y2="89.44" gradientUnits="userSpaceOnUse">
-          <stop offset="0" stopColor="#3ccbf4" />
-          <stop offset="1" stopColor="#2892df" />
-        </linearGradient>
-      </defs>
-      <path fill="url(#az-a)" d="M33.34 6.54h26.04l-27.03 80.1a4.15 4.15 0 0 1-3.94 2.81H8.15a4.14 4.14 0 0 1-3.93-5.47L29.4 9.38a4.15 4.15 0 0 1 3.94-2.83z" />
-      <path fill="#0078d4" d="M71.17 60.26H29.88a1.91 1.91 0 0 0-1.3 3.31l26.53 24.76a4.17 4.17 0 0 0 2.85 1.13h23.38z" />
-      <path fill="url(#az-c)" d="M66.6 9.36a4.14 4.14 0 0 0-3.93-2.82H33.65a4.15 4.15 0 0 1 3.93 2.82l25.18 74.62a4.15 4.15 0 0 1-3.93 5.48h29.02a4.15 4.15 0 0 0 3.93-5.48z" />
-    </svg>
-  );
-}
-
-function GcpLogo({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" className={className}>
-      <path fill="#EA4335" d="M10.313 5.376l1.887-1.5-.332-.414a5.935 5.935 0 00-5.586-1.217 5.89 5.89 0 00-3.978 4.084c-.03.113.312-.098.463-.056l2.608-.428s.127-.124.201-.205c1.16-1.266 3.126-1.432 4.465-.354l.272.09z" />
-      <path fill="#4285F4" d="M13.637 6.3a5.835 5.835 0 00-1.77-2.838l-1.83 1.82a3.226 3.226 0 011.193 2.564v.323c.9 0 1.63.725 1.63 1.62 0 .893-.73 1.619-1.63 1.619l-3.257-.003-.325.035v2.507l.325.053h3.257a4.234 4.234 0 004.08-2.962A4.199 4.199 0 0013.636 6.3z" />
-      <path fill="#34A853" d="M4.711 13.999H7.97v-2.594H4.71c-.232 0-.461-.066-.672-.161l-.458.14-1.313 1.297-.114.447a4.254 4.254 0 002.557.87z" />
-      <path fill="#FBBC05" d="M4.711 5.572A4.234 4.234 0 00.721 8.44a4.206 4.206 0 001.433 4.688l1.89-1.884a1.617 1.617 0 01.44-3.079 1.63 1.63 0 011.714.936l1.89-1.878A4.24 4.24 0 004.71 5.572z" />
-    </svg>
-  );
-}
 
 function SubmitButton() {
   return (
@@ -131,6 +91,11 @@ export function Header() {
   );
   const [focused, setFocused] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(-1);
+
+  // Live per-collection counts (icons.json is the source of truth), so the
+  // quick-access list below never drifts out of sync the way hardcoded
+  // counts did.
+  const collectionCounts = useMemo(() => getCollections(), []);
 
   const activeCollection =
     searchParams.get("collection") ||
@@ -344,58 +309,27 @@ export function Header() {
 
           {/* Collection switcher */}
           <nav className="hidden items-center gap-0.5 lg:flex" aria-label="Icon collections">
-            <Link
-              href="/"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                !activeCollection
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              )}
-              aria-current={!activeCollection ? "page" : undefined}
-            >
-              <Shapes className="h-3 w-3" />
-              Brands
-            </Link>
-            <Link
-              href="/collection/aws"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                activeCollection === "aws"
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              )}
-              aria-current={activeCollection === "aws" ? "page" : undefined}
-            >
-              <AwsLogo className="h-4 w-4" />
-              AWS
-            </Link>
-            <Link
-              href="/collection/gcp"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                activeCollection === "gcp"
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              )}
-              aria-current={activeCollection === "gcp" ? "page" : undefined}
-            >
-              <GcpLogo className="h-4 w-4" />
-              GCP
-            </Link>
-            <Link
-              href="/collection/azure"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                activeCollection === "azure"
-                  ? "bg-foreground text-background shadow-sm"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              )}
-              aria-current={activeCollection === "azure" ? "page" : undefined}
-            >
-              <AzureLogo className="h-4 w-4" />
-              Azure
-            </Link>
+            {COLLECTIONS_LIST.map((meta) => {
+              const href = meta.id === "brands" ? "/" : `/collection/${meta.id}`;
+              const isActive = meta.id === "brands" ? !activeCollection : activeCollection === meta.id;
+              const Icon = meta.icon;
+              return (
+                <Link
+                  key={meta.id}
+                  href={href}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                    isActive
+                      ? "bg-foreground text-background shadow-sm"
+                      : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  <Icon className={cn("h-3.5 w-3.5", isActive ? meta.color : "opacity-60")} />
+                  {meta.shortLabel}
+                </Link>
+              );
+            })}
           </nav>
 
           {/* Center: search with dropdown. On mobile the form takes the
@@ -579,24 +513,22 @@ export function Header() {
                     <p className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/50">
                       Quick access
                     </p>
-                    {[
-                      { href: "/collection/brands", icon: Shapes, label: "Brand Icons", count: "4,019", color: "text-orange-500" },
-                      { href: "/collection/aws", icon: Cloud, label: "AWS Architecture", count: "739", color: "text-[#ff9900]" },
-                      { href: "/collection/azure", icon: Cloud, label: "Azure Services", count: "626", color: "text-[#0078d4]" },
-                      { href: "/collection/gcp", icon: Cloud, label: "Google Cloud", count: "214", color: "text-[#4285f4]" },
-                    ].map((item) => (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        onClick={() => setFocused(false)}
-                        className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-accent/50"
-                      >
-                        <item.icon className={`h-4 w-4 shrink-0 ${item.color}`} />
-                        <span className="flex-1 text-sm font-medium text-foreground">{item.label}</span>
-                        <span className="text-[10px] text-muted-foreground/50">{item.count}</span>
-                        <ArrowRight className="h-3 w-3 text-muted-foreground/30" />
-                      </Link>
-                    ))}
+                    {COLLECTIONS_LIST.map((meta) => {
+                      const count = collectionCounts.find((c) => c.name === meta.id)?.count ?? 0;
+                      return (
+                        <Link
+                          key={meta.id}
+                          href={`/collection/${meta.id}`}
+                          onClick={() => setFocused(false)}
+                          className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-accent/50"
+                        >
+                          <meta.icon className={`h-4 w-4 shrink-0 ${meta.color}`} />
+                          <span className="flex-1 text-sm font-medium text-foreground">{meta.label}</span>
+                          <span className="text-[10px] text-muted-foreground/50">{count.toLocaleString()}</span>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground/30" />
+                        </Link>
+                      );
+                    })}
 
                     <div className="my-1.5 h-px bg-border/30 dark:bg-white/[0.04]" />
 

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -1,26 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Anchor, ArrowRight, Check, Clock, Cloud, Copy, Package, Shapes, Sparkles, X, Zap } from "lucide-react";
+import { Anchor, ArrowRight, Check, Clock, Cloud, Copy, Package, Sparkles, Users, X, Zap } from "lucide-react";
 import Link from "next/link";
 import posthog from "posthog-js";
 import type { Collection, IconEntry } from "@/lib/icons";
+import { COLLECTIONS_META } from "@/lib/collections-meta";
 import { loadIconsManifest } from "@/lib/icons-manifest";
 import { IconCard } from "@/components/icons/icon-card";
 import { IconGrid } from "@/components/icons/icon-grid";
 import { IconDetail } from "@/components/icons/icon-detail";
 import { useRecentsStore } from "@/lib/stores/recents-store";
 import { cn } from "@/lib/utils";
-
-/** Inline AWS logo - text inherits currentColor, arrow stays orange */
-function AwsLogo({ className }: { className?: string }) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" className={className}>
-      <path d="M6.763 11.212c0 .296.032.535.088.71.064.176.144.368.256.576.04.063.056.127.056.183 0 .08-.048.16-.152.24l-.503.335a.383.383 0 01-.208.072c-.08 0-.16-.04-.239-.112a2.47 2.47 0 01-.287-.375 6.18 6.18 0 01-.248-.471c-.622.734-1.405 1.101-2.347 1.101-.67 0-1.205-.191-1.596-.574-.39-.384-.59-.894-.59-1.533 0-.678.24-1.23.726-1.644.487-.415 1.133-.623 1.955-.623.272 0 .551.024.846.064.296.04.6.104.918.176v-.583c0-.607-.127-1.03-.375-1.277-.255-.248-.686-.367-1.3-.367-.28 0-.568.031-.863.103-.295.072-.583.16-.862.272a2.4 2.4 0 01-.28.104.488.488 0 01-.127.023c-.112 0-.168-.08-.168-.247v-.391c0-.128.016-.224.056-.28a.597.597 0 01.224-.167 4.577 4.577 0 011.005-.36 4.84 4.84 0 011.246-.151c.95 0 1.644.216 2.091.647.44.43.662 1.085.662 1.963v2.586h.016zm-3.24 1.214c.263 0 .534-.048.822-.144a1.78 1.78 0 00.758-.51 1.27 1.27 0 00.272-.512c.047-.191.08-.423.08-.694v-.335a6.66 6.66 0 00-.735-.136 6.02 6.02 0 00-.75-.048c-.535 0-.926.104-1.19.32-.263.215-.39.518-.39.917 0 .375.095.655.295.846.191.2.47.296.838.296zm6.41.862c-.144 0-.24-.024-.304-.08-.064-.048-.12-.16-.168-.311L7.586 6.726a1.398 1.398 0 01-.072-.32c0-.128.064-.2.191-.2h.783c.151 0 .255.025.31.08.065.048.113.16.16.312l1.342 5.284 1.245-5.284c.04-.16.088-.264.151-.312a.549.549 0 01.32-.08h.638c.152 0 .256.025.32.08.063.048.12.16.151.312l1.261 5.348 1.381-5.348c.048-.16.104-.264.16-.312a.52.52 0 01.311-.08h.743c.127 0 .2.065.2.2 0 .04-.009.08-.017.128a1.137 1.137 0 01-.056.2l-1.923 6.17c-.048.16-.104.263-.168.311a.51.51 0 01-.303.08h-.687c-.15 0-.255-.024-.32-.08-.063-.056-.119-.16-.15-.32L12.32 7.747l-1.23 5.14c-.04.16-.087.264-.15.32-.065.056-.177.08-.32.08l-.686.001zm10.256.215c-.415 0-.83-.048-1.229-.143-.399-.096-.71-.2-.918-.32-.128-.071-.215-.151-.247-.223a.563.563 0 01-.048-.224v-.407c0-.167.064-.247.183-.247.048 0 .096.008.144.024.048.016.12.048.2.08.271.12.566.215.878.279.32.064.63.096.95.096.502 0 .894-.088 1.165-.264a.86.86 0 00.415-.758.777.777 0 00-.215-.559c-.144-.151-.416-.287-.807-.415l-1.157-.36c-.583-.183-1.014-.454-1.277-.813a1.902 1.902 0 01-.4-1.158c0-.335.073-.63.216-.886.144-.255.335-.479.575-.654.24-.184.51-.32.83-.415.32-.096.655-.136 1.006-.136.175 0 .36.008.535.032.183.024.35.056.518.088.16.04.312.08.455.127.144.048.256.096.336.144a.69.69 0 01.24.2.43.43 0 01.071.263v.375c0 .168-.064.256-.184.256a.83.83 0 01-.303-.096 3.652 3.652 0 00-1.532-.311c-.455 0-.815.071-1.062.223-.248.152-.375.383-.375.71 0 .224.08.416.24.567.16.152.454.304.877.44l1.134.358c.574.184.99.44 1.237.767.247.327.367.702.367 1.117 0 .343-.072.655-.207.926a2.157 2.157 0 01-.583.703c-.248.2-.543.343-.886.447-.36.111-.734.167-1.142.167z" />
-      <path d="M.378 15.475c3.384 1.963 7.56 3.153 11.877 3.153 2.914 0 6.114-.607 9.06-1.852.44-.2.814.287.383.607-2.626 1.94-6.442 2.969-9.722 2.969-4.598 0-8.74-1.7-11.87-4.526-.247-.223-.024-.527.272-.351zm23.531-.2c.287.36-.08 2.826-1.485 4.007-.215.184-.423.088-.327-.151l.175-.439c.343-.88.802-2.198.52-2.555-.336-.43-2.22-.207-3.074-.103-.255.032-.295-.192-.063-.36 1.5-1.053 3.967-.75 4.254-.399z" fill="#F90" />
-    </svg>
-  );
-}
 
 /** Hand-picked popular brand slugs */
 const POPULAR_SLUGS = [
@@ -79,13 +70,10 @@ const POPULAR_K8S_SLUGS = [
   "k8s-controller-manager", "k8s-clusterrole",
 ];
 
-const COLLECTION_LABELS: Record<string, { label: string; description: string }> = {
-  brands: { label: "Brand Icons", description: "Logos and brand marks" },
-  aws: { label: "AWS Architecture", description: "AWS service and resource icons (2026-Q1)" },
-  azure: { label: "Azure Services", description: "Microsoft Azure service icons (2026-Q1)" },
-  gcp: { label: "Google Cloud", description: "Google Cloud Platform icons (2026-Q1)" },
-  k8s: { label: "Kubernetes", description: "Official Kubernetes architecture icons" },
-};
+/** Hand-picked popular Community slugs */
+const POPULAR_COMMUNITY_SLUGS = [
+  "airflow", "cockroachdb", "envoy", "alpinejs", "chartjs", "cassandra",
+];
 
 const ALL_SLIDES = [
   {
@@ -230,6 +218,19 @@ const ALL_SLIDES = [
     blob: "bg-[#326ce5]/10 dark:bg-[#326ce5]/5",
     collection: "k8s" as const,
     floatSlugs: POPULAR_K8S_SLUGS,
+  },
+  {
+    badge: "Community",
+    badgeIcon: Users,
+    title: "256 Community-Curated Icons",
+    description: "Dev tools, databases, frameworks, and platforms sourced from the open-source community. Free to use, always growing.",
+    cta: { label: "Browse Icons", href: "#popular" },
+    ctaSecondary: { label: "Submit an Icon", href: "/submit" },
+    gradient: "from-teal-50/50 via-background to-teal-50/30 dark:from-teal-950/20 dark:via-background dark:to-teal-950/10",
+    accent: "border-teal-200/50 bg-teal-50/80 text-teal-600 dark:border-teal-500/20 dark:bg-teal-500/10 dark:text-teal-400",
+    blob: "bg-teal-400/10 dark:bg-teal-500/5",
+    collection: "community" as const,
+    floatSlugs: POPULAR_COMMUNITY_SLUGS,
   },
 ];
 
@@ -383,6 +384,7 @@ export function HomeHero({
       azure: POPULAR_AZURE_SLUGS,
       gcp: POPULAR_GCP_SLUGS,
       k8s: POPULAR_K8S_SLUGS,
+      community: POPULAR_COMMUNITY_SLUGS,
     };
     const slugs = slugMap[activeCollection] ?? POPULAR_SLUGS;
     return slugs
@@ -654,7 +656,8 @@ export function HomeHero({
       {collections.length > 1 && (
         <div className="flex flex-wrap items-center gap-1" role="tablist" aria-label="Icon collections">
           {collections.map((col) => {
-            const info = COLLECTION_LABELS[col.name];
+            const meta = COLLECTIONS_META[col.name];
+            const Icon = meta?.icon;
             const isActive = activeCollection === col.name;
             return (
               <button
@@ -669,18 +672,10 @@ export function HomeHero({
                     : "text-muted-foreground hover:bg-accent hover:text-foreground dark:hover:bg-white/[0.06]"
                 }`}
               >
-                {col.name === "brands" && <Shapes className="h-3.5 w-3.5" />}
-                {col.name === "aws" && <AwsLogo className="h-3.5 w-3.5" />}
-                {col.name === "azure" && (
-                  <img src="/icons/microsoft-azure/default.svg" alt="" className="h-3.5 w-3.5 object-contain" />
+                {Icon && (
+                  <Icon className={cn("h-3.5 w-3.5", isActive ? meta.color : "opacity-60")} />
                 )}
-                {col.name === "gcp" && (
-                  <img src="/icons/google-cloud/default.svg" alt="" className="h-3.5 w-3.5 object-contain" />
-                )}
-                {col.name === "k8s" && (
-                  <img src="/icons/kubernetes/default.svg" alt="" className="h-3.5 w-3.5 object-contain" />
-                )}
-                {info?.label || col.name}
+                {meta?.heroLabel || col.name}
                 <span className={`rounded-full px-1.5 font-mono text-[9px] ${
                   isActive
                     ? "bg-background/20 text-background/70"
@@ -755,7 +750,7 @@ export function HomeHero({
       <section>
         <div className="mb-4 flex items-center gap-2">
           <h2 className="text-sm font-semibold text-foreground">
-            {activeCollection === "brands" ? "All Icons" : `All ${COLLECTION_LABELS[activeCollection]?.label ?? activeCollection} Icons`}
+            {activeCollection === "brands" ? "All Icons" : `All ${COLLECTIONS_META[activeCollection]?.heroLabel ?? activeCollection} Icons`}
           </h2>
           <span className="text-xs text-muted-foreground">{collectionIcons.length.toLocaleString()}</span>
           <div className="h-px flex-1 bg-border/40 dark:bg-white/[0.04]" />

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -5,7 +5,6 @@ import {
   Blocks,
   Bot,
   ChevronRight,
-  Cloud,
   Code,
   Code2,
   Eye,
@@ -23,6 +22,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { Collection } from "@/lib/icons";
+import { COLLECTIONS_META } from "@/lib/collections-meta";
 
 import { cn } from "@/lib/utils";
 
@@ -35,14 +35,6 @@ const EXTENSION_CATEGORIES = [
   { id: "integrations", label: "Integrations", icon: Blocks },
   { id: "frameworks", label: "Framework Components", icon: Code2 },
 ];
-
-const COLLECTION_META: Record<string, { icon: typeof Cloud; label: string; color: string }> = {
-  brands: { icon: Shapes, label: "Brand Icons", color: "text-orange-500" },
-  aws: { icon: Cloud, label: "AWS Architecture", color: "text-[#ff9900]" },
-  azure: { icon: Cloud, label: "Azure Services", color: "text-[#0078d4]" },
-  gcp: { icon: Cloud, label: "Google Cloud", color: "text-[#4285f4]" },
-  k8s: { icon: Cloud, label: "Kubernetes", color: "text-[#326CE5]" },
-};
 
 interface SidebarProps {
   categories: { name: string; count: number }[];
@@ -227,7 +219,7 @@ export function Sidebar({
                 )}
               >
                 {collections.map((col) => {
-                  const meta = COLLECTION_META[col.name];
+                  const meta = COLLECTIONS_META[col.name];
                   const Icon = meta?.icon || Shapes;
                   const isActive = selectedCollection === col.name;
                   return (

--- a/src/lib/collections-meta.ts
+++ b/src/lib/collections-meta.ts
@@ -1,0 +1,186 @@
+import type { ComponentType } from "react";
+import { Cloud, Shapes, Users } from "lucide-react";
+
+/**
+ * Single source of truth for collection metadata. Every collection that
+ * exists in `src/data/icons.json` (see `getCollections()` in `src/lib/icons.ts`)
+ * must have an entry here. Previously this metadata was duplicated across
+ * `sidebar.tsx`, `collection/[name]/page.tsx`, `home-hero.tsx`, and
+ * `header.tsx` - the four copies drifted out of sync with each other and
+ * with the real data, which is how the "community" collection ended up
+ * missing from the static-page allowlist and 404ing in production.
+ *
+ * Add a new collection by adding one entry here; every consumer (sidebar,
+ * collection pages, hero carousel, header) picks it up automatically.
+ */
+export const COLLECTION_IDS = ["brands", "aws", "azure", "gcp", "k8s", "community"] as const;
+
+export type CollectionId = (typeof COLLECTION_IDS)[number];
+
+export interface CollectionMeta {
+  id: CollectionId;
+  /** Label used in the sidebar and hero carousel tabs. */
+  label: string;
+  /** Compact 1-2 word label for tight nav chrome (header collection switcher). */
+  shortLabel: string;
+  /** Lucide icon component used to represent the collection in UI chrome. */
+  icon: ComponentType<{ className?: string }>;
+  /** Tailwind text-color class applied to the icon when active/selected. */
+  color: string;
+  /** `<title>` for the collection's static page. */
+  pageTitle: string;
+  /** Meta/OG description for the collection's static page. */
+  pageDescription: string;
+  /** SEO keywords for the collection's static page. */
+  pageKeywords: string[];
+  /** Label shown in the home hero carousel's collection tabs. */
+  heroLabel: string;
+  /** Short description shown alongside the hero carousel tab. */
+  heroDescription: string;
+}
+
+export const COLLECTIONS_META: Record<CollectionId, CollectionMeta> = {
+  brands: {
+    id: "brands",
+    label: "Brand Icons",
+    shortLabel: "Brands",
+    icon: Shapes,
+    color: "text-orange-500",
+    pageTitle: "Brand SVG Icons - Free Logo Download",
+    pageDescription:
+      "Browse and download 4,675 brand SVG icons. GitHub, Stripe, Vercel, Docker, React, and thousands more. Multiple variants: color, mono, dark, light, wordmark.",
+    pageKeywords: [
+      "brand icons",
+      "brand SVG",
+      "logo SVG",
+      "brand logos",
+      "free logo download",
+      "SVG icons",
+      "developer icons",
+    ],
+    heroLabel: "Brand Icons",
+    heroDescription: "Logos and brand marks",
+  },
+  aws: {
+    id: "aws",
+    label: "AWS Architecture",
+    shortLabel: "AWS",
+    icon: Cloud,
+    color: "text-[#ff9900]",
+    pageTitle: "AWS Architecture Icons - Free SVG Download",
+    pageDescription:
+      "Browse and download 739 official AWS Architecture SVG icons. Lambda, EC2, S3, RDS, DynamoDB, and all AWS services. Free for developers. Copy as SVG, JSX, React component, or CDN link.",
+    pageKeywords: [
+      "AWS icons",
+      "AWS architecture icons",
+      "AWS SVG",
+      "AWS Lambda icon",
+      "Amazon EC2 icon",
+      "AWS service icons",
+      "cloud architecture icons",
+      "AWS diagram icons",
+    ],
+    heroLabel: "AWS Architecture",
+    heroDescription: "AWS service and resource icons (2026-Q1)",
+  },
+  azure: {
+    id: "azure",
+    label: "Azure Services",
+    shortLabel: "Azure",
+    icon: Cloud,
+    color: "text-[#0078d4]",
+    pageTitle: "Microsoft Azure Icons - Free SVG Download",
+    pageDescription:
+      "Browse and download 626 official Microsoft Azure service SVG icons. Virtual Machines, App Services, Azure SQL, Cosmos DB, and all Azure services. Free for developers.",
+    pageKeywords: [
+      "Azure icons",
+      "Microsoft Azure icons",
+      "Azure SVG",
+      "Azure service icons",
+      "Azure architecture icons",
+      "cloud icons",
+      "Azure VM icon",
+      "Azure Functions icon",
+    ],
+    heroLabel: "Azure Services",
+    heroDescription: "Microsoft Azure service icons (2026-Q1)",
+  },
+  gcp: {
+    id: "gcp",
+    label: "Google Cloud",
+    shortLabel: "GCP",
+    icon: Cloud,
+    color: "text-[#4285f4]",
+    pageTitle: "Google Cloud Platform Icons - Free SVG Download",
+    pageDescription:
+      "Browse and download 214 Google Cloud Platform SVG icons. Compute Engine, BigQuery, Cloud Run, GKE, and all GCP services. Free for developers.",
+    pageKeywords: [
+      "GCP icons",
+      "Google Cloud icons",
+      "GCP SVG",
+      "Google Cloud Platform icons",
+      "BigQuery icon",
+      "Cloud Run icon",
+      "GKE icon",
+      "cloud architecture icons",
+    ],
+    heroLabel: "Google Cloud",
+    heroDescription: "Google Cloud Platform icons (2026-Q1)",
+  },
+  k8s: {
+    id: "k8s",
+    label: "Kubernetes",
+    shortLabel: "K8s",
+    icon: Cloud,
+    color: "text-[#326ce5]",
+    pageTitle: "Kubernetes Icons - Free SVG Download",
+    pageDescription:
+      "Browse and download 38 official Kubernetes architecture SVG icons. Pods, Deployments, Services, Ingress, ConfigMaps, Secrets, and the full CNCF Kubernetes icon set. Apache 2.0.",
+    pageKeywords: [
+      "Kubernetes icons",
+      "K8s icons",
+      "Kubernetes SVG",
+      "Pod icon",
+      "Deployment icon",
+      "Service icon",
+      "Ingress icon",
+      "CNCF icons",
+      "cloud native icons",
+    ],
+    heroLabel: "Kubernetes",
+    heroDescription: "Official Kubernetes architecture icons",
+  },
+  community: {
+    id: "community",
+    label: "Community",
+    shortLabel: "Community",
+    icon: Users,
+    color: "text-teal-500",
+    pageTitle: "Community SVG Icons - Free Download",
+    pageDescription:
+      "Browse and download 256 community-contributed SVG icons. Dev tools, databases, frameworks, and platforms sourced from the open-source community. Free for developers.",
+    pageKeywords: [
+      "community icons",
+      "dev tool icons",
+      "open source icons",
+      "community SVG",
+      "developer tool logos",
+      "database icons",
+      "framework icons",
+      "SVG icon library",
+    ],
+    heroLabel: "Community",
+    heroDescription: "Dev tools, databases, and frameworks from the community",
+  },
+};
+
+/** All collection metadata entries, in canonical display order. */
+export const COLLECTIONS_LIST: CollectionMeta[] = COLLECTION_IDS.map((id) => COLLECTIONS_META[id]);
+
+export function getCollectionMeta(id: string): CollectionMeta | undefined {
+  return isValidCollectionId(id) ? COLLECTIONS_META[id] : undefined;
+}
+
+export function isValidCollectionId(id: string): id is CollectionId {
+  return (COLLECTION_IDS as readonly string[]).includes(id);
+}

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,6 +1,13 @@
 import iconsData from "@/data/icons.json";
+import type { CollectionId } from "@/lib/collections-meta";
 
-export type Collection = "brands" | "aws" | "gcp" | "azure" | "emojis" | "k8s" | "community";
+/**
+ * The canonical list of collection ids lives in `collections-meta.ts`
+ * (the single source of truth for collection metadata); this type just
+ * mirrors it so the rest of this data layer has no runtime dependency
+ * on that module.
+ */
+export type Collection = CollectionId;
 
 /**
  * Cloud architecture collections. Their icons carry vendor taxonomy categories


### PR DESCRIPTION
## Problem

`/collection/community` 404s in production. The sidebar lists "community" (256 icons) as a real collection (data-driven from `icons.json` via `getCollections()`), and links to `/collection/community`, but `collection/[name]/page.tsx` hardcoded a `VALID_COLLECTIONS` allowlist that didn't include `"community"`. Combined with static export (`output: "export"`) and `dynamicParams = false`, that page never gets built, so the link 404s.

## Root cause

Collection metadata (icon, color, page title/description/keywords, hero carousel content) was duplicated across four separate files, none of which agreed with each other or with the real data in `icons.json`:

- `sidebar.tsx` - `COLLECTION_META` (missing community)
- `collection/[name]/page.tsx` - a different `COLLECTION_META` + the `VALID_COLLECTIONS` allowlist bug
- `home-hero.tsx` - `COLLECTION_LABELS` + `ALL_SLIDES` + an if-conditional chain for tab icons (missing community)
- `header.tsx` - desktop collection switcher + a quick-access list with hardcoded, stale icon counts (only 4 of 6 real collections)

## Fix

Added `src/lib/collections-meta.ts` as the single source of truth for all 6 real collections (`brands`, `aws`, `azure`, `gcp`, `k8s`, `community`), and refactored all four consumers to read from it:

- `sidebar.tsx` and `collection/[name]/page.tsx` now derive their lookups (and `VALID_COLLECTIONS`/`generateStaticParams`) from the shared config, so adding a collection there is enough to get it a working static page - this is the actual bug fix.
- `home-hero.tsx`'s hardcoded label table and per-collection icon if-chain are replaced by a lookup over the shared config; added a "Community" hero slide.
- `header.tsx`'s desktop switcher and quick-access list now render from the shared config, with quick-access counts derived live via `getCollectionCount()`/`getCollections()` instead of hardcoded strings that had already drifted (e.g. "4,019" vs the real 4,675 brand icons).
- Removed duplicate inline `AwsLogo`/`AzureLogo`/`GcpLogo` SVG components (previously redefined in both `header.tsx` and `home-hero.tsx`) in favor of the shared config's Lucide icon + brand color.
- `src/lib/icons.ts`'s `Collection` type now mirrors `collections-meta.ts`'s canonical id list and drops the unused `"emojis"` union member (confirmed zero occurrences in `icons.json`).

## Verification

- `npx tsc --noEmit` - clean.
- `npx eslint` on all changed files - 0 errors (2 pre-existing warnings in untouched code, confirmed present on `main` too).
- Ran a full static export (`next build`, matching this project's `output: "export"` + `dynamicParams: false` config) and served the `out/` directory:
  - `/collection/community` -> **200** (was 404)
  - `/collection/aws`, `/collection/azure`, `/collection/gcp`, `/collection/brands`, `/collection/k8s` -> all **200** (no regression)
  - `/collection/bogus-not-real` -> still **404** (invalid collections correctly rejected)

## Test plan

- [ ] Sidebar shows all 6 collections including Community, and clicking through to each works
- [ ] Header collection switcher (desktop) shows all 6 collections
- [ ] Header search dropdown "Quick access" counts match reality
- [ ] Home hero carousel cycles through the new Community slide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Community icon collection with dedicated homepage content and carousel access.
  * Collection navigation and quick-access links now reflect the available collections and current icon counts.
  * Collection pages now use consistent titles, descriptions, keywords, and sharing previews.
  * Collection tabs, labels, icons, colors, and headings are now presented consistently across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->