### PR TITLE
feat: floating icon feedback widget, badge/brand cross-links, fix stats-check bug

### DIFF
--- a/.github/workflows/icon-stats-snapshot.yml
+++ b/.github/workflows/icon-stats-snapshot.yml
@@ -70,7 +70,12 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet -- public/data/icon-stats.json; then
+          # `git diff` alone is blind to a brand-new untracked file (this
+          # snapshot didn't exist in the repo until the first successful
+          # run), so it would silently report "no change" forever. `git
+          # status --porcelain` catches both a new untracked file and a
+          # modified tracked one.
+          if [ -z "$(git status --porcelain -- public/data/icon-stats.json)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No change in public/data/icon-stats.json - nothing to snapshot this run."
           else

--- a/src/components/icons/detail/icon-feedback.tsx
+++ b/src/components/icons/detail/icon-feedback.tsx
@@ -71,7 +71,7 @@ function buildFeedbackIssueUrl(slug: string, title: string, reason: Reason): str
  * An upvote (once, site-wide, not per icon) offers a Product Hunt review
  * link, the positive-sentiment equivalent.
  */
-export function IconFeedback({ slug, title }: { slug: string; title: string }) {
+export function IconFeedback({ slug, title }: Readonly<{ slug: string; title: string }>) {
   const [voted, setVoted] = useState<Sentiment | null>(null);
   const [tally, setTally] = useState<Tally | null>(null);
   const [pickingReason, setPickingReason] = useState(false);
@@ -136,6 +136,8 @@ export function IconFeedback({ slug, title }: { slug: string; title: string }) {
     window.open(withUtm(buildFeedbackIssueUrl(slug, title, reason), "icon_feedback"), "_blank", "noopener,noreferrer");
   }
 
+  const statusLabel = reasonPicked ? "Thanks - opened an issue" : voted ? "Thanks!" : "Helpful?";
+
   return (
     <div
       className={cn(
@@ -176,7 +178,7 @@ export function IconFeedback({ slug, title }: { slug: string; title: string }) {
 
       <div className="surface-glass flex items-center gap-2 rounded-full border border-border/40 px-3 py-2 shadow-[0_12px_36px_-12px_rgba(0,0,0,0.45),0_2px_8px_-2px_rgba(0,0,0,0.25)] dark:border-white/[0.08]">
         <span className="hidden text-xs text-muted-foreground sm:inline">
-          {reasonPicked ? "Thanks - opened an issue" : voted ? "Thanks!" : "Helpful?"}
+          {statusLabel}
         </span>
         <div className="flex items-center gap-1.5">
           <button

--- a/src/components/icons/detail/icon-feedback.tsx
+++ b/src/components/icons/detail/icon-feedback.tsx
@@ -2,11 +2,19 @@
 
 import { useEffect, useState } from "react";
 import posthog from "posthog-js";
-import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { ArrowUpRight, ThumbsDown, ThumbsUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { withUtm } from "@/lib/external-link";
 
 type Sentiment = "up" | "down";
 type Tally = { up: number; down: number };
+
+const REASONS = ["Outdated logo", "Wrong colors", "Missing variant", "Other"] as const;
+type Reason = (typeof REASONS)[number];
+
+const REVIEW_PROMPTED_KEY = "thesvg-review-prompted";
+const PRODUCT_HUNT_REVIEW_URL =
+  "https://www.producthunt.com/products/thesvg/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-thesvg";
 
 function storageKey(slug: string) {
   return `thesvg-feedback-${slug}`;
@@ -26,24 +34,49 @@ function isTally(value: unknown): value is Tally {
  * tracking in header.tsx - no shared helper since each call site only fires
  * one event shape.
  */
-function gaFeedback(slug: string, sentiment: Sentiment) {
+function gaFeedback(slug: string, sentiment: Sentiment, reason?: Reason) {
   if (typeof window === "undefined") return;
   const w = window as unknown as {
     gtag?: (cmd: string, event: string, params: Record<string, unknown>) => void;
   };
   if (typeof w.gtag !== "function") return;
-  w.gtag("event", "icon_feedback", { icon_slug: slug, sentiment });
+  w.gtag("event", "icon_feedback", { icon_slug: slug, sentiment, reason });
+}
+
+function buildFeedbackIssueUrl(slug: string, title: string, reason: Reason): string {
+  const params = new URLSearchParams({
+    title: `[Icon Feedback] ${reason} - ${title}`,
+    body: `## Icon Feedback
+
+**Icon**: ${title} (\`${slug}\`)
+**Page**: https://thesvg.org/icon/${slug}
+**Reported issue**: ${reason}
+
+<!-- Add any more detail below - screenshots, the correct color/logo, etc. -->
+`,
+    labels: "icon-update",
+  });
+  return `https://github.com/glincker/thesvg/issues/new?${params.toString()}`;
 }
 
 /**
- * One-click "was this icon helpful" widget. No backend/DB - the vote is
- * captured as a PostHog + GA4 event (source of truth for aggregation) and
- * mirrored to localStorage only to lock the UI after voting and survive
- * repeat visits in the same browser.
+ * One-click "was this icon helpful" widget, floating so it stays visible
+ * regardless of scroll position instead of getting lost in the page's
+ * content flow. No backend/DB - the vote is captured as a PostHog + GA4
+ * event (source of truth for aggregation) and mirrored to localStorage only
+ * to lock the UI after voting and survive repeat visits in the same browser.
+ *
+ * A downvote offers a quick reason, which opens a pre-filled GitHub issue -
+ * turning "not helpful" into an actionable report instead of a silent stat.
+ * An upvote (once, site-wide, not per icon) offers a Product Hunt review
+ * link, the positive-sentiment equivalent.
  */
-export function IconFeedback({ slug }: { slug: string }) {
+export function IconFeedback({ slug, title }: { slug: string; title: string }) {
   const [voted, setVoted] = useState<Sentiment | null>(null);
   const [tally, setTally] = useState<Tally | null>(null);
+  const [pickingReason, setPickingReason] = useState(false);
+  const [reasonPicked, setReasonPicked] = useState<Reason | null>(null);
+  const [showReviewPrompt, setShowReviewPrompt] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -83,54 +116,110 @@ export function IconFeedback({ slug }: { slug: string }) {
     }
     posthog.capture("icon_feedback", { slug, sentiment, source: "detail_page" });
     gaFeedback(slug, sentiment);
+
+    if (sentiment === "down") {
+      setPickingReason(true);
+      return;
+    }
+
+    if (typeof window !== "undefined" && !window.localStorage.getItem(REVIEW_PROMPTED_KEY)) {
+      window.localStorage.setItem(REVIEW_PROMPTED_KEY, "1");
+      setShowReviewPrompt(true);
+    }
+  }
+
+  function pickReason(reason: Reason) {
+    posthog.capture("icon_feedback_reason", { slug, reason, source: "detail_page" });
+    gaFeedback(slug, "down", reason);
+    setReasonPicked(reason);
+    setPickingReason(false);
+    window.open(withUtm(buildFeedbackIssueUrl(slug, title, reason), "icon_feedback"), "_blank", "noopener,noreferrer");
   }
 
   return (
-    <div className="flex items-center justify-between rounded-xl border border-border/60 bg-card p-3 shadow-sm">
-      <span className="text-xs text-muted-foreground">
-        {voted ? "Thanks for the feedback!" : "Was this icon helpful?"}
-      </span>
-      <div className="flex items-center gap-1.5">
-        <button
-          type="button"
-          onClick={() => vote("up")}
-          disabled={voted !== null}
-          aria-label="This icon is helpful"
-          aria-pressed={voted === "up"}
-          className={cn(
-            "flex h-7 w-7 items-center justify-center rounded-full border border-border/50 text-muted-foreground transition-colors",
-            voted === "up" &&
-              "border-emerald-500/50 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-            voted === null &&
-              "hover:border-emerald-500/40 hover:bg-emerald-500/5 hover:text-emerald-600",
-            voted !== null && voted !== "up" && "opacity-40",
-          )}
+    <div
+      className={cn(
+        "fixed right-4 z-40 flex flex-col items-end gap-2",
+        "bottom-[max(76px,calc(var(--safe-bottom)+76px))] lg:bottom-6",
+      )}
+    >
+      {pickingReason && (
+        <div className="surface-glass flex flex-col gap-1 rounded-2xl border border-border/40 p-2 shadow-[0_12px_36px_-12px_rgba(0,0,0,0.45)] dark:border-white/[0.08]">
+          <p className="px-1.5 pt-1 text-[11px] font-medium text-muted-foreground">
+            What&apos;s wrong with it?
+          </p>
+          {REASONS.map((reason) => (
+            <button
+              key={reason}
+              type="button"
+              onClick={() => pickReason(reason)}
+              className="rounded-lg px-2 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-accent"
+            >
+              {reason}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {showReviewPrompt && (
+        <a
+          href={withUtm(PRODUCT_HUNT_REVIEW_URL, "icon_feedback")}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => setShowReviewPrompt(false)}
+          className="surface-glass flex items-center gap-1.5 rounded-full border border-border/40 px-3 py-2 text-xs text-foreground shadow-[0_12px_36px_-12px_rgba(0,0,0,0.45)] transition-colors hover:bg-accent dark:border-white/[0.08]"
         >
-          <ThumbsUp className="h-3.5 w-3.5" />
-        </button>
-        {tally !== null && tally.up > 0 && (
-          <span className="text-[10px] tabular-nums text-muted-foreground">{tally.up}</span>
-        )}
-        <button
-          type="button"
-          onClick={() => vote("down")}
-          disabled={voted !== null}
-          aria-label="This icon is not helpful"
-          aria-pressed={voted === "down"}
-          className={cn(
-            "flex h-7 w-7 items-center justify-center rounded-full border border-border/50 text-muted-foreground transition-colors",
-            voted === "down" &&
-              "border-red-500/50 bg-red-500/10 text-red-600 dark:text-red-400",
-            voted === null &&
-              "hover:border-red-500/40 hover:bg-red-500/5 hover:text-red-600",
-            voted !== null && voted !== "down" && "opacity-40",
+          Glad it helped - leave a review?
+          <ArrowUpRight className="h-3 w-3 opacity-60" />
+        </a>
+      )}
+
+      <div className="surface-glass flex items-center gap-2 rounded-full border border-border/40 px-3 py-2 shadow-[0_12px_36px_-12px_rgba(0,0,0,0.45),0_2px_8px_-2px_rgba(0,0,0,0.25)] dark:border-white/[0.08]">
+        <span className="hidden text-xs text-muted-foreground sm:inline">
+          {reasonPicked ? "Thanks - opened an issue" : voted ? "Thanks!" : "Helpful?"}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => vote("up")}
+            disabled={voted !== null}
+            aria-label="This icon is helpful"
+            aria-pressed={voted === "up"}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-muted-foreground transition-colors",
+              voted === "up" &&
+                "border-emerald-500/50 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+              voted === null &&
+                "hover:border-emerald-500/40 hover:bg-emerald-500/5 hover:text-emerald-600",
+              voted !== null && voted !== "up" && "opacity-40",
+            )}
+          >
+            <ThumbsUp className="h-4 w-4" />
+          </button>
+          {tally !== null && tally.up > 0 && (
+            <span className="text-[10px] tabular-nums text-muted-foreground">{tally.up}</span>
           )}
-        >
-          <ThumbsDown className="h-3.5 w-3.5" />
-        </button>
-        {tally !== null && tally.down > 0 && (
-          <span className="text-[10px] tabular-nums text-muted-foreground">{tally.down}</span>
-        )}
+          <button
+            type="button"
+            onClick={() => vote("down")}
+            disabled={voted !== null}
+            aria-label="This icon is not helpful"
+            aria-pressed={voted === "down"}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-full border border-border/50 text-muted-foreground transition-colors",
+              voted === "down" &&
+                "border-red-500/50 bg-red-500/10 text-red-600 dark:text-red-400",
+              voted === null &&
+                "hover:border-red-500/40 hover:bg-red-500/5 hover:text-red-600",
+              voted !== null && voted !== "down" && "opacity-40",
+            )}
+          >
+            <ThumbsDown className="h-4 w-4" />
+          </button>
+          {tally !== null && tally.down > 0 && (
+            <span className="text-[10px] tabular-nums text-muted-foreground">{tally.down}</span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/icons/icon-detail-page.tsx
+++ b/src/components/icons/icon-detail-page.tsx
@@ -336,6 +336,40 @@ export function IconDetailPage({
             );
           })()}
 
+          {(() => {
+            const isBadge = icon.collection === "auth-badges";
+            const counterpartSlug = isBadge
+              ? icon.slug.replace(/-badge$/, "")
+              : `${icon.slug}-badge`;
+            if (counterpartSlug === icon.slug) return null;
+            const counterpart = getIconBySlug(counterpartSlug);
+            if (!counterpart) return null;
+            return (
+              <Link
+                href={`/icon/${counterpart.slug}`}
+                className="group/badge-link flex items-center gap-3 rounded-xl border border-emerald-500/30 bg-gradient-to-r from-emerald-500/[0.06] to-teal-500/[0.04] p-3 shadow-sm transition-all hover:-translate-y-0.5 hover:border-emerald-500/50 hover:shadow-md"
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-background ring-1 ring-inset ring-border/40">
+                  <img
+                    src={counterpart.variants.default}
+                    alt=""
+                    className="h-6 w-6 object-contain"
+                    loading="lazy"
+                  />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[10px] font-semibold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+                    {isBadge ? "Brand logo" : "Also available as"}
+                  </span>
+                  <span className="block truncate text-sm font-medium text-foreground">
+                    {isBadge ? counterpart.title : "Auth Badge"}
+                  </span>
+                </span>
+                <ArrowUpRight className="h-4 w-4 shrink-0 text-emerald-600 transition-transform group-hover/badge-link:translate-x-0.5 group-hover/badge-link:-translate-y-0.5 dark:text-emerald-400" />
+              </Link>
+            );
+          })()}
+
           {/* Website + Guidelines links */}
           <div className="space-y-1.5">
             {icon.url &&
@@ -481,7 +515,7 @@ export function IconDetailPage({
             activeVariant={activeVariant}
           />
 
-          <IconFeedback slug={icon.slug} />
+          <IconFeedback slug={icon.slug} title={icon.title} />
 
           {/* Related icons - inline in right column */}
           {relatedIcons.length > 0 && primaryCategory && (


### PR DESCRIPTION
Three related changes:

1. **Icon feedback widget → floating pill.** Was buried inline after PngExport in a long scrolling column - now fixed to the viewport corner (above the mobile bottom dock, bottom-right on desktop) so it's actually visible regardless of scroll position.
2. **Post-vote follow-through.** A downvote now offers a quick reason (outdated logo / wrong colors / missing variant / other) that opens a pre-filled GitHub issue - turning a silent downvote into an actionable report. An upvote offers a Product Hunt review link, shown once site-wide (not per icon) via a separate localStorage flag.
3. **Brand ↔ Auth Badge cross-links.** 356 of the 858 auth-badges icons share a base slug with an existing brand icon (e.g. `1password` / `1password-badge`). Added a small card on the icon detail page (mirroring the existing supersedes/supersededBy version-lineage pattern) linking each to its counterpart when one exists.
4. **Fixed a real bug in the stats-snapshot workflow**, caught while manually testing it after adding the PostHog secret: the "check for changes" step used `git diff --quiet`, which is blind to a brand-new untracked file. Since `public/data/icon-stats.json` didn't exist in the repo yet, every run (including all future runs, not just the first) would silently report "no change" and never open a PR, even though the script itself was successfully querying PostHog and writing real data. Switched to `git status --porcelain`, which catches both a new untracked file and a modified tracked one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating feedback widget for icon detail pages.
  * Downvotes now provide selectable reasons and open a pre-filled feedback issue.
  * Upvotes can display a one-time prompt to leave a Product Hunt review.
  * Added links between icons and their corresponding brand logo or authentication badge when available.
  * Icon detail pages now display clearer labels for related logo and badge variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->