### PR TITLE
feat: add global UTM embedder for outbound links

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { ShareButtons } from "@/components/blog/share-buttons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { getCategoryCounts } from "@/lib/icons";
 import postsData from "@/data/posts.json";
+import { withUtm } from "@/lib/external-link";
 
 interface Post {
   slug: string;
@@ -76,7 +77,17 @@ function processInline(text: string): string {
     })
     .replace(
       /\[(.+?)\]\((.+?)\)/g,
-      '<a href="$2" class="text-orange-500 underline underline-offset-2 hover:text-orange-400">$1</a>'
+      (_match, label: string, href: string) => {
+        // External links get UTM-tagged (via withUtm, which no-ops for
+        // mailto:/internal hrefs) and open in a new tab; internal links
+        // keep the plain same-tab behavior.
+        const isExternal = href.startsWith("http");
+        const taggedHref = withUtm(href, "blog_post").replace(/&/g, "&amp;");
+        const extraAttrs = isExternal
+          ? ' target="_blank" rel="noopener noreferrer"'
+          : "";
+        return `<a href="${taggedHref}" class="text-orange-500 underline underline-offset-2 hover:text-orange-400"${extraAttrs}>${label}</a>`;
+      }
     );
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, ArrowUpRight, Rss, Sparkles } from "lucide-react";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { getCategoryCounts } from "@/lib/icons";
 import postsData from "@/data/posts.json";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Blog - Announcements & Updates",
@@ -223,7 +224,7 @@ export default function BlogPage() {
               RSS Feed
             </a>
             <a
-              href="https://github.com/GLINCKER/thesvg"
+              href={withUtm("https://github.com/GLINCKER/thesvg", "blog_page")}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 rounded-xl bg-foreground px-4 py-2 text-xs font-medium text-background shadow-sm transition-all hover:opacity-90"

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { getCategoryCounts, getIconCount } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Best SVG Icon Library 2026: theSVG vs Simple Icons, svgl, Lucide, Font Awesome, Iconify",
@@ -411,7 +412,7 @@ export default function ComparePage() {
               standard. Iconify is an incredible aggregator. Each serves a different need.
               If something is inaccurate,{" "}
               <a
-                href="https://github.com/GLINCKER/thesvg/issues"
+                href={withUtm("https://github.com/GLINCKER/thesvg/issues", "compare_page")}
                 className="text-orange-600 underline underline-offset-2 dark:text-orange-400"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Mail, MessageSquare, Shield } from "lucide-react";
 import { Github } from "@/components/icons/shared/brand-icons";
 import { TRADEMARK_POLICY_URL } from "@/lib/constants";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Contact",
@@ -84,7 +85,7 @@ export default function ContactPage() {
           {CONTACT_CHANNELS.map((channel) => (
             <a
               key={channel.title}
-              href={channel.href}
+              href={withUtm(channel.href, "contact_page")}
               target={channel.href.startsWith("mailto") ? undefined : "_blank"}
               rel={
                 channel.href.startsWith("mailto")
@@ -137,7 +138,7 @@ export default function ContactPage() {
             </a>{" "}
             or read our full{" "}
             <a
-              href={TRADEMARK_POLICY_URL}
+              href={withUtm(TRADEMARK_POLICY_URL, "contact_page")}
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-foreground underline underline-offset-2"

--- a/src/app/extensions/page.tsx
+++ b/src/app/extensions/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { getCategoryCounts, getFormattedIconCount } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Extensions & Integrations - Figma, VS Code, React, React Native",
@@ -437,7 +438,7 @@ function ExtLink({
   if (isExternal) {
     return (
       <a
-        href={href}
+        href={withUtm(href, "extensions_page")}
         target="_blank"
         rel="noopener noreferrer"
         className={className}
@@ -586,7 +587,7 @@ export default function ExtensionsPage() {
               {/* Action buttons */}
               <div className="flex flex-wrap gap-3">
                 <a
-                  href="https://github.com/GLINCKER/thesvg"
+                  href={withUtm("https://github.com/GLINCKER/thesvg", "extensions_page")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg bg-foreground px-4 py-2 text-sm font-medium text-background transition-opacity hover:opacity-90"
@@ -595,7 +596,7 @@ export default function ExtensionsPage() {
                   View on GitHub
                 </a>
                 <a
-                  href="https://www.jsdelivr.com/package/gh/glincker/thesvg"
+                  href={withUtm("https://www.jsdelivr.com/package/gh/glincker/thesvg", "extensions_page")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Shield, Mail, FileText, Scale, ExternalLink } from "lucide-react";
 import { getCategoryCounts } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Legal Notice - Trademark Policy, Licenses & DMCA",
@@ -66,7 +67,7 @@ export default function LegalPage() {
                 The theSVG codebase (website, build tools, npm packages, CLI, API, and MCP
                 server) is licensed under the{" "}
                 <a
-                  href="https://github.com/GLINCKER/thesvg/blob/main/LICENSE"
+                  href={withUtm("https://github.com/GLINCKER/thesvg/blob/main/LICENSE", "legal_page")}
                   className="text-foreground underline underline-offset-2"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -162,7 +163,7 @@ export default function LegalPage() {
               </ul>
               <div className="mt-4 flex flex-wrap gap-3">
                 <a
-                  href="https://github.com/GLINCKER/thesvg/issues/new?template=icon_removal.yml"
+                  href={withUtm("https://github.com/GLINCKER/thesvg/issues/new?template=icon_removal.yml", "legal_page")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:border-white/[0.08]"
@@ -171,7 +172,7 @@ export default function LegalPage() {
                   Open removal request
                 </a>
                 <a
-                  href="mailto:support@glincker.com"
+                  href={withUtm("mailto:support@glincker.com", "legal_page")}
                   className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-xs font-medium text-foreground transition-colors hover:bg-accent dark:border-white/[0.08]"
                 >
                   <Mail className="h-3 w-3" />
@@ -214,7 +215,7 @@ export default function LegalPage() {
                 ].map((lib) => (
                   <li key={lib.name}>
                     <a
-                      href={lib.url}
+                      href={withUtm(lib.url, "legal_page")}
                       className="text-foreground underline underline-offset-2"
                       target="_blank"
                       rel="noopener noreferrer"
@@ -239,7 +240,7 @@ export default function LegalPage() {
             </Link>
             <span className="text-muted-foreground/30">|</span>
             <a
-              href="https://github.com/GLINCKER/thesvg/blob/main/TRADEMARK.md"
+              href={withUtm("https://github.com/GLINCKER/thesvg/blob/main/TRADEMARK.md", "legal_page")}
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
               target="_blank"
               rel="noopener noreferrer"
@@ -248,7 +249,7 @@ export default function LegalPage() {
             </a>
             <span className="text-muted-foreground/30">|</span>
             <a
-              href="https://github.com/GLINCKER/thesvg/blob/main/CONTRIBUTING.md"
+              href={withUtm("https://github.com/GLINCKER/thesvg/blob/main/CONTRIBUTING.md", "legal_page")}
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
               target="_blank"
               rel="noopener noreferrer"
@@ -257,7 +258,7 @@ export default function LegalPage() {
             </a>
             <span className="text-muted-foreground/30">|</span>
             <a
-              href="https://github.com/GLINCKER/thesvg/blob/main/LICENSE"
+              href={withUtm("https://github.com/GLINCKER/thesvg/blob/main/LICENSE", "legal_page")}
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Shield, Database, Globe, Clipboard, BarChart3, Mail } from "lucide-react";
 import { getCategoryCounts } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Privacy Policy - thesvg Browser Extension",
@@ -122,7 +123,7 @@ export default function PrivacyPage() {
                 jsDelivr&apos;s own privacy policy applies to requests made to their
                 CDN:{" "}
                 <a
-                  href="https://www.jsdelivr.com/privacy-policy-jsdelivr-net"
+                  href={withUtm("https://www.jsdelivr.com/privacy-policy-jsdelivr-net", "privacy_page")}
                   className="text-foreground underline underline-offset-2"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -156,7 +157,7 @@ export default function PrivacyPage() {
                 None. All extension logic is bundled locally and reviewed as part of
                 the open-source codebase at{" "}
                 <a
-                  href="https://github.com/GLINCKER/thesvg"
+                  href={withUtm("https://github.com/GLINCKER/thesvg", "privacy_page")}
                   className="text-foreground underline underline-offset-2"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -219,7 +220,7 @@ export default function PrivacyPage() {
             </Link>
             <span className="text-muted-foreground/30">|</span>
             <a
-              href="https://github.com/GLINCKER/thesvg"
+              href={withUtm("https://github.com/GLINCKER/thesvg", "privacy_page")}
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -13,6 +13,7 @@ import type { Metadata } from "next";
 import { getAllCategories, getCategoryCounts, getIconCount } from "@/lib/icons";
 import { SidebarShell } from "@/components/layout/sidebar-shell";
 import { SubmitForm } from "@/components/submit/submit-form";
+import { withUtm } from "@/lib/external-link";
 
 export const metadata: Metadata = {
   title: "Submit an Icon - Add Your Brand SVG",
@@ -118,7 +119,7 @@ export default function SubmitPage() {
               {/* GitHub links */}
               <div className="flex flex-wrap gap-3">
                 <a
-                  href="https://github.com/GLINCKER/thesvg"
+                  href={withUtm("https://github.com/GLINCKER/thesvg", "submit_page")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-border/40 bg-card/50 px-4 py-2.5 text-sm font-medium text-foreground transition-all hover:border-border hover:bg-card hover:shadow-md dark:border-white/[0.06] dark:hover:border-white/[0.1]"
@@ -128,7 +129,7 @@ export default function SubmitPage() {
                   <ArrowUpRight className="h-3 w-3 opacity-50" />
                 </a>
                 <a
-                  href="https://github.com/GLINCKER/thesvg/issues"
+                  href={withUtm("https://github.com/GLINCKER/thesvg/issues", "submit_page")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-border/40 bg-card/50 px-4 py-2.5 text-sm font-medium text-foreground transition-all hover:border-border hover:bg-card hover:shadow-md dark:border-white/[0.06] dark:hover:border-white/[0.1]"

--- a/src/components/blog/share-buttons.tsx
+++ b/src/components/blog/share-buttons.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Check, Link2 } from "lucide-react";
 import posthog from "posthog-js";
 import { cn } from "@/lib/utils";
+import { withUtm } from "@/lib/external-link";
 
 interface ShareButtonsProps {
   url: string;
@@ -85,7 +86,7 @@ export function ShareButtons({ url, title, tags, vertical = false }: ShareButton
         {PLATFORMS.map((platform) => (
           <a
             key={platform.name}
-            href={platform.buildUrl(url, title, tags)}
+            href={withUtm(platform.buildUrl(url, title, tags), "blog_share")}
             target="_blank"
             rel="noopener noreferrer"
             title={`Share on ${platform.name}`}
@@ -125,7 +126,7 @@ export function ShareButtons({ url, title, tags, vertical = false }: ShareButton
       {PLATFORMS.map((platform) => (
         <a
           key={platform.name}
-          href={platform.buildUrl(url, title, tags)}
+          href={withUtm(platform.buildUrl(url, title, tags), "blog_share")}
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => handleShare(platform.name)}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -3,6 +3,7 @@ import { Github } from "@/components/icons/shared/brand-icons";
 import { TheSVGMark } from "@/components/icons/the-svg-mark";
 import Link from "next/link";
 import { TRADEMARK_POLICY_URL } from "@/lib/constants";
+import { withUtm } from "@/lib/external-link";
 import {
   getIconCount,
   getVariantCount,
@@ -50,7 +51,7 @@ function FooterLinkItem({ link }: { link: FooterLink }) {
   if (link.external) {
     return (
       <a
-        href={link.href}
+        href={withUtm(link.href, "footer")}
         target="_blank"
         rel="noopener noreferrer"
         className="group flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -156,7 +157,7 @@ export function Footer() {
               Submit an Icon
             </Link>
             <a
-              href="https://github.com/GLINCKER/thesvg"
+              href={withUtm("https://github.com/GLINCKER/thesvg", "footer")}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-lg border border-border/60 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground dark:border-white/[0.1]"
@@ -188,7 +189,7 @@ export function Footer() {
               <p className="text-xs text-muted-foreground/60">
                 A{" "}
                 <a
-                  href="https://glincker.com"
+                  href={withUtm("https://glincker.com", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-muted-foreground/80 transition-colors hover:text-foreground"
@@ -199,7 +200,7 @@ export function Footer() {
               </p>
               <div className="flex items-center gap-3">
                 <a
-                  href="https://github.com/GLINCKER/thesvg"
+                  href={withUtm("https://github.com/GLINCKER/thesvg", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-muted-foreground/60 transition-colors hover:text-foreground"
@@ -208,7 +209,7 @@ export function Footer() {
                   <Github className="h-4 w-4" />
                 </a>
                 <a
-                  href="https://www.figma.com/community/plugin/1612997159050367763"
+                  href={withUtm("https://www.figma.com/community/plugin/1612997159050367763", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="opacity-60 transition-opacity hover:opacity-100"
@@ -223,7 +224,7 @@ export function Footer() {
                   />
                 </a>
                 <a
-                  href="https://www.npmjs.com/package/thesvg"
+                  href={withUtm("https://www.npmjs.com/package/thesvg", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 transition-colors hover:text-foreground"
@@ -233,7 +234,10 @@ export function Footer() {
                 </a>
               </div>
               <a
-                href="https://www.producthunt.com/products/thesvg/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-thesvg"
+                href={withUtm(
+                  "https://www.producthunt.com/products/thesvg/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-thesvg",
+                  "footer"
+                )}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -262,7 +266,7 @@ export function Footer() {
             <div className="flex flex-col gap-3">
               <FooterColumn title="Community" links={COMMUNITY_LINKS} />
               <a
-                href="https://thegdsks.com"
+                href={withUtm("https://thegdsks.com", "footer")}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="group mt-1 inline-flex w-fit items-center gap-1.5 rounded-full border border-orange-500/25 bg-orange-500/[0.06] py-1 pl-1 pr-3 text-xs font-medium text-foreground transition-colors hover:border-orange-500/40 hover:bg-orange-500/10"
@@ -282,7 +286,7 @@ export function Footer() {
             <p className="text-sm text-muted-foreground">
               A project by{" "}
               <a
-                href="https://glinr.com"
+                href={withUtm("https://glinr.com", "footer")}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-semibold text-foreground transition-colors hover:text-muted-foreground"
@@ -296,7 +300,7 @@ export function Footer() {
               </span>
               <div className="flex items-center gap-6">
                 <a
-                  href="https://glincker.com"
+                  href={withUtm("https://glincker.com", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 opacity-60 transition-opacity hover:opacity-100"
@@ -321,7 +325,7 @@ export function Footer() {
                 </a>
                 <span className="text-border/40">|</span>
                 <a
-                  href="https://askverdict.ai"
+                  href={withUtm("https://askverdict.ai", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 opacity-60 transition-opacity hover:opacity-100"
@@ -357,7 +361,7 @@ export function Footer() {
               <span>
                 All brand logos and trademarks belong to their respective owners.{" "}
                 <a
-                  href={TRADEMARK_POLICY_URL}
+                  href={withUtm(TRADEMARK_POLICY_URL, "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="underline underline-offset-2 transition-colors hover:text-muted-foreground"
@@ -369,7 +373,7 @@ export function Footer() {
               <span>
                 Built by{" "}
                 <a
-                  href="https://glinr.com"
+                  href={withUtm("https://glinr.com", "footer")}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium transition-colors hover:text-muted-foreground"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,6 +17,7 @@ import { getCollections, type IconEntry } from "@/lib/icons";
 import { COLLECTIONS_LIST } from "@/lib/collections-meta";
 import { loadIconsManifest } from "@/lib/icons-manifest";
 import { cn } from "@/lib/utils";
+import { withUtm } from "@/lib/external-link";
 
 const PLACEHOLDER_BRANDS = ["GitHub", "Stripe", "Figma", "Docker", "AWS Lambda", "Azure Functions", "BigQuery", "Vercel", "React", "Tailwind CSS"];
 
@@ -588,7 +589,7 @@ export function Header() {
 
             <div className="ml-1 flex items-center gap-0.5 sm:gap-1">
               <a
-                href="https://www.npmjs.com/package/thesvg"
+                href={withUtm("https://www.npmjs.com/package/thesvg", "header")}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="View on npm"
@@ -604,7 +605,7 @@ export function Header() {
                 />
               </a>
               <a
-                href="https://www.raycast.com/thegdsks/thesvg"
+                href={withUtm("https://www.raycast.com/thegdsks/thesvg", "header")}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="View on Raycast"
@@ -620,7 +621,7 @@ export function Header() {
                 />
               </a>
               <a
-                href="https://www.figma.com/community/plugin/1612997159050367763"
+                href={withUtm("https://www.figma.com/community/plugin/1612997159050367763", "header")}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={showFigmaBadge ? "Open the Figma plugin (new)" : "Open the Figma plugin"}
@@ -645,7 +646,7 @@ export function Header() {
                 )}
               </a>
               <a
-                href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"
+                href={withUtm("https://marketplace.visualstudio.com/items?itemName=glincker.thesvg", "header")}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Install the VS Code extension"
@@ -661,7 +662,7 @@ export function Header() {
                 />
               </a>
               <a
-                href="https://github.com/GLINCKER/thesvg"
+                href={withUtm("https://github.com/GLINCKER/thesvg", "header")}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="View on GitHub"

--- a/src/components/home-hero.tsx
+++ b/src/components/home-hero.tsx
@@ -12,6 +12,7 @@ import { IconGrid } from "@/components/icons/icon-grid";
 import { IconDetail } from "@/components/icons/icon-detail";
 import { useRecentsStore } from "@/lib/stores/recents-store";
 import { cn } from "@/lib/utils";
+import { withUtm } from "@/lib/external-link";
 
 /** Hand-picked popular brand slugs */
 const POPULAR_SLUGS = [
@@ -504,7 +505,7 @@ export function HomeHero({
               <div className="flex flex-wrap gap-2 sm:gap-3">
                 {slide.cta.href.startsWith("http") ? (
                   <a
-                    href={slide.cta.href}
+                    href={withUtm(slide.cta.href, "home_hero")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 rounded-xl bg-foreground min-h-[40px] px-4 py-2 text-xs font-medium text-background shadow-lg shadow-black/10 transition-all hover:opacity-90 hover:shadow-xl sm:px-5 sm:py-2.5 sm:text-sm dark:shadow-black/30"
@@ -521,12 +522,23 @@ export function HomeHero({
                     <ArrowRight className="h-3.5 w-3.5" />
                   </Link>
                 )}
-                <Link
-                  href={slide.ctaSecondary.href}
-                  className="inline-flex items-center gap-2 rounded-xl border border-border/60 bg-background/50 min-h-[40px] px-4 py-2 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm transition-all hover:bg-background/80 hover:shadow-md sm:px-5 sm:py-2.5 sm:text-sm dark:border-white/[0.1] dark:bg-white/[0.05]"
-                >
-                  {slide.ctaSecondary.label}
-                </Link>
+                {slide.ctaSecondary.href.startsWith("http") ? (
+                  <a
+                    href={withUtm(slide.ctaSecondary.href, "home_hero")}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 rounded-xl border border-border/60 bg-background/50 min-h-[40px] px-4 py-2 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm transition-all hover:bg-background/80 hover:shadow-md sm:px-5 sm:py-2.5 sm:text-sm dark:border-white/[0.1] dark:bg-white/[0.05]"
+                  >
+                    {slide.ctaSecondary.label}
+                  </a>
+                ) : (
+                  <Link
+                    href={slide.ctaSecondary.href}
+                    className="inline-flex items-center gap-2 rounded-xl border border-border/60 bg-background/50 min-h-[40px] px-4 py-2 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm transition-all hover:bg-background/80 hover:shadow-md sm:px-5 sm:py-2.5 sm:text-sm dark:border-white/[0.1] dark:bg-white/[0.05]"
+                  >
+                    {slide.ctaSecondary.label}
+                  </Link>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/icons/detail/contribution-cta.tsx
+++ b/src/components/icons/detail/contribution-cta.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { GitPullRequest, SealWarning, Sparkle } from "@phosphor-icons/react/dist/ssr";
+import { withUtm } from "@/lib/external-link";
 
 const REPO = "glincker/thesvg";
 
@@ -122,7 +123,7 @@ export function ContributionCta({
       </div>
       <div className="relative flex flex-wrap gap-2">
         <a
-          href={buildIssueUrl(slug, title, hasMultipleVariants, guidelinesMissing)}
+          href={withUtm(buildIssueUrl(slug, title, hasMultipleVariants, guidelinesMissing), "contribution_cta")}
           target="_blank"
           rel="noopener noreferrer"
           className="group flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-[11px] font-medium text-muted-foreground shadow-sm transition-all duration-150 hover:-translate-y-0.5 hover:border-foreground/30 hover:text-foreground hover:shadow-md active:translate-y-0 active:scale-95"
@@ -131,7 +132,7 @@ export function ContributionCta({
           Request via Issue
         </a>
         <a
-          href={buildPrUrl(slug, title, hasMultipleVariants, guidelinesMissing)}
+          href={withUtm(buildPrUrl(slug, title, hasMultipleVariants, guidelinesMissing), "contribution_cta")}
           target="_blank"
           rel="noopener noreferrer"
           className="group relative flex items-center gap-1.5 overflow-hidden rounded-lg border border-orange-500/40 bg-gradient-to-b from-orange-500 to-orange-600 px-3 py-1.5 text-[11px] font-medium text-white shadow-[0_1px_0_0_rgba(255,255,255,0.25)_inset,0_2px_8px_-2px_rgba(249,115,22,0.5)] transition-all duration-150 hover:-translate-y-0.5 hover:shadow-[0_1px_0_0_rgba(255,255,255,0.25)_inset,0_6px_16px_-2px_rgba(249,115,22,0.6)] active:translate-y-0 active:scale-95"

--- a/src/components/icons/icon-detail-page.tsx
+++ b/src/components/icons/icon-detail-page.tsx
@@ -29,6 +29,7 @@ import { ContributionCta } from "@/components/icons/detail/contribution-cta";
 import { QualityScoreCard } from "@/components/icons/detail/quality-score-card";
 import { DownloadMenu } from "@/components/icons/detail/download-menu";
 import { OpenInEditorMenu } from "@/components/icons/detail/open-in-editor-menu";
+import { withUtm } from "@/lib/external-link";
 
 interface IconDetailPageProps {
   icon: IconEntry;
@@ -344,7 +345,7 @@ export function IconDetailPage({
                 );
                 return (
                   <a
-                    href={icon.url}
+                    href={withUtm(icon.url, "icon_detail")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-xs text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
@@ -361,7 +362,7 @@ export function IconDetailPage({
               })()}
             {icon.guidelines && (
               <a
-                href={icon.guidelines}
+                href={withUtm(icon.guidelines, "icon_detail")}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 rounded-lg border border-violet-500/25 bg-violet-500/[0.06] px-3 py-2 text-xs text-violet-600 shadow-sm transition-colors hover:bg-violet-500/[0.12] dark:text-violet-400"
@@ -615,7 +616,7 @@ export function IconDetailPage({
                 <>
                   For official brand assets, visit{" "}
                   <a
-                    href={urlObj.toString()}
+                    href={withUtm(urlObj.toString(), "icon_detail")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline underline-offset-2 hover:text-muted-foreground"

--- a/src/components/icons/icon-detail.tsx
+++ b/src/components/icons/icon-detail.tsx
@@ -25,6 +25,7 @@ import { formatSvg } from "@/lib/copy-formats";
 import { useFavoritesStore } from "@/lib/stores/favorites-store";
 import { cn } from "@/lib/utils";
 import { VARIANT_LABELS, FORMAT_BUTTONS } from "@/components/icons/shared/icon-constants";
+import { withUtm } from "@/lib/external-link";
 
 interface IconDetailProps {
   icon: IconEntry | null;
@@ -328,7 +329,7 @@ export function IconDetail({ icon, onClose }: IconDetailProps) {
               <div className="flex flex-wrap gap-1.5">
                 {icon.url && (
                   <a
-                    href={icon.url}
+                    href={withUtm(icon.url, "icon_quick_view")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 px-2.5 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
@@ -348,7 +349,7 @@ export function IconDetail({ icon, onClose }: IconDetailProps) {
                 )}
                 {icon.guidelines && (
                   <a
-                    href={icon.guidelines}
+                    href={withUtm(icon.guidelines, "icon_quick_view")}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1.5 rounded-lg border border-violet-500/25 bg-violet-500/[0.06] px-2.5 py-1.5 text-[11px] text-violet-600 transition-colors hover:bg-violet-500/[0.12] dark:text-violet-400"

--- a/src/components/mobile/mobile-icon-sheet.tsx
+++ b/src/components/mobile/mobile-icon-sheet.tsx
@@ -15,6 +15,7 @@ import { loadIconsManifest } from "@/lib/icons-manifest";
 import { formatSvg, type CopyFormat } from "@/lib/copy-formats";
 import type { IconEntry } from "@/lib/icons";
 import { cn } from "@/lib/utils";
+import { withUtm } from "@/lib/external-link";
 
 const COPY_FORMATS: ReadonlyArray<{ key: CopyFormat | "png"; label: string }> = [
   { key: "svg", label: "SVG" },
@@ -281,7 +282,7 @@ export function MobileIconSheet() {
 
           {icon.url && (
             <a
-              href={icon.url}
+              href={withUtm(icon.url, "mobile_icon_sheet")}
               target="_blank"
               rel="noopener noreferrer"
               className="mx-4 mt-2 flex items-center justify-between rounded-xl border border-border/40 px-3 py-2 text-[12px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground dark:border-white/[0.06]"

--- a/src/components/mobile/mobile-more-sheet.tsx
+++ b/src/components/mobile/mobile-more-sheet.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { BottomSheet, type BottomSheetSnap } from "./bottom-sheet";
 import { useMobileShellStore } from "@/lib/stores/mobile-shell-store";
+import { withUtm } from "@/lib/external-link";
 
 interface InternalItem {
   href: string;
@@ -142,7 +143,7 @@ export function MobileMoreSheet() {
           {EXTERNAL_LINKS.map((item) => (
             <li key={item.href}>
               <a
-                href={item.href}
+                href={withUtm(item.href, "mobile_more_sheet")}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => closeSheet()}

--- a/src/components/submit/submit-form.tsx
+++ b/src/components/submit/submit-form.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { validateSvg, type ValidationResult } from "@/lib/svg-validation";
+import { withUtm } from "@/lib/external-link";
 import {
   LICENSE_OPTIONS,
   MAX_OTHER_LICENSE_LENGTH,
@@ -238,7 +239,7 @@ function LicenseSelector({
             {helperOpen ? "Hide" : "Help me pick"}
           </button>
           <a
-            href={LICENSING_GUIDE_URL}
+            href={withUtm(LICENSING_GUIDE_URL, "submit_form")}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
@@ -889,7 +890,7 @@ export function SubmitForm({
       {/* Submit Actions */}
       <div className="flex flex-col gap-3 border-t border-border pt-4 sm:flex-row">
         <a
-          href={canSubmit ? buildGitHubUrl() : undefined}
+          href={canSubmit ? withUtm(buildGitHubUrl(), "submit_form") : undefined}
           target="_blank"
           rel="noopener noreferrer"
           aria-disabled={!canSubmit}

--- a/src/components/viewer/svg-viewer.tsx
+++ b/src/components/viewer/svg-viewer.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/svg-utils";
 import { DeepLinkActions } from "@/components/viewer/deep-link-actions";
 import { QuickImport } from "@/components/viewer/quick-import";
+import { withUtm } from "@/lib/external-link";
 
 type PreviewBg = "checker" | "light" | "dark";
 
@@ -524,7 +525,7 @@ export function SvgViewer() {
 
           {/* Partner CTA */}
           <a
-            href="https://www.filagram.com/svg-viewer"
+            href={withUtm("https://www.filagram.com/svg-viewer", "svg_viewer")}
             target="_blank"
             rel="noopener noreferrer"
             className="group flex items-start gap-3 rounded-2xl border border-border/40 bg-card/30 p-4 transition-colors hover:border-border hover:bg-card/60"

--- a/src/lib/external-link.ts
+++ b/src/lib/external-link.ts
@@ -1,0 +1,61 @@
+/**
+ * Global UTM-parameter embedder for outbound links.
+ *
+ * Every external link on thesvg.org should carry UTM params so:
+ *   - brand/partner sites can attribute referral traffic back to thesvg.org
+ *   - thesvg's own analytics can distinguish which page/section drove a
+ *     given outbound click (via the `source` -> utm_campaign mapping)
+ */
+
+/**
+ * Appends thesvg's standard UTM parameters to an external URL.
+ *
+ * @param url The href to wrap. Internal/relative URLs and `mailto:` links
+ *   are returned unchanged so callers can call this unconditionally
+ *   without special-casing non-http(s) hrefs.
+ * @param source Identifies which page/section the link lives in (e.g.
+ *   "footer", "header", "icon_detail"). Used as the default utm_campaign.
+ * @param overrides Optional overrides for utm_medium / utm_campaign.
+ */
+export function withUtm(
+  url: string,
+  source: string,
+  overrides?: { medium?: string; campaign?: string }
+): string {
+  // No-op for mailto: links - UTM params on a mailto have no meaning.
+  if (url.startsWith("mailto:")) {
+    return url;
+  }
+
+  // No-op for internal/relative links - only fully-qualified http(s) URLs
+  // are "external" and worth attributing.
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    return url;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Not a parseable absolute URL - return as-is rather than throw.
+    return url;
+  }
+
+  // Safety rule: if the URL already carries ANY utm_ query parameter,
+  // leave it completely untouched. Some outbound links (e.g. a Product
+  // Hunt badge URL) already carry the PARTNER's own UTM params for their
+  // own attribution. Overriding or merging with those would clobber the
+  // partner's tracking, not ours - so we deliberately skip injection
+  // entirely rather than trying to merge/override individual params.
+  for (const key of parsed.searchParams.keys()) {
+    if (key.startsWith("utm_")) {
+      return url;
+    }
+  }
+
+  parsed.searchParams.set("utm_source", "thesvg.org");
+  parsed.searchParams.set("utm_medium", overrides?.medium ?? "referral");
+  parsed.searchParams.set("utm_campaign", overrides?.campaign ?? source);
+
+  return parsed.toString();
+}


### PR DESCRIPTION
## Summary

Adds a global UTM-parameter embedder (`src/lib/external-link.ts`) and applies it to every outbound external link on the site, so brand/partner sites can attribute referral traffic back to thesvg.org and our own analytics can distinguish which page/section drove a given outbound click.

`withUtm(url, source, overrides?)`:
- Always sets `utm_source=thesvg.org`.
- Sets `utm_medium` to `referral` by default (overridable).
- Sets `utm_campaign` to the `source` value by default (identifies the page/section, e.g. `footer`, `header`, `icon_detail`, `submit_form`).
- No-ops for `mailto:` links and internal/relative URLs, so callers can call it unconditionally without special-casing.
- Safety rule: if a URL already has ANY `utm_` query param, it's returned completely unchanged, no merge, no override. This protects partner-owned attribution links (e.g. the Product Hunt review badge in `footer.tsx`) from having their own UTM params clobbered.
- Uses the `URL`/`URLSearchParams` constructors throughout (no manual string concatenation), so it composes correctly with URLs that already carry their own query params (GitHub "new issue" prefill links, social share intent URLs, etc.).

## Changes

- New: `src/lib/external-link.ts`
- Applied `withUtm` at every external link site across 18 files: `footer.tsx`, `header.tsx`, `extensions/page.tsx`, `legal/page.tsx`, `contact/page.tsx`, `privacy/page.tsx`, `icon-detail-page.tsx`, `icon-detail.tsx`, `submit-form.tsx`, `contribution-cta.tsx`, `share-buttons.tsx`, `submit/page.tsx`, `blog/page.tsx`, `compare/page.tsx`, `svg-viewer.tsx`, `mobile-icon-sheet.tsx`, `mobile-more-sheet.tsx`, and `blog/[slug]/page.tsx` (markdown-rendered links, which also now get `target="_blank" rel="noopener noreferrer"` when external).
- Fixed a bug in `home-hero.tsx`: the secondary CTA button unconditionally rendered `<Link>` even when the href was a genuinely external URL (AWS/Azure/GCP/Kubernetes icon pages). It now branches on `http` the same way the primary CTA already did, rendering a plain `<a target="_blank">` for external hrefs.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on all changed files: 0 errors (3 pre-existing warnings unrelated to this change, confirmed present on `main` too)
- [x] `pnpm build` completes successfully (7000+ icon pages)
- [x] Spot-checked built output: `utm_source=thesvg.org&utm_medium=referral&utm_campaign=footer` appears in rendered `out/index.html`
- [x] Confirmed the Product Hunt badge link in the built output still only carries its own `utm_source=badge-product_review` param, untouched by our injector
- [x] Confirmed internal hrefs (e.g. `/submit`) render with no UTM params appended

https://claude.ai/code/session_01NKqGVSo5LJGfvz3ahfT1WV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent tracking parameters to external links across blog, marketing, legal, privacy, and submission pages.
  * Added tracking to header, footer, mobile navigation, icon, sharing, and call-to-action links.
  * External blog links now open in a new tab with secure referrer handling.
  * Internal and email links continue to behave as before.
  * Existing tracking parameters are preserved without duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->