### PR TITLE
docs: refresh README stats and add Auth Badges / Community / Kubernetes collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <strong>6,500+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
+  <strong>7,400+ SVG icons. Brands, AWS, Azure, GCP, and more. Search, copy, ship.</strong>
 </p>
 
 <p align="center">
@@ -17,7 +17,7 @@
   <a href="https://www.npmjs.com/package/thesvg"><img src="https://img.shields.io/npm/dm/thesvg?style=flat-square&color=F97316&label=downloads" alt="downloads" /></a>
   <a href="https://www.jsdelivr.com/package/gh/glincker/thesvg"><img src="https://data.jsdelivr.com/v1/package/gh/glincker/thesvg/badge" alt="jsDelivr" /></a>
   <a href="https://github.com/glincker/thesvg/stargazers"><img src="https://img.shields.io/github/stars/glincker/thesvg?style=flat-square&label=stars" alt="stars" /></a>
-  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-6%2C500%2B-F97316?style=flat-square" alt="6,500+ icons" /></a>
+  <a href="https://github.com/glincker/thesvg"><img src="https://img.shields.io/badge/icons-7%2C400%2B-F97316?style=flat-square" alt="7,400+ icons" /></a>
   <a href="https://github.com/glincker/thesvg/blob/main/LICENSE"><img src="https://img.shields.io/github/license/glincker/thesvg?style=flat-square" alt="license" /></a>
   <a href="https://www.figma.com/community/plugin/1612997159050367763"><img src="https://img.shields.io/badge/Figma-Plugin-F24E1E?style=flat-square&logo=figma&logoColor=white" alt="Figma" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=glincker.thesvg"><img src="https://img.shields.io/badge/VS%20Code-Extension-007ACC?style=flat-square&logo=visualstudiocode&logoColor=white" alt="VS Code" /></a>
@@ -45,7 +45,7 @@
 
 <p align="center">
   <a href="https://thesvg.org">
-    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 6,500+ SVG icons for developers" width="720" />
+    <img src="https://raw.githubusercontent.com/glincker/thesvg/main/public/og-image.png" alt="theSVG - 7,400+ SVG icons for developers" width="720" />
   </a>
 </p>
 
@@ -55,10 +55,12 @@
 
 Most icon libraries focus on UI icons. Brand logos are scattered across press kits, Figma files, and random GitHub repos. **theSVG** is the single source for SVG icons - brand logos, cloud architecture diagrams, and more. Searchable, versioned, and available as npm packages, CDN, CLI, API, and MCP server.
 
-- **6,500+ icons** across multiple collections
-- **4,600+ brand icons** across 140+ categories
+- **7,400+ icons** across multiple collections
+- **4,600+ brand icons** across 115+ categories
+- **858 Auth Badge icons** - circular icon badges for 2FA/authenticator apps
 - **739 AWS Architecture icons** (2026-Q1)
 - **626 Azure Service icons** (2026-Q1)
+- **256 community-curated icons** - dev tools, databases, frameworks
 - **214 Google Cloud icons** (2026-Q1)
 - **12,300+ SVG variants** - color, mono, light, dark, wordmark
 - **Tree-shakeable** - import one icon, ship only that icon
@@ -72,14 +74,21 @@ theSVG organizes icons into collections:
 
 | Collection | Icons | Description |
 |------------|-------|-------------|
-| **Brand Icons** | 4,629 | Brand logos from 140+ categories |
+| **Brand Icons** | 4,675 | Brand logos from 115+ categories |
+| **Auth Badges** | 858 | Circular icon badges styled for 2FA/authenticator apps |
 | **AWS Architecture** | 739 | Official AWS service, resource, category, and group icons (2026-Q1) |
 | **Azure Services** | 626 | Microsoft Azure service icons (2026-Q1) |
+| **Community** | 256 | Dev tools, databases, and frameworks sourced from the open-source community |
 | **Google Cloud** | 214 | Google Cloud Platform icons (2026-Q1) |
+| **Kubernetes** | 38 | Official Kubernetes/CNCF architecture icons |
 
 ### AWS Architecture Icons
 
 Browse all AWS service and resource icons at [thesvg.org/collection/aws](https://thesvg.org/collection/aws). Icons are sourced from the official [AWS Architecture Icons](https://aws.amazon.com/architecture/icons/) package and distributed unmodified under [CC BY-ND 2.0](https://creativecommons.org/licenses/by-nd/2.0/). Updated quarterly.
+
+### Auth Badges
+
+Browse the full set at [thesvg.org/collection/auth-badges](https://thesvg.org/collection/auth-badges). Circular, flat-color badge icons designed for authenticator-app entry lists and 2FA UI - a distinct visual style from the primary brand-mark collection above. Distributed under CC0-1.0 (public domain).
 
 ## Install
 
@@ -129,8 +138,8 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 
 | Extension | Status | Description |
 |-----------|--------|-------------|
-| [Figma Plugin](https://www.figma.com/community/plugin/1612997159050367763) | Published | Browse 6,500+ brand SVGs, variant picker, recents row, keyboard shortcuts. Insert as editable vectors. |
-| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 6,500+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
+| [Figma Plugin](https://www.figma.com/community/plugin/1612997159050367763) | Published | Browse 7,400+ brand SVGs, variant picker, recents row, keyboard shortcuts. Insert as editable vectors. |
+| [VS Code](https://marketplace.visualstudio.com/items?itemName=glincker.thesvg) | Published | Search 7,400+ icons from the command palette. Copy SVG, JSX, CDN link, or insert at cursor. |
 | [Raycast](https://www.raycast.com/thegdsks/thesvg) | Published | Search, preview, and copy any brand SVG in one keystroke. Filter by category, preview variants. |
 | [MCP Server](https://www.npmjs.com/package/@thesvg/mcp-server) | Published | AI tool calls for Claude, Cursor, Windsurf. Fetch icons by name or category. |
 | [Agent Skill](https://skills.sh/glincker/thesvg) | Published | Drop-in skill for AI agents. Install via `npx skills add glincker/thesvg`. Teaches the icon CDN and registry. |
@@ -138,7 +147,7 @@ Use theSVG icons everywhere you build, design, and ship. Browse the full ecosyst
 | [Homebrew](https://github.com/glincker/homebrew-thesvg) | Published | `brew tap glincker/thesvg && brew install thesvg` |
 | [CDN via jsDelivr](https://www.jsdelivr.com/package/gh/glincker/thesvg) | Published | Serve any icon via global CDN. Drop into HTML, CSS, Markdown, Notion, Webflow, Framer. |
 | [Iconify](https://icon-sets.iconify.design/thesvg-color/) | Published | Brand icons available as [`thesvg`](https://icon-sets.iconify.design/thesvg/) (mono) and [`thesvg-color`](https://icon-sets.iconify.design/thesvg-color/) sets. Works with any Iconify-consuming tool: Mermaid architecture diagrams, Iconify's VS Code and Figma plugins, `@iconify/react`, and more. |
-| [Browser Extension](https://github.com/glincker/thesvg/tree/main/extensions/browser) | Beta | Chrome, Firefox, Edge popup with 6,500+ brand SVGs. MV3, no telemetry. |
+| [Browser Extension](https://github.com/glincker/thesvg/tree/main/extensions/browser) | Beta | Chrome, Firefox, Edge popup with 7,400+ brand SVGs. MV3, no telemetry. |
 | [JetBrains](https://github.com/glincker/thesvg/issues?q=label%3Aextension) | Open | IntelliJ, WebStorm, PyCharm, Rider tool window. Help wanted. |
 | [Neovim](https://github.com/glincker/thesvg/tree/main/extensions/neovim) | Published | Lua plugin with Telescope picker. Insert SVG URL or inline content at cursor. |
 | [Alfred Workflow](https://github.com/glincker/thesvg/tree/main/extensions/alfred) | Published | macOS quick access. Search anywhere, copy SVG, CDN URL, or markdown. |
@@ -260,9 +269,9 @@ You can also clone the repo (~30 MB) and self-host. The codebase is MIT-licensed
 
 ## Categories
 
-Icons are organized into 140+ categories:
+Icons are organized into 115+ categories:
 
-`AI` `Analytics` `Authentication` `Automotive` `Aviation` `Browser` `Cloud` `CMS` `Community` `Crypto` `Database` `Design` `Devtool` `Education` `Entertainment` `Finance` `Food` `Framework` `Gaming` `Hardware` `Hosting` `IoT` `Language` `Library` `Linux` `Media` `Music` `Payment` `Platform` `Privacy` `Security` `Self-Hosted` `Shopping` `Social` `Software` and more...
+`AI` `Analytics` `Identity` `Automotive` `Aviation` `Browser` `Cloud` `CMS` `Community` `Crypto` `Database` `Design` `DevTool` `Education` `Entertainment` `Finance` `Food` `Framework` `Gaming` `Hardware` `Hosting` `IoT` `Language` `Library` `Linux` `Media` `Music` `Payment` `Platform` `Privacy` `Security` `Self-Hosted` `Shopping` `Social` `Software` and more...
 
 ## Contributing
 


### PR DESCRIPTION
The README's icon counts and collections table were stale (still said 6,500+ / 4,629 brand icons / 140+ categories) and the collections table was missing Community (256) and Kubernetes (38) rows entirely, plus never mentioned the new Auth Badges collection (858).

- Bumped all count references to the current 7,400+ total
- Added Auth Badges, Community, and Kubernetes rows to the collections table
- Added a short Auth Badges section matching the existing AWS Architecture Icons one
- Fixed category casing/naming in the sample tag list to match the normalization pass (Devtool → DevTool, Authentication → Identity) and corrected the category count (117 distinct brand categories, was overstated at 140+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated catalog references to reflect 7,400+ icons.
  - Revised feature lists, collection details, and category information.
  - Added Auth Badges, Community, and Kubernetes collections.
  - Updated category naming and listings, including DevTool and Identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->