### PR TITLE
feat: allow resetting icon feedback vote, slow cron to every 6h

### DIFF
--- a/.github/workflows/icon-stats-snapshot.yml
+++ b/.github/workflows/icon-stats-snapshot.yml
@@ -20,9 +20,14 @@ name: Icon stats snapshot
 #     auto-merge-icon-stats-pr.yml would sit at "action_required" needing a
 #     human to manually approve every single run.
 #
-# Runs every 2 hours (PostHog Cloud's HogQL rate limit is shared org-wide,
-# and this is a low-traffic feature - no need for anything tighter), plus
-# workflow_dispatch for manual runs/testing.
+# Runs every 6 hours, plus workflow_dispatch for manual runs/testing. The
+# binding constraint isn't PostHog's HogQL rate limit (120/hour org-wide -
+# even hourly would use a small fraction of that); it's that any run which
+# finds a changed vote count triggers a full site rebuild/redeploy (7,400+
+# pages) through the merge -> deploy chain. That's disproportionate for what
+# is currently a low-volume feature, so this favors a slower cadence and
+# less rebuild churn over near-real-time freshness. Tighten later if real
+# vote volume grows enough that fresher data is worth more frequent rebuilds.
 #
 # Never pushes to main directly (repo policy): changes land on the
 # automated/icon-stats-refresh branch (force-pushed each run, since only the
@@ -32,7 +37,7 @@ name: Icon stats snapshot
 
 on:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */6 * * *"
   workflow_dispatch:
 
 env:

--- a/src/components/icons/detail/icon-feedback.tsx
+++ b/src/components/icons/detail/icon-feedback.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import posthog from "posthog-js";
-import { ArrowUpRight, ThumbsDown, ThumbsUp } from "lucide-react";
+import { ArrowUpRight, RotateCcw, ThumbsDown, ThumbsUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { withUtm } from "@/lib/external-link";
 
@@ -41,6 +41,15 @@ function gaFeedback(slug: string, sentiment: Sentiment, reason?: Reason) {
   };
   if (typeof w.gtag !== "function") return;
   w.gtag("event", "icon_feedback", { icon_slug: slug, sentiment, reason });
+}
+
+function gaFeedbackReset(slug: string, previousSentiment: Sentiment) {
+  if (typeof window === "undefined") return;
+  const w = window as unknown as {
+    gtag?: (cmd: string, event: string, params: Record<string, unknown>) => void;
+  };
+  if (typeof w.gtag !== "function") return;
+  w.gtag("event", "icon_feedback_reset", { icon_slug: slug, previous_sentiment: previousSentiment });
 }
 
 function buildFeedbackIssueUrl(slug: string, title: string, reason: Reason): string {
@@ -136,6 +145,22 @@ export function IconFeedback({ slug, title }: Readonly<{ slug: string; title: st
     window.open(withUtm(buildFeedbackIssueUrl(slug, title, reason), "icon_feedback"), "_blank", "noopener,noreferrer");
   }
 
+  // Reset doesn't (and can't, without a backend) retract the original
+  // capture event from PostHog - it just clears the local lock so the
+  // person can vote again, and logs the retraction as its own event so
+  // there's at least a record that the earlier vote was undone.
+  function resetVote() {
+    if (!voted) return;
+    posthog.capture("icon_feedback_reset", { slug, previous_sentiment: voted, source: "detail_page" });
+    gaFeedbackReset(slug, voted);
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(storageKey(slug));
+    }
+    setVoted(null);
+    setReasonPicked(null);
+    setPickingReason(false);
+  }
+
   const statusLabel = reasonPicked ? "Thanks - opened an issue" : voted ? "Thanks!" : "Helpful?";
 
   return (
@@ -180,6 +205,17 @@ export function IconFeedback({ slug, title }: Readonly<{ slug: string; title: st
         <span className="hidden text-xs text-muted-foreground sm:inline">
           {statusLabel}
         </span>
+        {voted !== null && !pickingReason && (
+          <button
+            type="button"
+            onClick={resetVote}
+            aria-label="Reset your feedback"
+            title="Reset your feedback"
+            className="flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <RotateCcw className="h-3 w-3" />
+          </button>
+        )}
         <div className="flex items-center gap-1.5">
           <button
             type="button"


### PR DESCRIPTION
Two small, related changes:

1. **Reset feedback.** A small undo icon now appears next to the status label once you've voted, clearing your local vote so you can vote again (or change your mind). Also fires an `icon_feedback_reset` event (PostHog + GA4) with the previous sentiment, since there's no backend to retract the original capture event - this just gives future analysis a record that a vote was undone, without trying to mutate history.
2. **Cron cadence: 2h -> 6h.** The real cost of this pipeline isn't PostHog's query rate limit (barely touched at either cadence) - it's that every run with a changed vote count triggers a full site rebuild/redeploy through the merge -> deploy chain. That's disproportionate for a low-volume feature right now; 6h cuts rebuild churn 3x while staying reasonably fresh. Easy to tighten later if vote volume grows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to reset locally stored icon feedback after voting.
  * Resetting feedback clears the selected sentiment and related interface state.
  * Reset actions are tracked for analytics, including the previously selected sentiment.

* **Chores**
  * Updated automated icon statistics snapshots to run less frequently while retaining manual execution support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->