### PR TITLE
chore: use GH_PAT for icon-stats pipeline to fix workflow-cascade gap

### DIFF
--- a/.github/workflows/auto-merge-icon-stats-pr.yml
+++ b/.github/workflows/auto-merge-icon-stats-pr.yml
@@ -4,14 +4,20 @@ name: Auto-merge icon stats PR
 # public/data/icon-stats.json snapshot to a dedicated automated/icon-stats-refresh
 # branch and opens (or reuses) a single PR from it - this workflow enables
 # GitHub's native auto-merge on that PR once required CI checks pass, so the
-# whole pipeline stays hands-off after the POSTHOG_PERSONAL_API_KEY secret is
-# configured.
+# whole pipeline stays hands-off after the POSTHOG_PERSONAL_API_KEY and GH_PAT
+# secrets are configured.
 #
 # Gated purely on the head branch name rather than author/labels (unlike
 # auto-merge-icon-pr.yml): every PR from automated/icon-stats-refresh is
 # pushed by this same automation, there's no submitter to vet, and the
 # content is always just a data-file snapshot. CI (Lint & Build) is still
 # the real safety net before anything actually merges.
+#
+# Uses GH_PAT (not the default GITHUB_TOKEN) for the merge itself: a merge
+# performed with GITHUB_TOKEN can't trigger downstream push-triggered
+# workflows (GitHub's anti-recursion rule), which would silently prevent
+# the resulting main-branch push from ever kicking off the site's deploy
+# workflow. A PAT-authored merge doesn't have that restriction.
 
 on:
   pull_request:
@@ -32,4 +38,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/icon-stats-snapshot.yml
+++ b/.github/workflows/icon-stats-snapshot.yml
@@ -6,12 +6,19 @@ name: Icon stats snapshot
 # per-icon thumbs-up/down counts without a live authenticated query from the
 # browser.
 #
-# Requires POSTHOG_PERSONAL_API_KEY as a repo secret - a Personal API Key
-# with "Query Read" scope, generated at
-# https://us.posthog.com/settings/user-api-keys. Until that secret is added,
-# this workflow will fail with a clear, actionable error from the script
-# itself (see src/scripts/fetch-icon-stats.ts) and will NOT touch the existing
-# snapshot file or push anything - failure here is inert.
+# Requires two repo secrets:
+#   - POSTHOG_PERSONAL_API_KEY: a Personal API Key with "Query Read" scope,
+#     generated at https://us.posthog.com/settings/user-api-keys. Until it's
+#     added, this workflow fails with a clear, actionable error from the
+#     script itself (see src/scripts/fetch-icon-stats.ts) and does NOT touch
+#     the existing snapshot file or push anything - failure here is inert.
+#   - GH_PAT: a fine-grained Personal Access Token scoped to this repo only,
+#     with Contents (read/write) and Pull requests (read/write) permissions.
+#     Used instead of the default GITHUB_TOKEN for checkout/push/PR-create,
+#     because GITHUB_TOKEN-authored pushes and PRs can't trigger downstream
+#     workflows (GitHub's anti-recursion rule) - without a PAT here,
+#     auto-merge-icon-stats-pr.yml would sit at "action_required" needing a
+#     human to manually approve every single run.
 #
 # Runs every 2 hours (PostHog Cloud's HogQL rate limit is shared org-wide,
 # and this is a low-traffic feature - no need for anything tighter), plus
@@ -48,6 +55,14 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Checking out (and later pushing) with the default GITHUB_TOKEN
+          # means the resulting push/PR can't trigger downstream workflows
+          # (GitHub's anti-recursion rule for GITHUB_TOKEN-authored events) -
+          # auto-merge-icon-stats-pr.yml would sit at "action_required"
+          # forever without a human manually approving it each run. A PAT
+          # doesn't have that restriction, so pushes/PRs made with it behave
+          # like a normal contributor's and cascade normally.
+          token: ${{ secrets.GH_PAT }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
@@ -95,7 +110,7 @@ jobs:
       - name: Open PR if none exists
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           EXISTING=$(gh pr list --head automated/icon-stats-refresh --state open --json number --jq 'length')
           if [ "$EXISTING" = "0" ]; then


### PR DESCRIPTION
Manual testing today surfaced the same GitHub limitation twice: pushes/PR-opens/merges performed with the default `GITHUB_TOKEN` can't trigger downstream workflows (GitHub's anti-recursion protection). This hit the icon-stats pipeline in two places:

1. `icon-stats-snapshot.yml` opening a PR via `GITHUB_TOKEN` left `auto-merge-icon-stats-pr.yml`'s `pull_request` trigger sitting at `action_required`, needing a human to manually approve every single run.
2. `auto-merge-icon-stats-pr.yml` merging via `GITHUB_TOKEN` meant the resulting push to `main` never triggered the site's deploy workflow either - confirmed by testing end-to-end today (had to manually trigger both the approval and the deploy to get real data live).

Fix: both workflows now use a `GH_PAT` secret (a fine-grained PAT scoped to just this repo, Contents + Pull requests read/write) instead of `GITHUB_TOKEN` for the checkout/push/PR-create/merge steps. PAT-authored events aren't subject to the anti-recursion rule, so the whole pipeline - vote → PostHog capture → cron query → snapshot PR → auto-merge → deploy - should now run fully hands-off.

Requires the `GH_PAT` secret to be added before this takes effect; documented in both workflow files' header comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated icon statistics workflows to use the configured personal access token for checkout, pull request creation, and merges.
  * Expanded workflow documentation to clarify required secrets, permissions, and downstream workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->