### PR TITLE
fix: gate persisted zustand stores behind post-mount rehydration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Footer } from "@/components/footer";
 import { ScrollToTop } from "@/components/scroll-to-top";
 import { MobileShell } from "@/components/mobile/mobile-shell";
 import { NotificationToasts } from "@/components/notification-toasts";
+import { StoreHydration } from "@/components/store-hydration";
 import { getFormattedIconCount } from "@/lib/icons";
 import postsData from "@/data/posts.json";
 import "./globals.css";
@@ -154,6 +155,7 @@ export default function RootLayout({
           storageKey="thesvg-theme"
           disableTransitionOnChange
         >
+          <StoreHydration />
           <ScrollToTop />
           {/* Desktop header — `lg:` and above. Rendered as a body-level
               sibling (not wrapped) so position: sticky keeps a containing

--- a/src/components/store-hydration.tsx
+++ b/src/components/store-hydration.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useFavoritesStore } from "@/lib/stores/favorites-store";
+import { useRecentsStore } from "@/lib/stores/recents-store";
+import { useMobilePrefsStore } from "@/lib/stores/mobile-prefs-store";
+
+/**
+ * Rehydrates the persisted zustand stores from localStorage after mount.
+ *
+ * The stores set `skipHydration: true`, so their first client render uses
+ * the same default state the server prerendered. That keeps the first pass
+ * identical to the shipped HTML and avoids a hydration mismatch (React #418)
+ * for returning visitors who have saved favorites, recents, or mobile prefs.
+ * We load the stored values here, one tick later, and the affected consumers
+ * re-render with them.
+ */
+export function StoreHydration() {
+  useEffect(() => {
+    useFavoritesStore.persist.rehydrate();
+    useRecentsStore.persist.rehydrate();
+    useMobilePrefsStore.persist.rehydrate();
+  }, []);
+
+  return null;
+}

--- a/src/lib/stores/favorites-store.ts
+++ b/src/lib/stores/favorites-store.ts
@@ -21,6 +21,6 @@ export const useFavoritesStore = create<FavoritesState>()(
       isFavorite: (slug) => get().favorites.includes(slug),
       clearAll: () => set({ favorites: [] }),
     }),
-    { name: "thesvg-favorites" }
+    { name: "thesvg-favorites", skipHydration: true }
   )
 );

--- a/src/lib/stores/mobile-prefs-store.ts
+++ b/src/lib/stores/mobile-prefs-store.ts
@@ -17,6 +17,7 @@ export const useMobilePrefsStore = create<MobilePrefsState>()(
     {
       name: "thesvg-mobile-prefs",
       version: 1,
+      skipHydration: true,
     },
   ),
 );

--- a/src/lib/stores/recents-store.ts
+++ b/src/lib/stores/recents-store.ts
@@ -135,6 +135,6 @@ export const useRecentsStore = create<RecentsState>()(
       clearSearched: () => set({ searched: [] }),
       clearAll: () => set({ viewed: [], copied: [], searched: [] }),
     }),
-    { name: "thesvg-recents" },
+    { name: "thesvg-recents", skipHydration: true },
   ),
 );


### PR DESCRIPTION
Returning visitors with saved favorites, recents, or mobile prefs hit a React hydration mismatch (error #418) on the statically prerendered home page: the persisted zustand stores read localStorage synchronously at module load, so the first client render can differ from the shipped HTML.

Fix: set `skipHydration: true` on the three persisted stores (favorites, recents, mobile-prefs) so the first client render matches the prerendered defaults, then rehydrate once after mount via a small `StoreHydration` component mounted in the root layout. Non-persisted stores (search, sidebar, mobile-shell) are untouched.

Independently identified and reimplemented from the same root cause PostHog's self-driving monitoring flagged (left its own draft PR untouched, not merging/using it directly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability by ensuring saved favorites, recent items, and mobile preferences load consistently after the initial page render.
  - Prevented potential mismatches between server-rendered content and the first client view, reducing flicker and hydration-related display issues.
  - Existing saved preferences continue to be restored automatically once the application has loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->