### PR TITLE
fix: widen icon-stats query timeout to reduce false aborts

### DIFF
--- a/src/scripts/fetch-icon-stats.ts
+++ b/src/scripts/fetch-icon-stats.ts
@@ -38,8 +38,14 @@ const QUERY_URL = `${POSTHOG_HOST}/api/projects/${PROJECT_ID}/query`;
 
 const OUTPUT_PATH = join(__dirname, "../../public/data/icon-stats.json");
 
-/** 15s client-side timeout - PostHog's own HogQL execution cap is 10s. */
-const REQUEST_TIMEOUT_MS = 15_000;
+/**
+ * PostHog's own HogQL execution cap is 10s, but that only bounds query
+ * execution - it leaves little margin for request queueing/network
+ * overhead on top. A 15s client timeout raced that too closely in practice
+ * (two consecutive aborts in manual testing), so this leaves a wider
+ * buffer above the 10s cap instead of just barely clearing it.
+ */
+const REQUEST_TIMEOUT_MS = 30_000;
 
 const HOGQL_QUERY = `
   SELECT


### PR DESCRIPTION
Manual testing of `icon-stats-snapshot.yml` after adding the PostHog secret hit the client-side abort twice in a row (`This operation was aborted`), both right around the 15s mark. PostHog's HogQL execution cap is documented at 10s, but that only bounds query execution time - a 15s client timeout leaves almost no margin for request queueing/network overhead on top of that, so it's racing the server cap too closely rather than comfortably exceeding it.

Widened to 30s. This only affects how long we wait before giving up - the graceful-failure behavior (leave the existing snapshot untouched, exit non-zero with a clear message) is unchanged, this just makes false aborts less likely for a query that's actually going to succeed if given a bit more time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the reliability of icon statistics updates by allowing analytics queries additional time to complete.
  - Reduced the likelihood of interrupted data retrieval during slower responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->