### PR TITLE
feat: add scheduled icon-stats snapshot pipeline

### DIFF
--- a/.github/workflows/auto-merge-icon-stats-pr.yml
+++ b/.github/workflows/auto-merge-icon-stats-pr.yml
@@ -1,0 +1,35 @@
+name: Auto-merge icon stats PR
+
+# Companion to icon-stats-snapshot.yml. That workflow pushes each refreshed
+# public/data/icon-stats.json snapshot to a dedicated automated/icon-stats-refresh
+# branch and opens (or reuses) a single PR from it - this workflow enables
+# GitHub's native auto-merge on that PR once required CI checks pass, so the
+# whole pipeline stays hands-off after the POSTHOG_PERSONAL_API_KEY secret is
+# configured.
+#
+# Gated purely on the head branch name rather than author/labels (unlike
+# auto-merge-icon-pr.yml): every PR from automated/icon-stats-refresh is
+# pushed by this same automation, there's no submitter to vet, and the
+# content is always just a data-file snapshot. CI (Lint & Build) is still
+# the real safety net before anything actually merges.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.pull_request.draft &&
+      github.event.pull_request.head.ref == 'automated/icon-stats-refresh'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/icon-stats-snapshot.yml
+++ b/.github/workflows/icon-stats-snapshot.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:
           version: 9
 

--- a/.github/workflows/icon-stats-snapshot.yml
+++ b/.github/workflows/icon-stats-snapshot.yml
@@ -1,0 +1,104 @@
+name: Icon stats snapshot
+
+# Scheduled job that pulls aggregate icon_feedback tallies out of PostHog
+# (HogQL Query API) via src/scripts/fetch-icon-stats.ts and snapshots the result
+# to public/data/icon-stats.json, so the statically-exported site can show
+# per-icon thumbs-up/down counts without a live authenticated query from the
+# browser.
+#
+# Requires POSTHOG_PERSONAL_API_KEY as a repo secret - a Personal API Key
+# with "Query Read" scope, generated at
+# https://us.posthog.com/settings/user-api-keys. Until that secret is added,
+# this workflow will fail with a clear, actionable error from the script
+# itself (see src/scripts/fetch-icon-stats.ts) and will NOT touch the existing
+# snapshot file or push anything - failure here is inert.
+#
+# Runs every 2 hours (PostHog Cloud's HogQL rate limit is shared org-wide,
+# and this is a low-traffic feature - no need for anything tighter), plus
+# workflow_dispatch for manual runs/testing.
+#
+# Never pushes to main directly (repo policy): changes land on the
+# automated/icon-stats-refresh branch (force-pushed each run, since only the
+# latest snapshot matters) and a PR is opened once, then just updated by the
+# force-push on subsequent runs. See auto-merge-icon-stats-pr.yml for the
+# companion workflow that merges those PRs once CI is green.
+
+on:
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: "20"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: icon-stats-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    name: Fetch and snapshot icon stats
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch icon stats from PostHog
+        run: pnpm exec tsx src/scripts/fetch-icon-stats.ts
+        env:
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet -- public/data/icon-stats.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No change in public/data/icon-stats.json - nothing to snapshot this run."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push snapshot branch
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B automated/icon-stats-refresh
+          git add public/data/icon-stats.json
+          git commit -m "chore: refresh icon feedback stats snapshot"
+          git push --force origin automated/icon-stats-refresh
+
+      - name: Open PR if none exists
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh pr list --head automated/icon-stats-refresh --state open --json number --jq 'length')
+          if [ "$EXISTING" = "0" ]; then
+            gh pr create \
+              --title "chore: refresh icon feedback stats snapshot" \
+              --head automated/icon-stats-refresh \
+              --base main \
+              --body "Automated snapshot of \`icon_feedback\` tallies from PostHog, written by \`src/scripts/fetch-icon-stats.ts\` on a 2-hour schedule. Auto-merges once CI passes (see \`.github/workflows/auto-merge-icon-stats-pr.yml\`). Force-pushed on every run - only the latest snapshot matters here, so this PR is reused rather than re-created."
+          else
+            echo "Open PR already exists for automated/icon-stats-refresh - force-push updated it, nothing further to do."
+          fi

--- a/src/components/icons/detail/icon-feedback.tsx
+++ b/src/components/icons/detail/icon-feedback.tsx
@@ -6,9 +6,19 @@ import { ThumbsDown, ThumbsUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type Sentiment = "up" | "down";
+type Tally = { up: number; down: number };
 
 function storageKey(slug: string) {
   return `thesvg-feedback-${slug}`;
+}
+
+function isTally(value: unknown): value is Tally {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { up?: unknown }).up === "number" &&
+    typeof (value as { down?: unknown }).down === "number"
+  );
 }
 
 /**
@@ -33,10 +43,36 @@ function gaFeedback(slug: string, sentiment: Sentiment) {
  */
 export function IconFeedback({ slug }: { slug: string }) {
   const [voted, setVoted] = useState<Sentiment | null>(null);
+  const [tally, setTally] = useState<Tally | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     setVoted(window.localStorage.getItem(storageKey(slug)) as Sentiment | null);
+  }, [slug]);
+
+  // Best-effort read of the last cron-generated stats snapshot. The file
+  // won't exist until the first successful icon-stats-snapshot workflow
+  // run, and most slugs won't have an entry yet either - both are
+  // expected, not errors, so we just leave the tally at null.
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch("/data/icon-stats.json")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: unknown) => {
+        if (cancelled || typeof data !== "object" || data === null) return;
+        const feedback = (data as { feedback?: unknown }).feedback;
+        if (typeof feedback !== "object" || feedback === null) return;
+        const entry = (feedback as Record<string, unknown>)[slug];
+        if (isTally(entry)) setTally(entry);
+      })
+      .catch(() => {
+        // Missing file (404) or network hiccup - no tally to show.
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [slug]);
 
   function vote(sentiment: Sentiment) {
@@ -72,6 +108,9 @@ export function IconFeedback({ slug }: { slug: string }) {
         >
           <ThumbsUp className="h-3.5 w-3.5" />
         </button>
+        {tally !== null && tally.up > 0 && (
+          <span className="text-[10px] tabular-nums text-muted-foreground">{tally.up}</span>
+        )}
         <button
           type="button"
           onClick={() => vote("down")}
@@ -89,6 +128,9 @@ export function IconFeedback({ slug }: { slug: string }) {
         >
           <ThumbsDown className="h-3.5 w-3.5" />
         </button>
+        {tally !== null && tally.down > 0 && (
+          <span className="text-[10px] tabular-nums text-muted-foreground">{tally.down}</span>
+        )}
       </div>
     </div>
   );

--- a/src/scripts/fetch-icon-stats.ts
+++ b/src/scripts/fetch-icon-stats.ts
@@ -93,6 +93,31 @@ function toCount(value: unknown): number | null {
   return Math.trunc(n);
 }
 
+interface RawRow {
+  slugRaw: unknown;
+  upRaw: unknown;
+  downRaw: unknown;
+}
+
+/** Extracts the three raw column values from an array-shaped row, using the
+ * `columns` list to find the right index when present (column order isn't
+ * guaranteed to match the SELECT list verbatim), falling back to positional
+ * access otherwise. */
+function extractFromArrayRow(row: unknown[], columns: string[] | null): RawRow {
+  if (columns?.length === row.length) {
+    const slugIdx = columns.indexOf("slug");
+    const upIdx = columns.indexOf("up_count");
+    const downIdx = columns.indexOf("down_count");
+    return {
+      slugRaw: slugIdx >= 0 ? row[slugIdx] : row[0],
+      upRaw: upIdx >= 0 ? row[upIdx] : row[1],
+      downRaw: downIdx >= 0 ? row[downIdx] : row[2],
+    };
+  }
+  const [slugRaw, upRaw, downRaw] = row;
+  return { slugRaw, upRaw, downRaw };
+}
+
 /**
  * Normalizes one result row into { slug, up, down }. The HogQL Query API's
  * documented response shape is `results: any[][]` (rows as arrays, in the
@@ -104,42 +129,28 @@ function normalizeRow(
   row: unknown,
   columns: string[] | null
 ): { slug: string; up: number; down: number } | null {
-  let slugRaw: unknown;
-  let upRaw: unknown;
-  let downRaw: unknown;
-
+  let raw: RawRow;
   if (Array.isArray(row)) {
-    if (columns && columns.length === row.length) {
-      const slugIdx = columns.indexOf("slug");
-      const upIdx = columns.indexOf("up_count");
-      const downIdx = columns.indexOf("down_count");
-      slugRaw = slugIdx >= 0 ? row[slugIdx] : row[0];
-      upRaw = upIdx >= 0 ? row[upIdx] : row[1];
-      downRaw = downIdx >= 0 ? row[downIdx] : row[2];
-    } else {
-      [slugRaw, upRaw, downRaw] = row;
-    }
+    raw = extractFromArrayRow(row, columns);
   } else if (isRecord(row)) {
-    slugRaw = row.slug;
-    upRaw = row.up_count;
-    downRaw = row.down_count;
+    raw = { slugRaw: row.slug, upRaw: row.up_count, downRaw: row.down_count };
   } else {
     return null;
   }
 
-  if (typeof slugRaw !== "string" || slugRaw.length === 0) return null;
-  const up = toCount(upRaw);
-  const down = toCount(downRaw);
+  if (typeof raw.slugRaw !== "string" || raw.slugRaw.length === 0) return null;
+  const up = toCount(raw.upRaw);
+  const down = toCount(raw.downRaw);
   if (up === null || down === null) return null;
 
-  return { slug: slugRaw, up, down };
+  return { slug: raw.slugRaw, up, down };
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Query execution (split out of main() to keep each step's branching small)
 // ---------------------------------------------------------------------------
 
-async function main() {
+function requireApiKey(): string {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   if (!apiKey) {
     fail(
@@ -150,23 +161,21 @@ async function main() {
         "manually)."
     );
   }
+  return apiKey;
+}
 
+async function queryPostHog(apiKey: string): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-
-  let response: Response;
   try {
-    response = await fetch(QUERY_URL, {
+    return await fetch(QUERY_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        query: {
-          kind: "HogQLQuery",
-          query: HOGQL_QUERY,
-        },
+        query: { kind: "HogQLQuery", query: HOGQL_QUERY },
         name: "icon_feedback_tallies",
       }),
       signal: controller.signal,
@@ -180,31 +189,37 @@ async function main() {
   } finally {
     clearTimeout(timeout);
   }
+}
 
-  if (!response.ok) {
-    let bodyText = "";
-    try {
-      bodyText = await response.text();
-    } catch {
-      // ignore - we still have the status code to report
-    }
+async function assertOk(response: Response): Promise<void> {
+  if (response.ok) return;
 
-    if (response.status === 401 || response.status === 403) {
-      fail(
-        `PostHog rejected the request (HTTP ${response.status}). ` +
-          "POSTHOG_PERSONAL_API_KEY is missing, invalid, or lacks 'Query Read' " +
-          "scope. Generate a new key at " +
-          "https://us.posthog.com/settings/user-api-keys and update the " +
-          `POSTHOG_PERSONAL_API_KEY secret. Response body: ${bodyText.slice(0, 500)}`
-      );
-    }
+  let bodyText = "";
+  try {
+    bodyText = await response.text();
+  } catch {
+    // ignore - we still have the status code to report
+  }
 
+  if (response.status === 401 || response.status === 403) {
     fail(
-      `PostHog query failed (HTTP ${response.status}). Response body: ` +
-        `${bodyText.slice(0, 500)}`
+      `PostHog rejected the request (HTTP ${response.status}). ` +
+        "POSTHOG_PERSONAL_API_KEY is missing, invalid, or lacks 'Query Read' " +
+        "scope. Generate a new key at " +
+        "https://us.posthog.com/settings/user-api-keys and update the " +
+        `POSTHOG_PERSONAL_API_KEY secret. Response body: ${bodyText.slice(0, 500)}`
     );
   }
 
+  fail(
+    `PostHog query failed (HTTP ${response.status}). Response body: ` +
+      `${bodyText.slice(0, 500)}`
+  );
+}
+
+async function parseQueryResponse(
+  response: Response
+): Promise<{ results: unknown[]; columns: string[] | null }> {
   let json: unknown;
   try {
     json = await response.json();
@@ -229,7 +244,6 @@ async function main() {
         JSON.stringify(json).slice(0, 500)
     );
   }
-
   if (!Array.isArray(results)) {
     fail(
       "PostHog response 'results' field was not an array; unexpected query " +
@@ -240,6 +254,19 @@ async function main() {
   const columns = Array.isArray(parsed.columns)
     ? parsed.columns.filter((c): c is string => typeof c === "string")
     : null;
+
+  return { results, columns };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const apiKey = requireApiKey();
+  const response = await queryPostHog(apiKey);
+  await assertOk(response);
+  const { results, columns } = await parseQueryResponse(response);
 
   const feedback: IconStats["feedback"] = {};
   let skipped = 0;

--- a/src/scripts/fetch-icon-stats.ts
+++ b/src/scripts/fetch-icon-stats.ts
@@ -1,0 +1,286 @@
+/**
+ * fetch-icon-stats.ts
+ *
+ * Pulls aggregate icon_feedback tallies out of PostHog (via the HogQL Query
+ * API) and writes them to public/data/icon-stats.json as a static snapshot
+ * the (statically-exported) site can fetch client-side. This is the "read
+ * side" of the thumbs-up/down widget in
+ * src/components/icons/detail/icon-feedback.tsx, which fires the raw
+ * `icon_feedback` event with { slug, sentiment } properties.
+ *
+ * Run with:
+ *   tsx src/scripts/fetch-icon-stats.ts
+ *
+ * Requires POSTHOG_PERSONAL_API_KEY in the environment - a secret Personal
+ * API Key with "Query Read" access, generated at
+ * https://us.posthog.com/settings/user-api-keys. This is fundamentally
+ * different from NEXT_PUBLIC_POSTHOG_KEY (the public write-only key used
+ * client-side) and must never be exposed to the browser.
+ *
+ * On any failure (missing/invalid key, network error, malformed response)
+ * this script logs a clear, actionable error and exits non-zero WITHOUT
+ * touching the existing public/data/icon-stats.json - a failed run leaves
+ * the last-known-good snapshot in place instead of overwriting it with
+ * empty/broken data.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** thesvg's PostHog project ID (us.posthog.com/project/335675). */
+const PROJECT_ID = process.env.POSTHOG_PROJECT_ID || "335675";
+const POSTHOG_HOST = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
+const QUERY_URL = `${POSTHOG_HOST}/api/projects/${PROJECT_ID}/query`;
+
+const OUTPUT_PATH = join(__dirname, "../../public/data/icon-stats.json");
+
+/** 15s client-side timeout - PostHog's own HogQL execution cap is 10s. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const HOGQL_QUERY = `
+  SELECT
+    properties.slug AS slug,
+    countIf(properties.sentiment = 'up') AS up_count,
+    countIf(properties.sentiment = 'down') AS down_count
+  FROM events
+  WHERE event = 'icon_feedback'
+    AND properties.slug IS NOT NULL
+  GROUP BY slug
+  ORDER BY slug
+  LIMIT 10000
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface IconStats {
+  generatedAt: string;
+  feedback: Record<string, { up: number; down: number }>;
+}
+
+interface HogQLQueryResponse {
+  results?: unknown;
+  columns?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fail(message: string): never {
+  console.error(`[fetch-icon-stats] ${message}`);
+  console.error(
+    "[fetch-icon-stats] Existing public/data/icon-stats.json was left untouched."
+  );
+  process.exit(1);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Coerces a ClickHouse-returned count, which may arrive as a number or a
+ * numeric string (ClickHouse serializes UInt64 as a string to avoid JS
+ * precision loss), into a safe integer. */
+function toCount(value: unknown): number | null {
+  const n = typeof value === "string" ? Number(value) : value;
+  if (typeof n !== "number" || !Number.isFinite(n) || n < 0) return null;
+  return Math.trunc(n);
+}
+
+/**
+ * Normalizes one result row into { slug, up, down }. The HogQL Query API's
+ * documented response shape is `results: any[][]` (rows as arrays, in the
+ * same order as the SELECT list) - but we defensively also accept a
+ * row-as-object shape (keyed by column alias) in case that ever changes,
+ * rather than crashing the whole run over a shape mismatch.
+ */
+function normalizeRow(
+  row: unknown,
+  columns: string[] | null
+): { slug: string; up: number; down: number } | null {
+  let slugRaw: unknown;
+  let upRaw: unknown;
+  let downRaw: unknown;
+
+  if (Array.isArray(row)) {
+    if (columns && columns.length === row.length) {
+      const slugIdx = columns.indexOf("slug");
+      const upIdx = columns.indexOf("up_count");
+      const downIdx = columns.indexOf("down_count");
+      slugRaw = slugIdx >= 0 ? row[slugIdx] : row[0];
+      upRaw = upIdx >= 0 ? row[upIdx] : row[1];
+      downRaw = downIdx >= 0 ? row[downIdx] : row[2];
+    } else {
+      [slugRaw, upRaw, downRaw] = row;
+    }
+  } else if (isRecord(row)) {
+    slugRaw = row.slug;
+    upRaw = row.up_count;
+    downRaw = row.down_count;
+  } else {
+    return null;
+  }
+
+  if (typeof slugRaw !== "string" || slugRaw.length === 0) return null;
+  const up = toCount(upRaw);
+  const down = toCount(downRaw);
+  if (up === null || down === null) return null;
+
+  return { slug: slugRaw, up, down };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  if (!apiKey) {
+    fail(
+      "POSTHOG_PERSONAL_API_KEY is missing. Generate a Personal API Key with " +
+        "'Query Read' access at https://us.posthog.com/settings/user-api-keys " +
+        "and set it as a GitHub Actions repository secret named " +
+        "POSTHOG_PERSONAL_API_KEY (or in your local shell env to run this script " +
+        "manually)."
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(QUERY_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: {
+          kind: "HogQLQuery",
+          query: HOGQL_QUERY,
+        },
+        name: "icon_feedback_tallies",
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    fail(
+      `Network error while querying PostHog: ${
+        error instanceof Error ? error.message : String(error)
+      }. Check connectivity to ${POSTHOG_HOST} and retry.`
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    let bodyText = "";
+    try {
+      bodyText = await response.text();
+    } catch {
+      // ignore - we still have the status code to report
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      fail(
+        `PostHog rejected the request (HTTP ${response.status}). ` +
+          "POSTHOG_PERSONAL_API_KEY is missing, invalid, or lacks 'Query Read' " +
+          "scope. Generate a new key at " +
+          "https://us.posthog.com/settings/user-api-keys and update the " +
+          `POSTHOG_PERSONAL_API_KEY secret. Response body: ${bodyText.slice(0, 500)}`
+      );
+    }
+
+    fail(
+      `PostHog query failed (HTTP ${response.status}). Response body: ` +
+        `${bodyText.slice(0, 500)}`
+    );
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch (error) {
+    fail(
+      `PostHog returned a non-JSON response: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (!isRecord(json)) {
+    fail("PostHog response was not a JSON object; cannot parse query results.");
+  }
+
+  const parsed = json as HogQLQueryResponse;
+  const { results } = parsed;
+
+  if (results === undefined || results === null) {
+    fail(
+      "PostHog response had no 'results' field. Full response: " +
+        JSON.stringify(json).slice(0, 500)
+    );
+  }
+
+  if (!Array.isArray(results)) {
+    fail(
+      "PostHog response 'results' field was not an array; unexpected query " +
+        `response shape. Full response: ${JSON.stringify(json).slice(0, 500)}`
+    );
+  }
+
+  const columns = Array.isArray(parsed.columns)
+    ? parsed.columns.filter((c): c is string => typeof c === "string")
+    : null;
+
+  const feedback: IconStats["feedback"] = {};
+  let skipped = 0;
+
+  for (const row of results) {
+    const normalized = normalizeRow(row, columns);
+    if (!normalized) {
+      skipped += 1;
+      continue;
+    }
+    if (normalized.up === 0 && normalized.down === 0) continue;
+    feedback[normalized.slug] = { up: normalized.up, down: normalized.down };
+  }
+
+  if (skipped > 0) {
+    console.warn(
+      `[fetch-icon-stats] Skipped ${skipped} row(s) with an unrecognized shape.`
+    );
+  }
+
+  // Empty results is expected (feature just shipped) - not an error.
+  const stats: IconStats = {
+    generatedAt: new Date().toISOString(),
+    feedback,
+  };
+
+  const outDir = dirname(OUTPUT_PATH);
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true });
+  }
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(stats, null, 2)}\n`, "utf-8");
+
+  const slugCount = Object.keys(feedback).length;
+  console.log(
+    `[fetch-icon-stats] Wrote public/data/icon-stats.json with ${slugCount} ` +
+      `slug(s) of feedback.`
+  );
+}
+
+main().catch((error) => {
+  fail(
+    `Unexpected error: ${error instanceof Error ? error.stack ?? error.message : String(error)}`
+  );
+});


### PR DESCRIPTION
## Summary

Read side of the icon feedback feature: a scheduled job that pulls aggregate `icon_feedback` tallies out of PostHog and snapshots them to a static JSON file, so the statically-exported site can show per-icon thumbs-up/down counts without a live authenticated query from the browser.

- **`src/scripts/fetch-icon-stats.ts`**: queries PostHog's HogQL Query API (`POST /api/projects/335675/query`) for a GROUP BY on the `icon_feedback` event (up/down counts per `slug`), and writes `public/data/icon-stats.json`. Handles an empty/near-empty result gracefully (the event just shipped). On any failure (missing/invalid key, network error, malformed response) it logs a clear, actionable error and exits non-zero **without touching the existing snapshot file** - a failed run leaves the last-known-good data in place.
- **`.github/workflows/icon-stats-snapshot.yml`**: runs the script on a schedule (every 2 hours) plus `workflow_dispatch`. If the snapshot actually changed, force-pushes to `automated/icon-stats-refresh` and opens a PR from it (only if one doesn't already exist for that branch - otherwise the force-push just updates the existing PR). Never pushes to `main` directly.
- **`.github/workflows/auto-merge-icon-stats-pr.yml`**: companion workflow that enables native GitHub auto-merge for PRs from `automated/icon-stats-refresh` once required CI checks pass, gated on the head branch name (this is bot-pushed data, not a contributor PR).
- **`src/components/icons/detail/icon-feedback.tsx`**: additive change, fetches `/data/icon-stats.json` client-side on mount and shows a small count next to each thumb when a tally exists for that slug. Missing file (404, expected until the first successful cron run) or a slug with no entry both render nothing extra - no fabricated "0 votes".

## Setup required

**`POSTHOG_PERSONAL_API_KEY` must be added as a repo secret before the scheduled workflow does anything beyond fail gracefully.** Generate a Personal API Key with **Query Read** scope at https://us.posthog.com/settings/user-api-keys and add it as a GitHub Actions secret named `POSTHOG_PERSONAL_API_KEY`. Until then, `icon-stats-snapshot.yml` runs will fail with a clear, actionable log message and will not touch the repo otherwise.

## Test plan

- [x] `npx tsc --noEmit` - clean
- [x] `npx eslint src/scripts/fetch-icon-stats.ts src/components/icons/detail/icon-feedback.tsx` - clean (0 errors; 1 pre-existing warning unrelated to this change)
- [x] `actionlint` on both new workflow files - clean
- [x] Ran the script locally with `POSTHOG_PERSONAL_API_KEY` unset - confirmed it prints a clear, actionable error, exits 1, and does not create/modify `public/data/icon-stats.json`
- [x] Verified the frontend's fetch/parse logic against a hand-written fixture (existing slug, missing slug, missing file, malformed data, 0/0 entry) - all render correctly; fixture removed before commit
- [ ] End-to-end run against real PostHog data (blocked until `POSTHOG_PERSONAL_API_KEY` secret is added)

Co-Authored-By: Glinr <bot@glincker.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Icon detail pages now display positive and negative feedback totals when available.
  * Feedback statistics are refreshed automatically, keeping displayed counts up to date.

* **Bug Fixes**
  * Improved handling of unavailable or invalid feedback statistics so existing voting functionality continues to work without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->