### PR TITLE
fix: drop Meta in-app browser bridge exceptions before capture

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,5 @@
 import posthog from "posthog-js";
+import type { CaptureResult } from "posthog-js";
 
 const shouldIgnore =
   typeof document !== "undefined" &&
@@ -6,12 +7,41 @@ const shouldIgnore =
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
+// Meta in-app browsers (Instagram, Threads, Facebook) inject their own native
+// bridge script into every page they open. That script throws when it calls
+// back to the host app, and posthog-js captures the throw even though the site
+// has no such bridge. One marker covers the Android "postMessage" family and
+// the iOS "webkit.messageHandlers" family, so new fingerprints stay filtered.
+const IN_APP_BROWSER_BRIDGE_MARKERS = [
+  "invoking postMessage",
+  "webkit.messageHandlers",
+];
+
+function isInAppBrowserBridgeError(result: CaptureResult): boolean {
+  if (result.event !== "$exception") return false;
+
+  const exceptions = result.properties?.["$exception_list"];
+  if (!Array.isArray(exceptions)) return false;
+
+  return exceptions.some((exception: { value?: unknown }) => {
+    const value = exception?.value;
+    return (
+      typeof value === "string" &&
+      IN_APP_BROWSER_BRIDGE_MARKERS.some((marker) => value.includes(marker))
+    );
+  });
+}
+
 if (posthogKey) {
   posthog.init(posthogKey, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
     ui_host: "https://us.posthog.com",
     defaults: "2026-01-30",
     capture_exceptions: !shouldIgnore,
+    before_send: (result) => {
+      if (result && isInAppBrowserBridgeError(result)) return null;
+      return result;
+    },
     debug: process.env.NODE_ENV === "development",
   });
 


### PR DESCRIPTION
Meta in-app browsers (Instagram, Threads, Facebook) inject their own native bridge script into every page they open. That script throws when it calls back to the host app, and posthog-js was capturing the throw even though thesvg.org has no such bridge - the only `postMessage` in the repo is the Figma plugin, and there's no `window.webkit.messageHandlers` caller in site code. Each new fingerprint was filing a fresh high-severity error tracking issue, driving repeat triage of a third-party script that isn't actually a bug in this site.

Adds a `before_send` filter in `instrumentation-client.ts` that drops $exception events matching the Android (`invoking postMessage`) or iOS (`webkit.messageHandlers`) bridge-error family before they're sent. All other events pass through unchanged.

Independently identified and reimplemented from the same root cause PostHog's self-driving monitoring flagged (left its own draft PR untouched, not merging/using it directly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Excluded known Meta in-app browser bridge errors from exception tracking.
  - Continued capturing other exception events as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->